### PR TITLE
Extract endpoints and add main.go for testing

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/docker/model-distribution/pkg/distribution"
+	"github.com/docker/model-runner/pkg/inference/models"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+func main() {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("Failed to get user home directory: %v", err)
+	}
+	distributionClient, err := distribution.NewClient(
+		distribution.WithStoreRootPath(filepath.Join(userHomeDir, ".docker", "models")),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create distribution client: %v", err)
+	}
+
+	modelManager := models.NewManager(log, distributionClient)
+
+	router := http.NewServeMux()
+	for _, route := range modelManager.GetRoutes() {
+		router.Handle(route, modelManager)
+	}
+
+	sockName := "model-runner.sock"
+	if err := os.Remove(sockName); err != nil {
+		if !os.IsNotExist(err) {
+			log.Fatalf("Failed to remove existing socket: %v", err)
+		}
+	}
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockName, Net: "unix"})
+	if err != nil {
+		log.Fatalf("Failed to listen on socket: %v", err)
+	}
+	defer os.Remove(sockName)
+
+	server := &http.Server{Handler: router}
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- server.Serve(ln)
+	}()
+	defer server.Close()
+
+	select {
+	case err := <-serverErrors:
+		if err != nil {
+			log.Errorf("Server error: %v", err)
+		}
+	case <-stop:
+		log.Infoln("Shutdown signal received")
+	}
+	log.Infoln("Server stopped")
+}

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -74,6 +74,15 @@ func (m *Manager) routeHandlers() map[string]http.HandlerFunc {
 	}
 }
 
+func (m *Manager) GetRoutes() []string {
+	routeHandlers := m.routeHandlers()
+	routes := make([]string, 0, len(routeHandlers))
+	for route := range routeHandlers {
+		routes = append(routes, route)
+	}
+	return routes
+}
+
 // handleCreateModel handles POST <inference-prefix>/models/create requests.
 func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 	if m.distributionClient == nil {


### PR DESCRIPTION
Built on top of https://github.com/docker/model-runner/pull/3.

Terminal 1:
```
go run main.go
```

Terminal 2:
```
$ curl --unix-socket model-runner.sock localhost/models/ai/smollm2
{"id":"sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9","tags":["ai/smollm2"],"created":1742816981,"config":{"format":"gguf","quantization":"IQ2_XXS/Q4_K_M","parameters":"361.82 M","architecture":"llama","size":"256.35 MiB"}}
$ curl --unix-socket model-runner.sock localhost/engines/v1/models/ai/smollm2
{"id":"ai/smollm2","object":"model","created":1742816981,"owned_by":"docker"}
$ curl --unix-socket model-runner.sock localhost/engines/llama.cpp/v1/models/ai/smollm2
{"id":"ai/smollm2","object":"model","created":1742816981,"owned_by":"docker"}
```