### PR TITLE
Set openAI ID to model ID when untagged

### DIFF
--- a/pkg/inference/models/api.go
+++ b/pkg/inference/models/api.go
@@ -48,7 +48,10 @@ func ToOpenAI(m types.Model) (*OpenAIModel, error) {
 		created = desc.Created.Unix()
 	}
 
-	id := ""
+	id, err := m.ID()
+	if err != nil {
+		return nil, fmt.Errorf("get model ID: %w", err)
+	}
 	if tags := m.Tags(); len(tags) > 0 {
 		id = tags[0]
 	}


### PR DESCRIPTION
When a model has no tags, set `id` to the model ID in openAI API responses. Preserve the original behavior when one or more tags are present.

Example:
```bash
> ./model-cli list --openai 2>&1 | jq .
{
  "object": "list",
  "data": [
    {
      "id": "sha256:8e29acb3019cd9bfb04b90b6a77b1bff4ab7abb9dc3efe2fba18729343d5e6d5",
      "object": "model",
      "created": 1743622285,
      "owned_by": "docker"
    },
    {
      "id": "ai/smollm2",
      "object": "model",
      "created": 1742816981,
      "owned_by": "docker"
    }
  ]
}
```