### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,76 @@
+# Version control
+.git/
+.gitignore
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Go build and cache artifacts
+/vendor/
+*.test
+*.out
+*.exe
+*.dll
+*.so
+*.dylib
+*.a
+*.o
+*.obj
+*.cgo*
+*.coverprofile
+*.prof
+*.tmp
+*.log
+
+# Go tool cache
+/go-build/
+/go-cache/
+
+# Test and development artifacts
+test/
+tests/
+*_test.go
+
+# Build outputs
+dist/
+build/
+out/
+debug/
+
+# Temporary and local files
+tmp/
+temp/
+.local/
+local/
+
+# Environment and secrets
+.env*
+*.env
+*.pem
+*.key
+*.crt
+config.local.*
+*.local.yml
+
+# Documentation and markdown
+docs/
+*.md
+README*
+LICENSE
+
+# Docker files
+Dockerfile*
+
+# Miscellaneous
+*.bak
+*.old
+*.orig
+*.rej
+*.DS_Store
+.Spotlight-V100
+.Trashes
+
+# Exclude nothing else; keep source code and necessary files for build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+model-runner
+model-runner.sock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .idea/
 model-runner
 model-runner.sock
-model-runner
-model-runner.sock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 model-runner
 model-runner.sock
+model-runner
+model-runner.sock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.23.7
+ARG GO_VERSION=1.24.2
 ARG LLAMA_SERVER_VERSION=latest
 ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.cpu.amd64
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 # Install git for go mod download if needed
-RUN apk add --no-cache git
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM docker/docker-model-backend-llamacpp:${LLAMA_SERVER_VERSION} AS llama-server
 
 # --- Final image ---
-FROM debian:bookworm-slim AS final
+FROM ubuntu:24.04 AS final
 
 # Create non-root user
 RUN groupadd --system modelrunner && useradd --system --gid modelrunner modelrunner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION=1.23.7
+ARG LLAMA_SERVER_VERSION=latest
+ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.cpu.amd64
+
+FROM golang:${GO_VERSION}-alpine AS builder
+
+# Install git for go mod download if needed
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+# Copy go mod/sum first for better caching
+COPY --link go.mod go.sum ./
+
+# Download dependencies (with cache mounts)
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+# Copy the rest of the source code
+COPY --link . .
+
+# Build the Go binary (static build)
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o model-runner ./main.go
+
+# --- Get llama.cpp binary ---
+FROM docker/docker-model-backend-llamacpp:${LLAMA_SERVER_VERSION} AS llama-server
+
+# --- Final image ---
+FROM alpine:latest AS final
+
+# Create non-root user
+RUN addgroup -S modelrunner && adduser -S modelrunner -G modelrunner
+
+# Install ca-certificates for HTTPS
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add --no-cache ca-certificates
+
+WORKDIR /app
+
+# Create directories for the socket file and llama.cpp binary, and set proper permissions
+RUN mkdir -p /var/run/model-runner /app/bin && \
+    chown -R modelrunner:modelrunner /var/run/model-runner /app/bin
+
+# Copy the built binary from builder
+COPY --from=builder /app/model-runner /app/model-runner
+
+# Copy the llama.cpp binary from the llama-server stage
+ARG LLAMA_BINARY_PATH
+COPY --from=llama-server ${LLAMA_BINARY_PATH} /app/bin/com.docker.llama-server
+
+USER modelrunner
+
+# Set the environment variable for the socket path and LLaMA server binary path
+ENV MODEL_RUNNER_SOCK=/var/run/model-runner/model-runner.sock
+ENV LLAMA_SERVER_PATH=/app/bin
+
+ENTRYPOINT ["/app/model-runner"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /app
 
 # Create directories for the socket file and llama.cpp binary, and set proper permissions
-RUN mkdir -p /var/run/model-runner /app/bin /home/modelrunner/.docker/models && \
-    chown -R modelrunner:modelrunner /var/run/model-runner /app/bin /home/modelrunner && \
-    chmod -R 755 /home/modelrunner
+RUN mkdir -p /var/run/model-runner /app/bin /models && \
+    chown -R modelrunner:modelrunner /var/run/model-runner /app/bin /models && \
+    chmod -R 755 /models
 
 # Copy the built binary from builder
 COPY --from=builder /app/model-runner /app/model-runner

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Project variables
+APP_NAME := model-runner
+GO_VERSION := 1.23.7
+
+# Main targets
+.PHONY: build run clean help
+
+# Default target
+.DEFAULT_GOAL := help
+
+# Build the Go application
+build:
+	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(APP_NAME) ./main.go
+
+# Run the application locally
+run: build
+	./$(APP_NAME)
+
+# Clean build artifacts
+clean:
+	rm -f $(APP_NAME)
+	rm -f model-runner.sock
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  build          - Build the Go application"
+	@echo "  run            - Run the application locally"
+	@echo "  clean          - Clean build artifacts"
+	@echo "  help           - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 # Project variables
 APP_NAME := model-runner
 GO_VERSION := 1.23.7
+LLAMA_SERVER_VERSION := v0.0.4-rc2-cpu
+TARGET_OS := linux
+TARGET_ARCH := amd64
+ACCEL := cpu
+DOCKER_IMAGE := go-model-runner:latest
+LLAMA_BINARY := /com.docker.llama-server.native.$(TARGET_OS).$(ACCEL).$(TARGET_ARCH)
 
 # Main targets
-.PHONY: build run clean help
+.PHONY: build run clean test docker-build docker-run help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -21,10 +27,28 @@ clean:
 	rm -f $(APP_NAME)
 	rm -f model-runner.sock
 
+# Run tests
+test:
+	go test -v ./...
+
+# Build Docker image
+docker-build:
+	docker build --platform linux/amd64 \
+		--build-arg LLAMA_SERVER_VERSION=$(LLAMA_SERVER_VERSION) \
+		--build-arg LLAMA_BINARY_PATH=$(LLAMA_BINARY) \
+		-t $(DOCKER_IMAGE) .
+
+# Run in Docker container
+docker-run: docker-build
+	docker run --rm $(DOCKER_IMAGE)
+
 # Show help
 help:
 	@echo "Available targets:"
 	@echo "  build          - Build the Go application"
 	@echo "  run            - Run the application locally"
 	@echo "  clean          - Clean build artifacts"
+	@echo "  test           - Run tests"
+	@echo "  docker-build   - Build Docker image"
+	@echo "  docker-run     - Run in Docker container"
 	@echo "  help           - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,10 @@ docker-run: docker-build
 	mkdir -p $(MODELS_PATH)
 	docker run --rm \
 		-p $(PORT):$(PORT) \
-		-v "$(MODELS_PATH):/home/modelrunner/.docker/models" \
+		-v "$(MODELS_PATH):/models" \
 		-e MODEL_RUNNER_PORT=$(PORT) \
 		-e LLAMA_SERVER_PATH=/app/bin \
+		-e MODELS_PATH=/models \
 		$(DOCKER_IMAGE)
 
 # Show help

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ TARGET_ARCH := amd64
 ACCEL := cpu
 DOCKER_IMAGE := go-model-runner:latest
 LLAMA_BINARY := /com.docker.llama-server.native.$(TARGET_OS).$(ACCEL).$(TARGET_ARCH)
+SOCKET_PATH := $(shell pwd)/socket
 
 # Main targets
-.PHONY: build run clean test docker-build docker-run help
+.PHONY: build run clean test docker-build docker-run docker-run-socket help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -26,6 +27,7 @@ run: build
 clean:
 	rm -f $(APP_NAME)
 	rm -f model-runner.sock
+	rm -rf ./socket
 
 # Run tests
 test:
@@ -42,13 +44,26 @@ docker-build:
 docker-run: docker-build
 	docker run --rm $(DOCKER_IMAGE)
 
+# Run in Docker container with socket accessible from host
+docker-run-socket: docker-build clean
+	mkdir -p $(SOCKET_PATH)
+	chmod 777 $(SOCKET_PATH)
+	docker run --rm \
+		-v "$(SOCKET_PATH):/var/run/model-runner" \
+		-e MODEL_RUNNER_SOCK=/var/run/model-runner/model-runner.sock \
+		$(DOCKER_IMAGE)
+	@echo ""
+	@echo "Socket available at: $(SOCKET_PATH)/model-runner.sock"
+	@echo "Example usage: curl --unix-socket $(SOCKET_PATH)/model-runner.sock http://localhost/models"
+
 # Show help
 help:
 	@echo "Available targets:"
-	@echo "  build          - Build the Go application"
-	@echo "  run            - Run the application locally"
-	@echo "  clean          - Clean build artifacts"
-	@echo "  test           - Run tests"
-	@echo "  docker-build   - Build Docker image"
-	@echo "  docker-run     - Run in Docker container"
-	@echo "  help           - Show this help message"
+	@echo "  build          	- Build the Go application"
+	@echo "  run            	- Run the application locally"
+	@echo "  clean          	- Clean build artifacts"
+	@echo "  test           	- Run tests"
+	@echo "  docker-build   	- Build Docker image"
+	@echo "  docker-run     	- Run in Docker container"
+	@echo "  docker-run-socket 	- Run in Docker container with socket accessible from host"
+	@echo "  help           	- Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ docker-run-socket: docker-build clean
 	docker run --rm \
 		-v "$(SOCKET_PATH):/var/run/model-runner" \
 		-e MODEL_RUNNER_SOCK=/var/run/model-runner/model-runner.sock \
+		-e LLAMA_SERVER_PATH=/app/bin \
 		$(DOCKER_IMAGE)
 	@echo ""
 	@echo "Socket available at: $(SOCKET_PATH)/model-runner.sock"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,101 @@ with [Model Distribution](https://github.com/docker/model-distribution) and the
 [Model CLI](https://github.com/docker/model-cli)). It includes a `main.go` that
 mimics its integration with Docker Desktop and allows the package to be run in a
 standalone mode.
+
+## Using the Makefile
+
+This project includes a Makefile to simplify common development tasks. It requires Docker Desktop >= 4.41.0 
+The Makefile provides the following targets:
+
+- `build` - Build the Go application
+- `run` - Run the application locally
+- `clean` - Clean build artifacts
+- `help` - Show available targets
+
+### Examples
+
+```sh
+# Build the application
+make build
+
+# Run the application locally
+make run
+
+# Show all available targets
+make help
+```
+
+## API Examples
+
+The Model Runner exposes a REST API over a Unix socket. You can interact with it using curl commands with the `--unix-socket` option.
+
+### Listing Models
+
+To list all available models:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models
+```
+
+### Creating a Model
+
+To create a new model:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models/create -X POST -d '{"from": "ai/smollm2"}'
+```
+
+### Getting Model Information
+
+To get information about a specific model:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models/ai/smollm2
+```
+
+### Chatting with a Model
+
+To chat with a model, you can send a POST request to the model's chat endpoint:
+
+```sh
+curl --unix-socket model-runner.sock localhost/engines/llama.cpp/v1/chat/completions -X POST -d '{
+  "model": "ai/smollm2",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello, how are you?"}
+  ]
+}'
+```
+
+The response will contain the model's reply:
+
+```json
+{
+  "id": "chat-12345",
+  "object": "chat.completion",
+  "created": 1682456789,
+  "model": "ai/smollm2",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I'm doing well, thank you for asking! How can I assist you today?"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 24,
+    "completion_tokens": 16,
+    "total_tokens": 40
+  }
+}
+```
+
+### Deleting a model
+To delete a model from the server, send a DELETE request to the model's endpoint:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models/ai/smollm2 -X DELETE
+```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,80 @@ The Makefile provides the following targets:
 - `build` - Build the Go application
 - `run` - Run the application locally
 - `clean` - Clean build artifacts
+- `test` - Run tests
+- `docker-build` - Build the Docker image
+- `docker-run` - Run the application in a Docker container
+- `help` - Show available targets
+
+### llama.cpp integration
+
+The Docker image includes the llama.cpp server binary from the `docker/docker-model-backend-llamacpp` image. You can specify the version of the image to use by setting the `LLAMA_SERVER_VERSION` variable. Additionally, you can configure the target OS, architecture, and acceleration type:
+
+```sh
+# Build with a specific llama.cpp server version
+LLAMA_SERVER_VERSION=v0.0.4-rc2-cpu make docker-build
+
+# Specify all parameters
+LLAMA_SERVER_VERSION=v0.0.4-rc2-cpu TARGET_OS=linux TARGET_ARCH=amd64 ACCEL=cpu make docker-build
+```
+
+Default values:
+- `LLAMA_SERVER_VERSION`: v0.0.4-rc2-cpu
+- `TARGETOS`: linux
+- `TARGETARCH`: amd64
+- `ACCEL`: cpu
+
+The binary path in the image follows this pattern: `/com.docker.llama-server.native.${TARGETOS}.${ACCEL}.${TARGETARCH}`
+
+### Examples
+
+```sh
+# Build the application
+make build
+
+# Run the application locally
+make run
+
+# Show all available targets
+make help
+```
+
+## API Examples
+
+The Model Runner exposes a REST API over a Unix socket. You can interact with it using curl commands with the `--unix-socket` option.
+
+### Listing Models
+
+To list all available models:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models
+```
+
+### Creating a Model
+
+To create a new model:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models/create -X POST -d '{"from": "ai/smollm2:"}'
+```
+
+### Getting Model Information
+
+To get information about a specific model:
+
+```sh
+curl --unix-socket model-runner.sock localhost/models/ai/smollm2
+```
+
+## Using the Makefile
+
+This project includes a Makefile to simplify common development tasks. It requires Docker Desktop >= 4.41.0 
+The Makefile provides the following targets:
+
+- `build` - Build the Go application
+- `run` - Run the application locally
+- `clean` - Clean build artifacts
 - `help` - Show available targets
 
 ### Examples

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250418222450-8f6c05a5ffa4
+	github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d
 	github.com/jaypipes/ghw v0.16.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZ
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/model-distribution v0.0.0-20250418222450-8f6c05a5ffa4 h1:v7DyBUd08t4XQe4NC2Rb8ZSWOiWVXD0TbdgIOQZ/IQo=
 github.com/docker/model-distribution v0.0.0-20250418222450-8f6c05a5ffa4/go.mod h1:fd9H/2KAY0+ByxbohWfCkxp0rxf0pqSlHEtFTjTXbLk=
+github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d h1:lyxdxjNHTSyQ2w1rjbuu5pbgX42AD3kmxWLNv3mdqQ4=
+github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -59,6 +61,8 @@ github.com/google/go-containerregistry v0.20.3 h1:oNx7IdTI936V8CQRveCjaxOiegWwvM
 github.com/google/go-containerregistry v0.20.3/go.mod h1:w00pIgBRDVUDFM6bq+Qx8lwNWK+cxgCuX1vd3PIBDNI=
 github.com/gpustack/gguf-parser-go v0.14.0 h1:9kMdbJ9pHhvEeATx163WE9q+O74bi05KPJLEtVBUjw0=
 github.com/gpustack/gguf-parser-go v0.14.0/go.mod h1:GvHh1Kvvq5ojCOsJ5UpwiJJmIjFw3Qk5cW7R+CZ3IJo=
+github.com/gpustack/gguf-parser-go v0.14.1 h1:tmz2eTnSEFfE52V10FESqo9oAUquZ6JKQFntWC/wrEg=
+github.com/gpustack/gguf-parser-go v0.14.1/go.mod h1:GvHh1Kvvq5ojCOsJ5UpwiJJmIjFw3Qk5cW7R+CZ3IJo=
 github.com/henvic/httpretty v0.1.4 h1:Jo7uwIRWVFxkqOnErcoYfH90o3ddQyVrSANeS4cxYmU=
 github.com/henvic/httpretty v0.1.4/go.mod h1:Dn60sQTZfbt2dYsdUSNsCljyF4AfdqnuJFDLJA1I4AM=
 github.com/jaypipes/ghw v0.16.0 h1:3HurCTS38VNpeQLo5fIdZsySuo/qAfpPSJ5t05QBFPM=

--- a/main.go
+++ b/main.go
@@ -27,10 +27,14 @@ func main() {
 		sockName = "model-runner.sock"
 	}
 
+	log.Infof("sockName: %s", sockName)
+
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatalf("Failed to get user home directory: %v", err)
 	}
+
+	log.Infof("userHomeDir: %s", userHomeDir)
 
 	modelManager := models.NewManager(log, models.ClientConfig{
 		StoreRootPath: filepath.Join(userHomeDir, ".docker", "models"),
@@ -41,6 +45,8 @@ func main() {
 	if llamaServerPath == "" {
 		llamaServerPath = "/Applications/Docker.app/Contents/Resources/bin"
 	}
+
+	log.Infof("LLAMA_SERVER_PATH: %s", llamaServerPath)
 
 	llamaCppBackend, err := llamacpp.New(
 		log,

--- a/main.go
+++ b/main.go
@@ -37,11 +37,16 @@ func main() {
 		Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
 	})
 
+	llamaServerPath := os.Getenv("LLAMA_SERVER_PATH")
+	if llamaServerPath == "" {
+		llamaServerPath = "/Applications/Docker.app/Contents/Resources/bin"
+	}
+
 	llamaCppBackend, err := llamacpp.New(
 		log,
 		modelManager,
 		log.WithFields(logrus.Fields{"component": "llama.cpp"}),
-		"/Applications/Docker.app/Contents/Resources/bin",
+		llamaServerPath,
 		func() string { wd, _ := os.Getwd(); return wd }(),
 	)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -36,8 +36,13 @@ func main() {
 
 	log.Infof("userHomeDir: %s", userHomeDir)
 
+	modelPath := os.Getenv("MODELS_PATH")
+	if modelPath == "" {
+		modelPath = filepath.Join(userHomeDir, ".docker", "models")
+	}
+
 	modelManager := models.NewManager(log, models.ClientConfig{
-		StoreRootPath: filepath.Join(userHomeDir, ".docker", "models"),
+		StoreRootPath: modelPath,
 		Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
 	})
 

--- a/main.go
+++ b/main.go
@@ -27,14 +27,10 @@ func main() {
 		sockName = "model-runner.sock"
 	}
 
-	log.Infof("sockName: %s", sockName)
-
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatalf("Failed to get user home directory: %v", err)
 	}
-
-	log.Infof("userHomeDir: %s", userHomeDir)
 
 	modelPath := os.Getenv("MODELS_PATH")
 	if modelPath == "" {

--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -33,6 +33,7 @@ var (
 func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
 	llamaCppPath, vendoredServerStoragePath, desiredVersion, desiredVariant string,
 ) error {
+	log.Infof("downloadLatestLlamaCpp: %s, %s, %s, %s", desiredVersion, desiredVariant, vendoredServerStoragePath, llamaCppPath)
 	desiredTag := desiredVersion + "-" + desiredVariant
 	url := fmt.Sprintf("https://hub.docker.com/v2/namespaces/%s/repositories/%s/tags/%s", hubNamespace, hubRepo, desiredTag)
 	resp, err := httpClient.Get(url)

--- a/pkg/inference/backends/llamacpp/download_linux.go
+++ b/pkg/inference/backends/llamacpp/download_linux.go
@@ -2,7 +2,6 @@ package llamacpp
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/docker/model-runner/pkg/logging"
@@ -11,5 +10,5 @@ import (
 func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
 	llamaCppPath, vendoredServerStoragePath string,
 ) error {
-	return errors.New("platform is not supported")
+	return errLlamaCppUpToDate
 }

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -69,12 +69,7 @@ func (l *llamaCpp) UsesExternalModelManagement() bool {
 // Install implements inference.Backend.Install.
 func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 	l.updatedLlamaCpp = false
-
-	// We don't currently support this backend on Windows or Linux. We'll likely
-	// never support it on Intel Macs.
-	if runtime.GOOS == "linux" {
-		return errors.New("not implemented")
-	} else if (runtime.GOOS == "darwin" && runtime.GOARCH == "amd64") || (runtime.GOOS == "windows" && runtime.GOARCH == "arm64") {
+	if (runtime.GOOS == "darwin" && runtime.GOARCH == "amd64") || (runtime.GOOS == "windows" && runtime.GOARCH == "arm64") {
 		return errors.New("platform not supported")
 	}
 
@@ -90,6 +85,8 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 	// Even if docker/docker-model-backend-llamacpp:latest has been downloaded before, we still require its
 	// digest to be equal to the one on Docker Hub.
 	llamaCppPath := filepath.Join(l.updatedServerStoragePath, llamaServerBin)
+	l.log.Infof("llamaCppPath: %s", llamaCppPath)
+	l.log.Infof("vendoredServerStoragePath: %s", l.vendoredServerStoragePath)
 	if err := l.ensureLatestLlamaCpp(ctx, l.log, httpClient, llamaCppPath, l.vendoredServerStoragePath); err != nil {
 		l.log.Infof("failed to ensure latest llama.cpp: %v\n", err)
 		if !errors.Is(err, errLlamaCppUpToDate) {


### PR DESCRIPTION
# Add Docker Support and TCP Port Access

This PR adds Docker support and TCP port access to the model-runner service.

## Changes

- Added Dockerfile with multi-stage build
- Added TCP port support (default: 8080) alongside Unix socket
- Added Docker-related Makefile targets (`docker-build`, `docker-run`)
- Updated documentation with Docker usage and API examples
- Added environment variable configuration for port and llama.cpp path
- Updated dependencies

## Usage

```bash
# Run in Docker
make docker-run

# Customize port and model storage
make docker-run PORT=3000 MODELS_PATH=/path/to/models
```

The service now supports both Unix socket and TCP port access, with persistent model storage through Docker volumes.