### PR TITLE
[AIE-151] native: support dynamic detection of OpenCL

### DIFF
--- a/pkg/inference/backends/llamacpp/gpuinfo_windows.go
+++ b/pkg/inference/backends/llamacpp/gpuinfo_windows.go
@@ -58,17 +58,6 @@ func hasCUDA11CapableGPU(ctx context.Context, nvGPUInfoBin string) (bool, error)
 	return false, nil
 }
 
-// supportedAdrenoGPUVersions are the Adreno versions supported by llama.cpp.
-// See (and keep in sync with):
-// https://github.com/ggml-org/llama.cpp/blob/43ddab6eeeaab5a04fe5a364af0bafb0e4d35065/ggml/src/ggml-opencl/ggml-opencl.cpp#L180-L196
-var supportedAdrenoGPUVersions = []string{
-	"730",
-	"740",
-	"750",
-	"830",
-	"X1",
-}
-
 func hasSupportedAdrenoGPU() (bool, error) {
 	gpus, err := ghw.GPU()
 	if err != nil {
@@ -77,13 +66,13 @@ func hasSupportedAdrenoGPU() (bool, error) {
 	for _, gpu := range gpus.GraphicsCards {
 		isAdrenoFamily := strings.Contains(gpu.DeviceInfo.Product.Name, "Adreno") ||
 			strings.Contains(gpu.DeviceInfo.Product.Name, "Qualcomm")
-		if !isAdrenoFamily {
-			continue
-		}
-		for _, version := range supportedAdrenoGPUVersions {
-			if strings.Contains(gpu.DeviceInfo.Product.Name, version) {
-				return true, nil
-			}
+		if isAdrenoFamily {
+			// llama.cpp will detect / classify a limited set of Adreno GPU
+			// versions, but it won't actually require a specific version, even
+			// though some, e.g. the 6xx series, won't work. Since we'll have
+			// the ability disable GPU support, we'll allow the model runner to
+			// try optimistically.
+			true, nil
 		}
 	}
 	return false, nil

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -118,8 +119,8 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 		return fmt.Errorf("failed to get model: %w", err)
 	}
 
-	if err := os.RemoveAll(socket); err != nil {
-		l.log.Warnln("failed to remove socket file %s: %w", socket, err)
+	if err := os.RemoveAll(socket); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		l.log.Warnf("failed to remove socket file %s: %w\n", socket, err)
 		l.log.Warnln("llama.cpp may not be able to start")
 	}
 
@@ -177,8 +178,8 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 		serverLogStream.Close()
 		llamaCppErrors <- llamaCppErr
 		close(llamaCppErrors)
-		if err := os.Remove(socket); err != nil {
-			l.log.Warnln("failed to remove socket file %s on exit: %w", socket, err)
+		if err := os.Remove(socket); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			l.log.Warnf("failed to remove socket file %s on exit: %w\n", socket, err)
 		}
 	}()
 	defer func() {


### PR DESCRIPTION
This PR is a proposal for how we might solve the OpenCL detection issue.  Expanded hardware checks could be added, especially if we want to allowlist specific GPU families as we go, but we'd need to distribute Adreno-specific and "vanilla" OpenCL backend compilations (i.e. ones with `GGML_OPENCL_USE_ADRENO_KERNELS=OFF`)