### PR TITLE
Add NormalizedServeMux

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/model-runner/pkg/inference/backends/llamacpp"
 	"github.com/docker/model-runner/pkg/inference/models"
 	"github.com/docker/model-runner/pkg/inference/scheduling"
+	"github.com/docker/model-runner/pkg/routing"
 	"github.com/sirupsen/logrus"
 )
 
@@ -68,7 +69,7 @@ func main() {
 		http.DefaultClient,
 	)
 
-	router := http.NewServeMux()
+	router := routing.NewNormalizedServeMux()
 	for _, route := range modelManager.GetRoutes() {
 		router.Handle(route, modelManager)
 	}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -1,0 +1,24 @@
+package routing
+
+import (
+	"net/http"
+	"path"
+	"strings"
+)
+
+type NormalizedServeMux struct {
+	*http.ServeMux
+}
+
+func NewNormalizedServeMux() *NormalizedServeMux {
+	return &NormalizedServeMux{http.NewServeMux()}
+}
+
+func (nm *NormalizedServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "//") {
+		normalizedPath := path.Clean(r.URL.Path)
+		r.URL.Path = normalizedPath
+	}
+
+	nm.ServeMux.ServeHTTP(w, r)
+}


### PR DESCRIPTION
Add `NormalizedServeMux` implementation that wraps the standard http.ServeMux with automatic path normalization.

The new implementation:
- Automatically normalizes and prevents incorrect route handling for paths with consecutive slashes (e.g., "//models" → "/models").
- Uses Go's `path.Clean()` for consistent path normalization.
- Maintains the same interface as `http.ServeMux` for easy drop-in replacement.

Without this patch, using `DMR_HOST=http://localhost:8080/` with a trailing `/` will make `docker model pull` fail.
```
$ make docker-run
$ DMR_HOST=http://localhost:8080/ docker model pull ai/smollm2
```