### PR TITLE
gitignore: Ignore models/ which is the default MODELS_PATH in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 model-runner
 model-runner.sock
+# Default MODELS_PATH in Makefile
+models/


### PR DESCRIPTION
Ignore `models/` which is the default `MODELS_PATH` in Makefile.