### PR TITLE
llama.cpp: linux: Set running status on errLlamaCppUpToDate

### DIFF
--- a/pkg/inference/backends/llamacpp/download_linux.go
+++ b/pkg/inference/backends/llamacpp/download_linux.go
@@ -2,13 +2,17 @@ package llamacpp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"path/filepath"
 
 	"github.com/docker/model-runner/pkg/logging"
 )
 
-func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
-	llamaCppPath, vendoredServerStoragePath string,
+func (l *llamaCpp) ensureLatestLlamaCpp(_ context.Context, log logging.Logger, _ *http.Client,
+	_, vendoredServerStoragePath string,
 ) error {
+	l.status = fmt.Sprintf("running llama.cpp version: %s",
+		getLlamaCppVersion(log, filepath.Join(vendoredServerStoragePath, "com.docker.llama-server")))
 	return errLlamaCppUpToDate
 }


### PR DESCRIPTION
By running `make docker-rune` I noticed:
```
$ DMR_HOST=http://localhost:8080 docker model status
Docker Model Runner is running

Status:
llama.cpp: installing
```

This patch aligns the status as on macOS and Windows:
```
$ DMR_HOST=http://localhost:8080 docker model status
Docker Model Runner is running

Status:
llama.cpp: running llama.cpp version: a0f7016
```
