### PR TITLE
Bump model distribution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d
+	github.com/docker/model-distribution v0.0.0-20250512190053-b3792c042d57
 	github.com/jaypipes/ghw v0.16.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
-github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d h1:lyxdxjNHTSyQ2w1rjbuu5pbgX42AD3kmxWLNv3mdqQ4=
-github.com/docker/model-distribution v0.0.0-20250423075433-587f475e591d/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250512190053-b3792c042d57 h1:ZqfKknb+0/uJid8XLFwSl/osjE+WuS6o6I3dh3ZqO4U=
+github.com/docker/model-distribution v0.0.0-20250512190053-b3792c042d57/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/docker/model-distribution/distribution"
+	"github.com/docker/model-distribution/registry"
 	"github.com/docker/model-distribution/types"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/logging"
@@ -129,17 +130,17 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 	// Pull the model. In the future, we may support additional operations here
 	// besides pulling (such as model building).
 	if err := m.PullModel(r.Context(), request.From, w); err != nil {
-		if errors.Is(err, distribution.ErrInvalidReference) {
+		if errors.Is(err, registry.ErrInvalidReference) {
 			m.log.Warnf("Invalid model reference %q: %v", request.From, err)
 			http.Error(w, "Invalid model reference", http.StatusBadRequest)
 			return
 		}
-		if errors.Is(err, distribution.ErrUnauthorized) {
+		if errors.Is(err, registry.ErrUnauthorized) {
 			m.log.Warnf("Unauthorized to pull model %q: %v", request.From, err)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		if errors.Is(err, distribution.ErrModelNotFound) {
+		if errors.Is(err, registry.ErrModelNotFound) {
 			m.log.Warnf("Failed to pull model %q: %v", request.From, err)
 			http.Error(w, "Model not found", http.StatusNotFound)
 			return
@@ -388,7 +389,7 @@ func (m *Manager) handlePushModel(w http.ResponseWriter, r *http.Request, model 
 			http.Error(w, "Model not found", http.StatusNotFound)
 			return
 		}
-		if errors.Is(err, distribution.ErrUnauthorized) {
+		if errors.Is(err, registry.ErrUnauthorized) {
 			m.log.Warnf("Unauthorized to push model %q: %v", model, err)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
https://github.com/docker/model-distribution/pull/74 required some moving of error types. This PR bumps model-distribution and updates to use `registry.Err*` to check registry related errors.