### PR TITLE
image: set default TCP port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ USER modelrunner
 
 # Set the environment variable for the socket path and LLaMA server binary path
 ENV MODEL_RUNNER_SOCK=/var/run/model-runner/model-runner.sock
+ENV MODEL_RUNNER_PORT=12434
 ENV LLAMA_SERVER_PATH=/app/bin
 ENV HOME=/home/modelrunner
 ENV MODELS_PATH=/models


### PR DESCRIPTION
When running as a container, we'll always want to listen on TCP, so we'll set the default port to match the standard model runner default.