### PR TITLE
standalone: hide supporting images on cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,7 @@ ENV LLAMA_SERVER_PATH=/app/bin
 ENV HOME=/home/modelrunner
 ENV MODELS_PATH=/models
 
+# Label the image so that it's hidden on cloud engines.
+LABEL com.docker.desktop.service="model-runner"
+
 ENTRYPOINT ["/app/model-runner"]


### PR DESCRIPTION
This PR adds a label to standalone model runner images that causes it to be hidden on cloud.