### PR TITLE
Use int64 for size instead of float64

### DIFF
--- a/pkg/diskusage/diskusage.go
+++ b/pkg/diskusage/diskusage.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-func Size(path string) (float64, error) {
+func Size(path string) (int64, error) {
 	var size int64
 	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -20,5 +20,5 @@ func Size(path string) (float64, error) {
 		}
 		return nil
 	})
-	return float64(size), err
+	return size, err
 }

--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -70,5 +70,5 @@ type Backend interface {
 	// Status returns a description of the backend's state.
 	Status() string
 	// GetDiskUsage returns the disk usage of the backend.
-	GetDiskUsage() (float64, error)
+	GetDiskUsage() (int64, error)
 }

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -201,7 +201,7 @@ func (l *llamaCpp) Status() string {
 	return l.status
 }
 
-func (l *llamaCpp) GetDiskUsage() (float64, error) {
+func (l *llamaCpp) GetDiskUsage() (int64, error) {
 	size, err := diskusage.Size(l.updatedServerStoragePath)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting store size: %v", err)

--- a/pkg/inference/backends/mlx/mlx.go
+++ b/pkg/inference/backends/mlx/mlx.go
@@ -59,6 +59,6 @@ func (m *mlx) Status() string {
 	return "not running"
 }
 
-func (m *mlx) GetDiskUsage() (float64, error) {
+func (m *mlx) GetDiskUsage() (int64, error) {
 	return 0, nil
 }

--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -59,6 +59,6 @@ func (v *vLLM) Status() string {
 	return "not running"
 }
 
-func (v *vLLM) GetDiskUsage() (float64, error) {
+func (v *vLLM) GetDiskUsage() (int64, error) {
 	return 0, nil
 }

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -401,7 +401,7 @@ func (m *Manager) handlePushModel(w http.ResponseWriter, r *http.Request, model 
 }
 
 // GetDiskUsage returns the disk usage of the model store.
-func (m *Manager) GetDiskUsage() (float64, error, int) {
+func (m *Manager) GetDiskUsage() (int64, error, int) {
 	if m.distributionClient == nil {
 		return 0, errors.New("model distribution service unavailable"), http.StatusServiceUnavailable
 	}

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -58,8 +58,8 @@ type BackendStatus struct {
 
 // DiskUsage represents the disk usage of the models and default backend.
 type DiskUsage struct {
-	ModelsDiskUsage         float64 `json:"models_disk_usage"`
-	DefaultBackendDiskUsage float64 `json:"default_backend_disk_usage"`
+	ModelsDiskUsage         int64 `json:"models_disk_usage"`
+	DefaultBackendDiskUsage int64 `json:"default_backend_disk_usage"`
 }
 
 // UnloadRequest is used to specify which models to unload.


### PR DESCRIPTION
Representing byte sizes as float64's can be confusing and potentially inefficient. So, use an integer type for representing byte sizes.