### PR TITLE
Allow disabling inference server auto update

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,13 @@ func main() {
 		modelPath = filepath.Join(userHomeDir, ".docker", "models")
 	}
 
+	_, disableServerUpdate := os.LookupEnv("DISABLE_SERVER_UPDATE")
+	if disableServerUpdate {
+		llamacpp.ShouldUpdateServerLock.Lock()
+		llamacpp.ShouldUpdateServer = false
+		llamacpp.ShouldUpdateServerLock.Unlock()
+	}
+
 	modelManager := models.NewManager(log, models.ClientConfig{
 		StoreRootPath: modelPath,
 		Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),


### PR DESCRIPTION
Being able to disable the inference server auto update process is useful for testing. Eventually we should also provide it as an option to DD users. So, add an option to disable the inference server auto update.