### PR TITLE
Fix return on server update disabled

### DIFF
--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -25,11 +25,12 @@ const (
 )
 
 var (
-	ShouldUseGPUVariant     bool
-	ShouldUseGPUVariantLock sync.Mutex
-	ShouldUpdateServer      = true
-	ShouldUpdateServerLock  sync.Mutex
-	errLlamaCppUpToDate     = errors.New("bundled llama.cpp version is up to date, no need to update")
+	ShouldUseGPUVariant       bool
+	ShouldUseGPUVariantLock   sync.Mutex
+	ShouldUpdateServer        = true
+	ShouldUpdateServerLock    sync.Mutex
+	errLlamaCppUpToDate       = errors.New("bundled llama.cpp version is up to date, no need to update")
+	errLlamaCppUpdateDisabled = errors.New("llama.cpp auto-updated is disabled")
 )
 
 func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
@@ -40,7 +41,7 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 	ShouldUpdateServerLock.Unlock()
 	if !shouldUpdateServer {
 		log.Infof("downloadLatestLlamaCpp: update disabled")
-		return nil
+		return errLlamaCppUpdateDisabled
 	}
 
 	log.Infof("downloadLatestLlamaCpp: %s, %s, %s, %s", desiredVersion, desiredVariant, vendoredServerStoragePath, llamaCppPath)

--- a/pkg/inference/backends/llamacpp/download_linux.go
+++ b/pkg/inference/backends/llamacpp/download_linux.go
@@ -14,5 +14,5 @@ func (l *llamaCpp) ensureLatestLlamaCpp(_ context.Context, log logging.Logger, _
 ) error {
 	l.status = fmt.Sprintf("running llama.cpp version: %s",
 		getLlamaCppVersion(log, filepath.Join(vendoredServerStoragePath, "com.docker.llama-server")))
-	return errLlamaCppUpToDate
+	return errLlamaCppUpdateDisabled
 }

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -94,7 +94,7 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 	llamaCppPath := filepath.Join(l.updatedServerStoragePath, llamaServerBin)
 	if err := l.ensureLatestLlamaCpp(ctx, l.log, httpClient, llamaCppPath, l.vendoredServerStoragePath); err != nil {
 		l.log.Infof("failed to ensure latest llama.cpp: %v\n", err)
-		if !errors.Is(err, errLlamaCppUpToDate) {
+		if !(errors.Is(err, errLlamaCppUpToDate) || errors.Is(err, errLlamaCppUpdateDisabled)) {
 			l.status = fmt.Sprintf("failed to install llama.cpp: %v", err)
 		}
 		if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
If we don't return an error from `ensureLatestLlamaCpp` when update is disabled, we'll fall into the wrong code path, and may end up trying to execute a non-existent `llama-server`. So, make sure we return an error from `ensureLatestLlamaCpp` if auto-update is disabled.