### PR TITLE
Add bin subdirectory to updated llama.cpp path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ model-runner
 model-runner.sock
 # Default MODELS_PATH in Makefile
 models-store/
+# Directory where we store the updated llama.cpp
+updated-inference/

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 		llamaServerPath,
 		func() string {
 			wd, _ := os.Getwd()
-			d := filepath.Join(wd, "updated-inference")
+			d := filepath.Join(wd, "updated-inference", "bin")
 			_ = os.MkdirAll(d, 0o755)
 			return d
 		}(),


### PR DESCRIPTION
Add bin subdirectory to updated llama.cpp path.
By doing this, both the binary and the libs will be in the updated-inference directory.

After a `make run`, unless your installed Docker Desktop has the latest llama.cpp bundled, you'll see:
```
$ tree updated-inference
updated-inference
├── bin
│   └── com.docker.llama-server
└── lib
    ├── libggml-base.dylib
    ├── libggml-blas.dylib
    ├── libggml-cpu.dylib
    ├── libggml-metal.dylib
    ├── libggml.dylib
    ├── libllama.dylib
    └── libmtmd_shared.dylib
```
