### PR TITLE
Improve CORS config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ docker-run: docker-build
 		-e LLAMA_SERVER_PATH=/app/bin \
 		-e MODELS_PATH=/models \
 		-e LLAMA_ARGS="$(LLAMA_ARGS)" \
+		-e DMR_ORIGINS="$(DMR_ORIGINS)" \
 		$(DOCKER_IMAGE)
 
 # Show help

--- a/main.go
+++ b/main.go
@@ -47,10 +47,14 @@ func main() {
 		llamacpp.ShouldUpdateServerLock.Unlock()
 	}
 
-	modelManager := models.NewManager(log, models.ClientConfig{
-		StoreRootPath: modelPath,
-		Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
-	})
+	modelManager := models.NewManager(
+		log,
+		models.ClientConfig{
+			StoreRootPath: modelPath,
+			Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
+		},
+		nil,
+	)
 
 	llamaServerPath := os.Getenv("LLAMA_SERVER_PATH")
 	if llamaServerPath == "" {
@@ -85,6 +89,7 @@ func main() {
 		llamaCppBackend,
 		modelManager,
 		http.DefaultClient,
+		nil,
 	)
 
 	router := routing.NewNormalizedServeMux()

--- a/pkg/inference/cors.go
+++ b/pkg/inference/cors.go
@@ -2,13 +2,30 @@ package inference
 
 import (
 	"net/http"
+	"os"
+	"strings"
 )
 
-// CorsMiddleware handles CORS and OPTIONS preflight requests and sets the necessary CORS headers.
-func CorsMiddleware(next http.Handler) http.Handler {
+// CorsMiddleware handles CORS and OPTIONS preflight requests with optional allowedOrigins.
+// If allowedOrigins is nil or empty, it falls back to getAllowedOrigins().
+func CorsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
+	if len(allowedOrigins) == 0 {
+		allowedOrigins = getAllowedOrigins()
+	}
+
+	// Explicitly disable all origins.
+	if allowedOrigins == nil {
+		return next
+	}
+
+	allowAll := len(allowedOrigins) == 1 && allowedOrigins[0] == "*"
+	allowedSet := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		allowedSet[o] = struct{}{}
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Set CORS headers for all requests.
-		if origin := r.Header.Get("Origin"); origin != "" {
+		if origin := r.Header.Get("Origin"); origin != "" && (allowAll || originAllowed(origin, allowedSet)) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 		}
 
@@ -23,4 +40,30 @@ func CorsMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func originAllowed(origin string, allowedSet map[string]struct{}) bool {
+	_, ok := allowedSet[origin]
+	return ok
+}
+
+// getAllowedOrigins retrieves allowed origins from the DMR_ORIGINS environment variable.
+// If the variable is not set it returns nil, indicating no origins are allowed.
+func getAllowedOrigins() (origins []string) {
+	dmrOrigins := os.Getenv("DMR_ORIGINS")
+	if dmrOrigins == "" {
+		return nil
+	}
+
+	for _, o := range strings.Split(dmrOrigins, ",") {
+		if trimmed := strings.TrimSpace(o); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+
+	if len(origins) == 0 {
+		return nil
+	}
+
+	return origins
 }


### PR DESCRIPTION
Allow passing a list of allowed origins or retrieve them from DMR_ORIGINS.

You can test this with https://github.com/ilopezluna/chat2cart/tree/streaming and the following patch:
```
diff --git a/web/static/js/chat.js b/web/static/js/chat.js
index 1ecb6f0..0c6ccec 100644
--- a/web/static/js/chat.js
+++ b/web/static/js/chat.js
@@ -637,11 +637,11 @@ async function updateModelSelector(provider) {
             let endpoint;
             if (provider === 'dmr') {
                 // Use backend endpoint for DMR models
-                endpoint = '/api/v1/models/dmr';
+                endpoint = 'http://localhost:12434/engines/v1/models';
                 const response = await fetch(endpoint);
                 if (response.ok) {
                     const data = await response.json();
-                    models = data.models.map(model => ({
+                    models = data.data.map(model => ({
                         id: model.id,
                         name: model.id // Use the model ID as the display name
                     }));
```

- Disable CORS by not setting `DMR_ORIGINS` with `MODEL_RUNNER_PORT=12434 make run`.
- Enable CORS for all with `DMR_ORIGINS=* MODEL_RUNNER_PORT=12434 make run`.
- Enable it for a specific origin with `DMR_ORIGINS=http://localhost:3131 MODEL_RUNNER_PORT=12434 make run` (run chat2cart on port 3131).
By default, it will restrict all.