### PR TITLE
Allow specifying a target llama-server version

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,11 @@ func main() {
 		llamacpp.ShouldUpdateServerLock.Unlock()
 	}
 
+	desiredSeverVersion, ok := os.LookupEnv("LLAMACPP_SERVER_VERSION")
+	if ok {
+		llamacpp.SetDesiredServerVersion(desiredSeverVersion)
+	}
+
 	modelManager := models.NewManager(
 		log,
 		models.ClientConfig{

--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -29,9 +29,23 @@ var (
 	ShouldUseGPUVariantLock   sync.Mutex
 	ShouldUpdateServer        = true
 	ShouldUpdateServerLock    sync.Mutex
+	DesiredServerVersion      = "latest"
+	DesiredServerVersionLock  sync.Mutex
 	errLlamaCppUpToDate       = errors.New("bundled llama.cpp version is up to date, no need to update")
 	errLlamaCppUpdateDisabled = errors.New("llama.cpp auto-updated is disabled")
 )
+
+func GetDesiredServerVersion() string {
+	DesiredServerVersionLock.Lock()
+	defer DesiredServerVersionLock.Unlock()
+	return DesiredServerVersion
+}
+
+func SetDesiredServerVersion(version string) {
+	DesiredServerVersionLock.Lock()
+	defer DesiredServerVersionLock.Unlock()
+	DesiredServerVersion = version
+}
 
 func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
 	llamaCppPath, vendoredServerStoragePath, desiredVersion, desiredVariant string,

--- a/pkg/inference/backends/llamacpp/download_darwin.go
+++ b/pkg/inference/backends/llamacpp/download_darwin.go
@@ -10,7 +10,7 @@ import (
 func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, httpClient *http.Client,
 	llamaCppPath, vendoredServerStoragePath string,
 ) error {
-	desiredVersion := "latest"
+	desiredVersion := GetDesiredServerVersion()
 	desiredVariant := "metal"
 	return l.downloadLatestLlamaCpp(ctx, log, httpClient, llamaCppPath, vendoredServerStoragePath, desiredVersion,
 		desiredVariant)

--- a/pkg/inference/backends/llamacpp/download_windows.go
+++ b/pkg/inference/backends/llamacpp/download_windows.go
@@ -33,7 +33,7 @@ func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger,
 			}
 		}
 	}
-	desiredVersion := "latest"
+	desiredVersion := GetDesiredServerVersion()
 	desiredVariant := "cpu"
 	if canUseCUDA11 {
 		desiredVariant = "cuda"


### PR DESCRIPTION
I've found being able to lock the `llama-server` version to be useful at times. If we want to merge this it may make sense to come up with a cleaner solution. LMK what you think.