### PR TITLE
Switch to slimmer CUDA base image since cuDNN isn't required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           build-args: |
             "LLAMA_SERVER_VERSION=latest"
             "LLAMA_SERVER_VARIANT=cuda"
-            "BASE_IMAGE=nvidia/cuda:12.9.0-cudnn-runtime-ubuntu24.04"
+            "BASE_IMAGE=nvidia/cuda:12.9.0-runtime-ubuntu24.04"
           push: true
           sbom: true
           provenance: mode=max


### PR DESCRIPTION
This shaves about 600 MB off the `docker/model-runner` CUDA images.