### PR TITLE
loader: trigger idle runner eviction immediately if a runner is defunct

### DIFF
--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -245,6 +245,12 @@ func (l *loader) idleCheckDuration() time.Duration {
 	// Compute the oldest usage time for any idle runner.
 	var oldest time.Time
 	for _, slot := range l.runners {
+		select {
+		case <-l.slots[slot].done:
+			// Check immediately if a runner is defunct
+			return 0
+		default:
+		}
 		if l.references[slot] == 0 {
 			timestamp := l.timestamps[slot]
 			if oldest.IsZero() || timestamp.Before(oldest) {


### PR DESCRIPTION
Modify `idleCheckDuration` so that when it's called randomly, it also verifies whether there's a defunct runner, and if so, returns `0` to trigger an immediate check.