### PR TITLE
Add OpenAIRecorder

### DIFF
--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -30,8 +30,8 @@ func (m BackendMode) String() string {
 }
 
 type BackendConfiguration struct {
-	ContextSize int64
-	RawFlags    []string
+	ContextSize int64    `json:"context_size,omitempty"`
+	RawFlags    []string `json:"flags,omitempty"`
 }
 
 // Backend is the interface implemented by inference engine backends. Backend

--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -169,6 +169,8 @@ func run(
 		}
 	}
 
+	r.openAIRecorder.SetConfigForModel(model, runnerConfig)
+
 	// Start the backend run loop.
 	go func() {
 		if err := backend.Run(runCtx, socket, model, mode, runnerConfig); err != nil {

--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/logging"
+	"github.com/docker/model-runner/pkg/metrics"
 )
 
 const (
@@ -63,6 +64,8 @@ type runner struct {
 	proxy *httputil.ReverseProxy
 	// proxyLog is the stream used for logging by proxy.
 	proxyLog io.Closer
+	// openAIRecorder is used to record OpenAI API inference requests and responses.
+	openAIRecorder *metrics.OpenAIRecorder
 	// err is the error returned by the runner's backend, only valid after done is closed.
 	err error
 }
@@ -75,6 +78,7 @@ func run(
 	mode inference.BackendMode,
 	slot int,
 	runnerConfig *inference.BackendConfiguration,
+	openAIRecorder *metrics.OpenAIRecorder,
 ) (*runner, error) {
 	// Create a dialer / transport that target backend on the specified slot.
 	socket, err := RunnerSocketPath(slot)
@@ -124,16 +128,17 @@ func run(
 	runDone := make(chan struct{})
 
 	r := &runner{
-		log:       log,
-		backend:   backend,
-		model:     model,
-		mode:      mode,
-		cancel:    runCancel,
-		done:      runDone,
-		transport: transport,
-		client:    client,
-		proxy:     proxy,
-		proxyLog:  proxyLog,
+		log:            log,
+		backend:        backend,
+		model:          model,
+		mode:           mode,
+		cancel:         runCancel,
+		done:           runDone,
+		transport:      transport,
+		client:         client,
+		proxy:          proxy,
+		proxyLog:       proxyLog,
+		openAIRecorder: openAIRecorder,
 	}
 
 	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
@@ -236,6 +241,8 @@ func (r *runner) terminate() {
 	if err := r.proxyLog.Close(); err != nil {
 		r.log.Warnf("Unable to close reverse proxy log writer: %v", err)
 	}
+
+	r.openAIRecorder.RemoveModel(r.model)
 }
 
 // ServeHTTP implements net/http.Handler.ServeHTTP. It forwards requests to the

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -40,6 +40,8 @@ type Scheduler struct {
 	router *http.ServeMux
 	// tracker is the metrics tracker.
 	tracker *metrics.Tracker
+	// openAIRecorder is used to record OpenAI API inference requests and responses.
+	openAIRecorder *metrics.OpenAIRecorder
 	// lock is used to synchronize access to the scheduler's router.
 	lock sync.Mutex
 }
@@ -64,6 +66,7 @@ func NewScheduler(
 		loader:         newLoader(log, backends, modelManager),
 		router:         http.NewServeMux(),
 		tracker:        tracker,
+		openAIRecorder: metrics.NewOpenAIRecorder(log.WithField("component", "openai-recorder")),
 	}
 
 	// Register routes.
@@ -115,6 +118,7 @@ func (s *Scheduler) routeHandlers(allowedOrigins []string) map[string]http.Handl
 	m["POST "+inference.InferencePrefix+"/unload"] = s.Unload
 	m["POST "+inference.InferencePrefix+"/{backend}/_configure"] = s.Configure
 	m["POST "+inference.InferencePrefix+"/_configure"] = s.Configure
+	m["GET "+inference.InferencePrefix+"/requests"] = s.openAIRecorder.GetRecordsByModelHandler()
 	return m
 }
 
@@ -231,6 +235,14 @@ func (s *Scheduler) handleOpenAIInference(w http.ResponseWriter, r *http.Request
 		// Non-blocking call to track the model usage.
 		s.tracker.TrackModel(model)
 	}
+
+	// Record the request in the OpenAI recorder.
+	recordID := s.openAIRecorder.RecordRequest(request.Model, r, body)
+	w = s.openAIRecorder.NewResponseRecorder(w)
+	defer func() {
+		// Record the response in the OpenAI recorder.
+		s.openAIRecorder.RecordResponse(recordID, request.Model, w)
+	}()
 
 	// Request a runner to execute the request and defer its release.
 	runner, err := s.loader.load(r.Context(), backend.Name(), request.Model, backendMode)

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -56,6 +56,8 @@ func NewScheduler(
 	allowedOrigins []string,
 	tracker *metrics.Tracker,
 ) *Scheduler {
+	openAIRecorder := metrics.NewOpenAIRecorder(log.WithField("component", "openai-recorder"))
+
 	// Create the scheduler.
 	s := &Scheduler{
 		log:            log,
@@ -63,10 +65,10 @@ func NewScheduler(
 		defaultBackend: defaultBackend,
 		modelManager:   modelManager,
 		installer:      newInstaller(log, backends, httpClient),
-		loader:         newLoader(log, backends, modelManager),
+		loader:         newLoader(log, backends, modelManager, openAIRecorder),
 		router:         http.NewServeMux(),
 		tracker:        tracker,
-		openAIRecorder: metrics.NewOpenAIRecorder(log.WithField("component", "openai-recorder")),
+		openAIRecorder: openAIRecorder,
 	}
 
 	// Register routes.

--- a/pkg/metrics/openai_recorder.go
+++ b/pkg/metrics/openai_recorder.go
@@ -38,6 +38,7 @@ type RequestResponsePair struct {
 	Response   string    `json:"response"`
 	Timestamp  time.Time `json:"timestamp"`
 	StatusCode int       `json:"status_code"`
+	UserAgent  string    `json:"user_agent,omitempty"`
 }
 
 type ModelData struct {
@@ -90,6 +91,7 @@ func (r *OpenAIRecorder) RecordRequest(model string, req *http.Request, body []b
 		URL:       req.URL.Path,
 		Request:   string(body),
 		Timestamp: time.Now(),
+		UserAgent: req.UserAgent(),
 	}
 
 	if r.records[model] == nil {

--- a/pkg/metrics/openai_recorder.go
+++ b/pkg/metrics/openai_recorder.go
@@ -226,3 +226,15 @@ func (r *OpenAIRecorder) GetRecordsByModel(model string) []*RequestResponsePair 
 
 	return nil
 }
+
+func (r *OpenAIRecorder) RemoveModel(model string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if _, exists := r.records[model]; exists {
+		delete(r.records, model)
+		r.log.Infof("Removed records for model: %s", model)
+	} else {
+		r.log.Warnf("No records found for model: %s", model)
+	}
+}

--- a/pkg/metrics/openai_recorder.go
+++ b/pkg/metrics/openai_recorder.go
@@ -1,0 +1,228 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/model-runner/pkg/logging"
+)
+
+type responseRecorder struct {
+	http.ResponseWriter
+	body       *bytes.Buffer
+	statusCode int
+}
+
+func (rr *responseRecorder) Write(b []byte) (int, error) {
+	rr.body.Write(b)
+	return rr.ResponseWriter.Write(b)
+}
+
+func (rr *responseRecorder) WriteHeader(statusCode int) {
+	rr.statusCode = statusCode
+	rr.ResponseWriter.WriteHeader(statusCode)
+}
+
+type RequestResponsePair struct {
+	ID         string    `json:"id"`
+	Model      string    `json:"model"`
+	Method     string    `json:"method"`
+	URL        string    `json:"url"`
+	Request    string    `json:"request"`
+	Response   string    `json:"response"`
+	Timestamp  time.Time `json:"timestamp"`
+	StatusCode int       `json:"status_code"`
+}
+
+type OpenAIRecorder struct {
+	log     logging.Logger
+	records map[string][]*RequestResponsePair
+	m       sync.RWMutex
+}
+
+func NewOpenAIRecorder(log logging.Logger) *OpenAIRecorder {
+	return &OpenAIRecorder{
+		log:     log,
+		records: make(map[string][]*RequestResponsePair),
+	}
+}
+
+func (r *OpenAIRecorder) RecordRequest(model string, req *http.Request, body []byte) string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	recordID := fmt.Sprintf("%s_%d", model, time.Now().UnixNano())
+
+	record := &RequestResponsePair{
+		ID:        recordID,
+		Model:     model,
+		Method:    req.Method,
+		URL:       req.URL.Path,
+		Request:   string(body),
+		Timestamp: time.Now(),
+	}
+
+	if r.records[model] == nil {
+		r.records[model] = make([]*RequestResponsePair, 0, 10)
+	}
+
+	r.records[model] = append(r.records[model], record)
+
+	if len(r.records[model]) > 10 {
+		r.records[model] = r.records[model][1:]
+	}
+
+	return recordID
+}
+
+func (r *OpenAIRecorder) NewResponseRecorder(w http.ResponseWriter) http.ResponseWriter {
+	rc := &responseRecorder{
+		ResponseWriter: w,
+		body:           &bytes.Buffer{},
+		statusCode:     http.StatusOK,
+	}
+	return rc
+}
+
+func (r *OpenAIRecorder) RecordResponse(id, model string, rw http.ResponseWriter) {
+	rr := rw.(*responseRecorder)
+
+	responseBody := rr.body.String()
+	statusCode := rr.statusCode
+
+	var response string
+	if strings.Contains(responseBody, "data: ") {
+		response = r.convertStreamingResponse(responseBody)
+	} else {
+		response = responseBody
+	}
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if modelRecords, exists := r.records[model]; exists {
+		for _, record := range modelRecords {
+			if record.ID == id {
+				record.Response = response
+				record.StatusCode = statusCode
+				return
+			}
+		}
+		r.log.Errorf("Matching request (id=%s) not found for model %s - %d\n%s", id, model, statusCode, response)
+	} else {
+		r.log.Errorf("Model %s not found in records - %d\n%s", model, statusCode, response)
+	}
+}
+
+func (r *OpenAIRecorder) convertStreamingResponse(streamingBody string) string {
+	lines := strings.Split(streamingBody, "\n")
+	var contentBuilder strings.Builder
+	var lastChunk map[string]interface{}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+
+			var chunk map[string]interface{}
+			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+				continue
+			}
+
+			lastChunk = chunk
+
+			if choices, ok := chunk["choices"].([]interface{}); ok && len(choices) > 0 {
+				if choice, ok := choices[0].(map[string]interface{}); ok {
+					if delta, ok := choice["delta"].(map[string]interface{}); ok {
+						if content, ok := delta["content"].(string); ok {
+							contentBuilder.WriteString(content)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if lastChunk == nil {
+		return streamingBody
+	}
+
+	finalResponse := make(map[string]interface{})
+
+	for key, value := range lastChunk {
+		finalResponse[key] = value
+	}
+
+	if choices, ok := finalResponse["choices"].([]interface{}); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]interface{}); ok {
+			choice["message"] = map[string]interface{}{
+				"role":    "assistant",
+				"content": contentBuilder.String(),
+			}
+			delete(choice, "delta")
+
+			if _, ok := choice["finish_reason"]; !ok {
+				choice["finish_reason"] = "stop"
+			}
+		}
+	}
+
+	finalResponse["object"] = "chat.completion"
+
+	jsonResult, err := json.Marshal(finalResponse)
+	if err != nil {
+		return streamingBody
+	}
+
+	return string(jsonResult)
+}
+
+func (r *OpenAIRecorder) GetRecordsByModelHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		model := req.URL.Query().Get("model")
+
+		if model == "" {
+			http.Error(w, "A 'model' query parameter is required", http.StatusBadRequest)
+		} else {
+			// Retrieve records for the specified model.
+			records := r.GetRecordsByModel(model)
+			if records == nil {
+				// No records found for the specified model.
+				http.Error(w, fmt.Sprintf("No records found for model '%s'", model), http.StatusNotFound)
+				return
+			}
+
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"model":   model,
+				"records": records,
+				"count":   len(records),
+			}); err != nil {
+				http.Error(w, fmt.Sprintf("Failed to encode records for model '%s': %v", model, err),
+					http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+}
+
+func (r *OpenAIRecorder) GetRecordsByModel(model string) []*RequestResponsePair {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	if modelRecords, exists := r.records[model]; exists {
+		result := make([]*RequestResponsePair, len(modelRecords))
+		copy(result, modelRecords)
+		return result
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds recording functionality for OpenAI inference requests and responses:
- record last 10 request/response pairs per model
- convert streaming responses to single JSON format
- add `GET /engines/requests?model=<model>` endpoint

Necessary work left to be done:
- ~remove records on model eviction~ (2nd commit)
- ~include the configured context size for the model~ (3rd commit)

```
$ MODEL_RUNNER_PORT=8080 make run # in a separate terminal

$ curl http://localhost:8080/engines/v1/chat/completions -X POST -H "Content-Type: application/json" -d '{
   "model": "ai/smollm2",
   "messages": [
     {"role": "user", "content": "Capital of Romania?"}
   ]
 }'
{"choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"Romania's capital city is Bucharest."}}],"created":1750775388,"model":"ai/smollm2","system_fingerprint":"b1-1e8659e","object":"chat.completion","usage":{"completion_tokens":10,"prompt_tokens":33,"total_tokens":43},"id":"chatcmpl-T9Pa73gpAAAcgXp2EzckiZ0fTjUJtEIk","timings":{"prompt_n":33,"prompt_ms":34.326,"prompt_per_token_ms":1.040181818181818,"prompt_per_second":961.3703897919944,"predicted_n":10,"predicted_ms":59.546,"predicted_per_token_ms":5.9546,"predicted_per_second":167.937392939912}}

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run ai/smollm2 hi
Hello! How can I help you today?

$ curl -s http://localhost:8080/engines/requests\?model\=ai/smollm2 | jq .
{
  "count": 2,
  "model": "ai/smollm2",
  "records": [
    {
      "id": "ai/smollm2_1750775387439166000",
      "model": "ai/smollm2",
      "method": "POST",
      "url": "/engines/v1/chat/completions",
      "request": "{\n    \"model\": \"ai/smollm2\",\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Capital of Romania?\"}\n    ]\n  }",
      "response": "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Romania's capital city is Bucharest.\"}}],\"created\":1750775388,\"model\":\"ai/smollm2\",\"system_fingerprint\":\"b1-1e8659e\",\"object\":\"chat.completion\",\"usage\":{\"completion_tokens\":10,\"prompt_tokens\":33,\"total_tokens\":43},\"id\":\"chatcmpl-T9Pa73gpAAAcgXp2EzckiZ0fTjUJtEIk\",\"timings\":{\"prompt_n\":33,\"prompt_ms\":34.326,\"prompt_per_token_ms\":1.040181818181818,\"prompt_per_second\":961.3703897919944,\"predicted_n\":10,\"predicted_ms\":59.546,\"predicted_per_token_ms\":5.9546,\"predicted_per_second\":167.937392939912}}",
      "timestamp": "2025-06-24T17:29:47.43917+03:00",
      "status_code": 200
    },
    {
      "id": "ai/smollm2_1750775394431273000",
      "model": "ai/smollm2",
      "method": "POST",
      "url": "/engines/v1/chat/completions",
      "request": "{\"model\":\"ai/smollm2\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"stream\":true}",
      "response": "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"content\":\"Hello! How can I help you today?\",\"role\":\"assistant\"}}],\"created\":1750775394,\"id\":\"chatcmpl-xJpM5U2j8AtQaHphIMXkRC6EaFp7dDdl\",\"model\":\"ai/smollm2\",\"object\":\"chat.completion\",\"system_fingerprint\":\"b1-1e8659e\",\"timings\":{\"predicted_ms\":57.182,\"predicted_n\":10,\"predicted_per_second\":174.88020705816513,\"predicted_per_token_ms\":5.7182,\"prompt_ms\":46.706,\"prompt_n\":7,\"prompt_per_second\":149.87367790005567,\"prompt_per_token_ms\":6.672285714285715},\"usage\":{\"completion_tokens\":10,\"prompt_tokens\":30,\"total_tokens\":40}}",
      "timestamp": "2025-06-24T17:29:54.431274+03:00",
      "status_code": 200
    }
  ]
}
```

With the backend configuration included (the 3rd commit):

```
$ MODEL_RUNNER_PORT=8080 make run # in a separate terminal

$ cat dc.yaml
services:
  model1:
    provider:
      type: model
      options:
        model: ai/smollm2
        context-size: 8192
        runtime-flags: "--no-prefill-assistant"

$ MODEL_RUNNER_HOST=http://localhost:8080 docker compose -f dc.yaml --progress plain up

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run ai/smollm2 hi
Hi there, I'm SmolLM. I'm here to help with any questions or issues related to Natural Language Processing (NLP) or machine learning. What can I help you with today?

$ curl -s http://localhost:8080/engines/requests\?model\=ai/smollm2 | jq .
{
  "config": {
    "context_size": 8192,
    "flags": [
      "--no-prefill-assistant"
    ]
  },
  "count": 1,
  "model": "ai/smollm2",
  "records": [
    {
      "id": "ai/smollm2_1750852528701065000",
      "model": "ai/smollm2",
      "method": "POST",
      "url": "/engines/v1/chat/completions",
      "request": "{\"model\":\"ai/smollm2\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"stream\":true}",
      "response": "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"content\":\"Hi there, I'm SmolLM. I'm here to help with any questions or issues related to Natural Language Processing (NLP) or machine learning. What can I help you with today?\",\"role\":\"assistant\"}}],\"created\":1750852530,\"id\":\"chatcmpl-298syWcQ7fC0v02baVJ2fyFXO5UtI9Fg\",\"model\":\"ai/smollm2\",\"object\":\"chat.completion\",\"system_fingerprint\":\"b1-1e8659e\",\"timings\":{\"predicted_ms\":322.368,\"predicted_n\":41,\"predicted_per_second\":127.18383958705579,\"predicted_per_token_ms\":7.862634146341463,\"prompt_ms\":33.975,\"prompt_n\":30,\"prompt_per_second\":883.0022075055188,\"prompt_per_token_ms\":1.1325},\"usage\":{\"completion_tokens\":41,\"prompt_tokens\":30,\"total_tokens\":71}}",
      "timestamp": "2025-06-25T14:55:28.701065+03:00",
      "status_code": 200
    }
  ]
}
```

With the User-Agent captured in records if it's not empty (the 4th commit):
```
$ MODEL_RUNNER_PORT=8080 make run # in a separate terminal

$ # no User-Agent for the following curl:
$ curl -A "" http://localhost:8080/engines/v1/chat/completions ...
...

$ curl http://localhost:8080/engines/v1/chat/completions ...
...

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run ai/smollm2 hi
Hello! How can I help you today?

$ curl -s http://localhost:8080/engines/requests\?model\=ai/smollm2 | jq '.records[] | {request: .request, user_agent: .user_agent}'
{
  "request": "{\n    \"model\": \"ai/smollm2\",\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Capital of Romania?\"}\n    ]\n  }",
  "user_agent": null
}
{
  "request": "{\n    \"model\": \"ai/smollm2\",\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Capital of Romania?\"}\n    ]\n  }",
  "user_agent": "curl/8.7.1"
}
{
  "request": "{\"model\":\"ai/smollm2\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"stream\":true}",
  "user_agent": "docker-model-cli/dev"
}