### PR TITLE
Log Hub response in llama-server auto update failure path

### DIFF
--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -87,6 +87,7 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 		latest = response.Digest
 	}
 	if latest == "" {
+		log.Warnf("could not fing the %s tag, hub response: %s", desiredTag, body)
 		return fmt.Errorf("could not find the %s tag", desiredTag)
 	}
 


### PR DESCRIPTION
In case Hub responds with an unexpected tag (or other unexpected content) when querying for the desired llama-server tag during the auto update process, we return an ok error, but extra info would be nice for debugging. So add a log entry in case the Hub response does not contain the desired tag.