### PR TITLE
Respect context size from model config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
+	github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0
 	github.com/google/go-containerregistry v0.20.3
 	github.com/jaypipes/ghw v0.16.0
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250618082521-fb5c8332c857
+	github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
 	github.com/google/go-containerregistry v0.20.3
 	github.com/jaypipes/ghw v0.16.0
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
-github.com/docker/model-distribution v0.0.0-20250618082521-fb5c8332c857 h1:2IvvpdPZvpNn06+RUh5DC5O64dnrKjdsBKCMrzR5QTk=
-github.com/docker/model-distribution v0.0.0-20250618082521-fb5c8332c857/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
-github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5 h1:4qs7OwrJJQE1de5kbHg83gm5rmCRQzAwAp8gG/3cLY8=
-github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0 h1:bve4JZI06Admw+NewtPfrpJXsvRnGKTQvBOEICNC1C0=
+github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZ
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/model-distribution v0.0.0-20250618082521-fb5c8332c857 h1:2IvvpdPZvpNn06+RUh5DC5O64dnrKjdsBKCMrzR5QTk=
 github.com/docker/model-distribution v0.0.0-20250618082521-fb5c8332c857/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5 h1:4qs7OwrJJQE1de5kbHg83gm5rmCRQzAwAp8gG/3cLY8=
+github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -41,12 +41,12 @@ func (c *Config) GetArgs(model types.Model, socket string, mode inference.Backen
 
 	modelPath, err := model.GGUFPath()
 	if err != nil {
-		return nil, fmt.Errorf("get gguf path: %v", err)
+		return nil, fmt.Errorf("get gguf path: %w", err)
 	}
 
 	modelCfg, err := model.Config()
 	if err != nil {
-		return nil, fmt.Errorf("get model config: %v", err)
+		return nil, fmt.Errorf("get model config: %w", err)
 	}
 
 	// Add model and socket arguments

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -65,7 +65,7 @@ func (c *Config) GetArgs(model types.Model, socket string, mode inference.Backen
 	// Add arguments from backend config
 	if config != nil {
 		if config.ContextSize > 0 && !containsArg(args, "--ctx-size") {
-			args = append(args, "--ctx-size", fmt.Sprintf("%d", config.ContextSize))
+			args = append(args, "--ctx-size", strconv.FormatInt(config.ContextSize, 10))
 		}
 		args = append(args, config.RuntimeFlags...)
 	}

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -1,9 +1,11 @@
 package llamacpp
 
 import (
+	"fmt"
 	"runtime"
 	"strconv"
 
+	"github.com/docker/model-distribution/types"
 	"github.com/docker/model-runner/pkg/inference"
 )
 
@@ -33,9 +35,19 @@ func NewDefaultLlamaCppConfig() *Config {
 }
 
 // GetArgs implements BackendConfig.GetArgs.
-func (c *Config) GetArgs(modelPath, socket string, mode inference.BackendMode) []string {
+func (c *Config) GetArgs(model types.Model, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
 	// Start with the arguments from LlamaCppConfig
 	args := append([]string{}, c.Args...)
+
+	modelPath, err := model.GGUFPath()
+	if err != nil {
+		return nil, fmt.Errorf("get gguf path: %v", err)
+	}
+
+	modelCfg, err := model.Config()
+	if err != nil {
+		return nil, fmt.Errorf("get model config: %v", err)
+	}
 
 	// Add model and socket arguments
 	args = append(args, "--model", modelPath, "--host", socket)
@@ -45,7 +57,20 @@ func (c *Config) GetArgs(modelPath, socket string, mode inference.BackendMode) [
 		args = append(args, "--embeddings")
 	}
 
-	return args
+	// Add arguments from model config
+	if modelCfg.ContextSize != nil {
+		args = append(args, "--ctx-size", strconv.FormatUint(*modelCfg.ContextSize, 10))
+	}
+
+	// Add arguments from backend config
+	if config != nil {
+		if config.ContextSize > 0 && !containsArg(args, "--ctx-size") {
+			args = append(args, "--ctx-size", fmt.Sprintf("%d", config.ContextSize))
+		}
+		args = append(args, config.RuntimeFlags...)
+	}
+
+	return args, nil
 }
 
 // containsArg checks if the given argument is already in the args slice.

--- a/pkg/inference/config/config.go
+++ b/pkg/inference/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/docker/model-distribution/types"
 	"github.com/docker/model-runner/pkg/inference"
 )
 
@@ -11,5 +12,5 @@ type BackendConfig interface {
 	// GetArgs returns the command-line arguments for the backend.
 	// It takes the model path, socket, and mode as input and returns
 	// the appropriate arguments for the backend.
-	GetArgs(modelPath, socket string, mode inference.BackendMode) []string
+	GetArgs(model types.Model, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error)
 }


### PR DESCRIPTION
* Respects context-size defined in the model artifact (see https://github.com/docker/model-distribution/pull/92). This takes precedence over backend config.
* Small refactoring of arg generation and testing