### PR TITLE
Allow configuration through argument list (in addition to string)

### DIFF
--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -30,8 +30,8 @@ func (m BackendMode) String() string {
 }
 
 type BackendConfiguration struct {
-	ContextSize int64    `json:"context_size,omitempty"`
-	RawFlags    []string `json:"flags,omitempty"`
+	ContextSize  int64    `json:"context-size,omitempty"`
+	RuntimeFlags []string `json:"runtime-flags,omitempty"`
 }
 
 // Backend is the interface implemented by inference engine backends. Backend

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -144,7 +144,7 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 		if config.ContextSize >= 0 {
 			args = append(args, "--ctx-size", strconv.Itoa(int(config.ContextSize)))
 		}
-		args = append(args, config.RawFlags...)
+		args = append(args, config.RuntimeFlags...)
 	}
 
 	l.log.Infof("llamaCppArgs: %v", args)

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -86,7 +86,8 @@ type UnloadResponse struct {
 
 // ConfigureRequest specifies per-model runtime configuration options.
 type ConfigureRequest struct {
-	Model           string `json:"model"`
-	ContextSize     int64  `json:"context-size,omitempty"`
-	RawRuntimeFlags string `json:"raw-runtime-flags,omitempty"`
+	Model           string   `json:"model"`
+	ContextSize     int64    `json:"context-size,omitempty"`
+	RuntimeFlags    []string `json:"runtime-flags,omitempty"`
+	RawRuntimeFlags string   `json:"raw-runtime-flags,omitempty"`
 }


### PR DESCRIPTION
We'll allow runtime flag configuration via either an explicit, pre-parsed list (via `runtime-flags`) or via a string (via `raw-runtime-flags`).  This will support the Compose `models:` spec as well as the Compose `model` provider, respectively.