### PR TITLE
Implement Flusher interface for responseRecorder

### DIFF
--- a/pkg/metrics/openai_recorder.go
+++ b/pkg/metrics/openai_recorder.go
@@ -29,6 +29,12 @@ func (rr *responseRecorder) WriteHeader(statusCode int) {
 	rr.ResponseWriter.WriteHeader(statusCode)
 }
 
+func (rr *responseRecorder) Flush() {
+	if flusher, ok := rr.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 type RequestResponsePair struct {
 	ID         string    `json:"id"`
 	Model      string    `json:"model"`


### PR DESCRIPTION
Implement `Flusher` interface for `responseRecorder`.
Without this, the streamed responses will be buffered and we don't need that.