### PR TITLE
runner: Do not allow CORS headers set by the inference engines

### DIFF
--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -118,6 +118,12 @@ func run(
 		r.URL.Path = trimRequestPathToOpenAIRoot(r.URL.Path)
 		r.URL.RawPath = trimRequestPathToOpenAIRoot(r.URL.RawPath)
 	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		// CORS headers are set by the CorsMiddleware from pkg/inference/cors.go,
+		// so we remove them here to avoid duplication and potential misconfiguration.
+		resp.Header.Del("Access-Control-Allow-Origin")
+		return nil
+	}
 	proxy.Transport = transport
 	proxyLog := log.Writer()
 	proxy.ErrorLog = logpkg.New(proxyLog, "", 0)


### PR DESCRIPTION
@ilopezluna noticed that the CORS headers are also set by the underlying inference engine.

Notice that the `Access-Control-Allow-Origin` header is set even if the origin is not part of the allowed origins list, and duplicated if the origin is part of the allowed origins list.

Before:
```
$ DMR_ORIGINS=http://localhost:5555 MODEL_RUNNER_PORT=8080 make run
$ curl -X POST  -i 'http://localhost:8080/engines/v1/chat/completions' \
  -H 'Origin: http://localhost:5551' \
  --data-raw '{"model":"ai/smollm2","messages":[{"role":"user","content":"hello"}]}'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://localhost:5551
Content-Length: 644
Content-Type: application/json; charset=utf-8
Server: dd-llama.cpp
Date: Mon, 14 Jul 2025 11:19:37 GMT
$ curl -X POST  -i 'http://localhost:8080/engines/v1/chat/completions' \
  -H 'Origin: http://localhost:5555' \
  --data-raw '{"model":"ai/smollm2","messages":[{"role":"user","content":"hello"}]}'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://localhost:5555
Access-Control-Allow-Origin: http://localhost:5555
Content-Length: 658
Content-Type: application/json; charset=utf-8
Server: dd-llama.cpp
Date: Mon, 14 Jul 2025 11:19:40 GMT
```

Now:
```
$ DMR_ORIGINS=http://localhost:5555 MODEL_RUNNER_PORT=8080 make run
$ curl -X POST  -i 'http://localhost:8080/engines/v1/chat/completions' \
  -H 'Origin: http://localhost:5551' \
  --data-raw '{"model":"ai/smollm2","messages":[{"role":"user","content":"hello"}]}'
HTTP/1.1 200 OK
Content-Length: 774
Content-Type: application/json; charset=utf-8
Server: dd-llama.cpp
Date: Mon, 14 Jul 2025 11:17:10 GMT
$ curl -X POST  -i 'http://localhost:8080/engines/v1/chat/completions' \
  -H 'Origin: http://localhost:5555' \
  --data-raw '{"model":"ai/smollm2","messages":[{"role":"user","content":"hello"}]}'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://localhost:5555
Content-Length: 585
Content-Type: application/json; charset=utf-8
Server: dd-llama.cpp
Date: Mon, 14 Jul 2025 11:17:15 GMT
```