### PR TITLE
Use more aggressive server shutdown and resequence termination

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,13 +165,13 @@ func main() {
 		}
 	case <-ctx.Done():
 		log.Infoln("Shutdown signal received")
+		log.Infoln("Shutting down the server")
+		if err := server.Close(); err != nil {
+			log.Errorf("Server shutdown error: %v", err)
+		}
 		log.Infoln("Waiting for the scheduler to stop")
 		if err := <-schedulerErrors; err != nil {
 			log.Errorf("Scheduler error: %v", err)
-		}
-		log.Infoln("Shutting down the server")
-		if err := server.Shutdown(ctx); err != nil {
-			log.Errorf("Server shutdown error: %v", err)
 		}
 	}
 	log.Infoln("Docker Model Runner stopped")


### PR DESCRIPTION
Using `Shutdown` with an already cancelled context will cause the method to return almost immediately, with only idle connections being closed. More problematically, it can't close active connections, which can remain in flight indefinitely. At the moment, these active connections (and their associated contexts) can cause `loader.load()` to block `loader.run()` from exiting, especially if a backend is misbehaving, which can cause shutdown to halt waiting on the request. Even if a backend isn't misbehaving, an inference request can take many seconds. The best solution would be to make `loader.load()` unblock if the context passed to `loader.run()` is cancelled, but this is fairly complicated to implemented. The easier solution for now is just to use a hard server `Close()` to cancel inflight requests (and their contexts) and then wait for scheduler shutdown. This is what we do in Docker Desktop.