### PR TITLE
models: avoid error response when request is canceled/timed out

### DIFF
--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -163,6 +163,10 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 	// Pull the model. In the future, we may support additional operations here
 	// besides pulling (such as model building).
 	if err := m.PullModel(request.From, r, w); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			m.log.Infof("Request canceled/timed out while pulling model %q", request.From)
+			return
+		}
 		if errors.Is(err, registry.ErrInvalidReference) {
 			m.log.Warnf("Invalid model reference %q: %v", request.From, err)
 			http.Error(w, "Invalid model reference", http.StatusBadRequest)


### PR DESCRIPTION
Prevents "superfluous response.WriteHeader" errors by checking if the request context was canceled or timed out before attempting to call http.Error().

Without this patch you see the following error when you cancel a pull - `docker model pull ai/llama3.3`:
```
http: superfluous response.WriteHeader call from github.com/docker/model-runner/pkg/inference/models.(*Manager).handleCreateModel (manager.go:181)
```