### PR TITLE
Fix the broken link to the Helm chart README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Check [METRICS.md](./METRICS.md) for more details.
 ##  Kubernetes
 
 Experimental support for running in Kubernetes is available
-in the form of [a Helm chart and static YAML](charts/docker-model-runner/README).
+in the form of [a Helm chart and static YAML](charts/docker-model-runner/README.md).
 
 If you are interested in a specific Kubernetes use-case, please start a
 discussion on the issue tracker.


### PR DESCRIPTION
This fixes the broken link to the Helm chart documentation.

<img width="832" height="417" alt="Screenshot 2025-07-30 at 10 11 10" src="https://github.com/user-attachments/assets/6a73eef2-bb76-4cc3-8a7c-5aeb474b581b" />
