### PR TITLE
inference: Ignore parse errors when estimating model memory

### DIFF
--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -2,6 +2,7 @@ package inference
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
 
@@ -15,6 +16,10 @@ const (
 	// BackendModeEmbedding indicates that the backend should run in embedding
 	// mode.
 	BackendModeEmbedding
+)
+
+var (
+	ErrGGUFParse = errors.New("failed to parse GGUF file")
 )
 
 // String implements Stringer.String for BackendMode.

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -234,7 +234,8 @@ func (l *llamaCpp) GetRequiredMemoryForModel(model string, config *inference.Bac
 	}
 	mdlGguf, err := parser.ParseGGUFFile(mdlPath)
 	if err != nil {
-		return nil, fmt.Errorf("parsing gguf(%s): %w", mdlPath, err)
+		l.log.Warnf("Failed to parse gguf(%s): %s", mdlPath, err)
+		return nil, inference.ErrGGUFParse
 	}
 	mdlConfig, err := mdl.Config()
 	if err != nil {


### PR DESCRIPTION
We will run into cases where our model runner is ahead of gguf-parser-go. In such cases we may want to load a model that will cause the model parse to fail. So, for now, in such cases ignore model parsing errors, and assume it takes no resources. In the future we should come up with a cleaner way of dealing with this (e.g. ship a model memory estimator along with the llama-server).