### PR TITLE
Support GGUF shards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250724114133-a11d745e582c
+	github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be
 	github.com/elastic/go-sysinfo v1.15.3
 	github.com/google/go-containerregistry v0.20.3
 	github.com/gpustack/gguf-parser-go v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.7
 require (
 	github.com/containerd/containerd/v2 v2.0.4
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be
+	github.com/docker/model-distribution v0.0.0-20250822172258-8fe9daa4a4da
 	github.com/elastic/go-sysinfo v1.15.3
 	github.com/google/go-containerregistry v0.20.3
 	github.com/gpustack/gguf-parser-go v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
-github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be h1:S6v82p2JPC4HwaZcnM5TmOjMQktIqu7HCvJMbkDIS+U=
-github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250822172258-8fe9daa4a4da h1:ml99WBfcLnsy1frXQR4X+5WAC0DoGtwZyGoU/xBsDQM=
+github.com/docker/model-distribution v0.0.0-20250822172258-8fe9daa4a4da/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/elastic/go-sysinfo v1.15.3 h1:W+RnmhKFkqPTCRoFq2VCTmsT4p/fwpo+3gKNQsn1XU0=
 github.com/elastic/go-sysinfo v1.15.3/go.mod h1:K/cNrqYTDrSoMh2oDkYEMS2+a72GRxMvNP+GC+vRIlo=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
-github.com/docker/model-distribution v0.0.0-20250724114133-a11d745e582c h1:w9MekYamXmWLe9ZWXWgNXJ7BLDDemXwB8WcF7wzHF5Q=
-github.com/docker/model-distribution v0.0.0-20250724114133-a11d745e582c/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be h1:S6v82p2JPC4HwaZcnM5TmOjMQktIqu7HCvJMbkDIS+U=
+github.com/docker/model-distribution v0.0.0-20250822151640-fca29728e7be/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/elastic/go-sysinfo v1.15.3 h1:W+RnmhKFkqPTCRoFq2VCTmsT4p/fwpo+3gKNQsn1XU0=
 github.com/elastic/go-sysinfo v1.15.3/go.mod h1:K/cNrqYTDrSoMh2oDkYEMS2+a72GRxMvNP+GC+vRIlo=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -62,8 +62,7 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	}
 
 	// Add arguments for Multimodal projector
-	mmprojPath := bundle.MMPROJPath()
-	if path := mmprojPath; path != "" {
+	if path := bundle.MMPROJPath(); path != "" {
 		args = append(args, "--mmproj", path)
 	}
 

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/docker/model-distribution/types"
+
 	"github.com/docker/model-runner/pkg/inference"
 )
 
@@ -35,18 +36,13 @@ func NewDefaultLlamaCppConfig() *Config {
 }
 
 // GetArgs implements BackendConfig.GetArgs.
-func (c *Config) GetArgs(model types.Model, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
+func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
 	// Start with the arguments from LlamaCppConfig
 	args := append([]string{}, c.Args...)
 
-	modelPath, err := model.GGUFPath()
-	if err != nil {
-		return nil, fmt.Errorf("get gguf path: %w", err)
-	}
-
-	modelCfg, err := model.Config()
-	if err != nil {
-		return nil, fmt.Errorf("get model config: %w", err)
+	modelPath := bundle.GGUFPath()
+	if modelPath == "" {
+		return nil, fmt.Errorf("GGUF file required by llama.cpp backend")
 	}
 
 	// Add model and socket arguments
@@ -57,7 +53,8 @@ func (c *Config) GetArgs(model types.Model, socket string, mode inference.Backen
 		args = append(args, "--embeddings")
 	}
 
-	args = append(args, "--ctx-size", strconv.FormatUint(GetContextSize(&modelCfg, config), 10))
+	// Add context size from model config or backend config
+	args = append(args, "--ctx-size", strconv.FormatUint(GetContextSize(bundle.RuntimeConfig(), config), 10))
 
 	// Add arguments from backend config
 	if config != nil {
@@ -65,17 +62,17 @@ func (c *Config) GetArgs(model types.Model, socket string, mode inference.Backen
 	}
 
 	// Add arguments for Multimodal projector
-	path, err := model.MMPROJPath()
-	if path != "" && err == nil {
+	mmprojPath := bundle.MMPROJPath()
+	if path := mmprojPath; path != "" {
 		args = append(args, "--mmproj", path)
 	}
 
 	return args, nil
 }
 
-func GetContextSize(modelCfg *types.Config, backendCfg *inference.BackendConfiguration) uint64 {
+func GetContextSize(modelCfg types.Config, backendCfg *inference.BackendConfiguration) uint64 {
 	// Model config takes precedence
-	if modelCfg != nil && modelCfg.ContextSize != nil {
+	if modelCfg.ContextSize != nil {
 		return *modelCfg.ContextSize
 	}
 	// else use backend config

--- a/pkg/inference/config/config.go
+++ b/pkg/inference/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/docker/model-distribution/types"
+
 	"github.com/docker/model-runner/pkg/inference"
 )
 
@@ -12,5 +13,5 @@ type BackendConfig interface {
 	// GetArgs returns the command-line arguments for the backend.
 	// It takes the model path, socket, and mode as input and returns
 	// the appropriate arguments for the backend.
-	GetArgs(model types.Model, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error)
+	GetArgs(bundle types.ModelBundle, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error)
 }

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -15,10 +15,11 @@ import (
 	"github.com/docker/model-distribution/distribution"
 	"github.com/docker/model-distribution/registry"
 	"github.com/docker/model-distribution/types"
+	"github.com/sirupsen/logrus"
+
 	"github.com/docker/model-runner/pkg/diskusage"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/logging"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -571,17 +572,13 @@ func (m *Manager) GetModel(ref string) (types.Model, error) {
 	return model, err
 }
 
-// GetModelPath returns the path to a model's files.
-func (m *Manager) GetModelPath(ref string) (string, error) {
-	model, err := m.GetModel(ref)
+// GetBundle returns model bundle.
+func (m *Manager) GetBundle(ref string) (types.ModelBundle, error) {
+	bundle, err := m.distributionClient.GetBundle(ref)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("error while getting model bundle: %w", err)
 	}
-	path, err := model.GGUFPath()
-	if err != nil {
-		return "", fmt.Errorf("error while getting model path: %w", err)
-	}
-	return path, nil
+	return bundle, err
 }
 
 // PullModel pulls a model to local storage. Any error it returns is suitable


### PR DESCRIPTION
* `llama.cpp` backend supports models that are split across multiple GGUF shards.
* Executes from runtime bundle instead of pointing to raw blob paths from content store.
* See https://github.com/docker/model-distribution/pull/123 for details on model and bundle formats

** In draft until https://github.com/docker/model-distribution/pull/123 merges and we can repoint at main branch **