### PR TITLE
fix: move CORS middleware to top level to handle preflight requests

### DIFF
--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/inference/memory"
 	"github.com/docker/model-runner/pkg/logging"
+	"github.com/docker/model-runner/pkg/middleware"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -38,6 +39,9 @@ type Manager struct {
 	pullTokens chan struct{}
 	// router is the HTTP request router.
 	router *http.ServeMux
+	// httpHandler is the HTTP request handler, which wraps router with
+	// the server-level middleware.
+	httpHandler http.Handler
 	// distributionClient is the client for model distribution.
 	distributionClient *distribution.Client
 	// registryClient is the client for model registry.
@@ -95,9 +99,11 @@ func NewManager(log logging.Logger, c ClientConfig, allowedOrigins []string, mem
 		http.Error(w, "not found", http.StatusNotFound)
 	})
 
-	for route, handler := range m.routeHandlers(allowedOrigins) {
+	for route, handler := range m.routeHandlers() {
 		m.router.HandleFunc(route, handler)
 	}
+
+	m.RebuildRoutes(allowedOrigins)
 
 	// Populate the pull concurrency semaphore.
 	for i := 0; i < maximumConcurrentModelPulls; i++ {
@@ -111,19 +117,12 @@ func NewManager(log logging.Logger, c ClientConfig, allowedOrigins []string, mem
 func (m *Manager) RebuildRoutes(allowedOrigins []string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	// Clear existing routes and re-register them.
-	m.router = http.NewServeMux()
-	// Register routes.
-	m.router.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	})
-	for route, handler := range m.routeHandlers(allowedOrigins) {
-		m.router.HandleFunc(route, handler)
-	}
+	// Update handlers that depend on the allowed origins.
+	m.httpHandler = middleware.CorsMiddleware(allowedOrigins, m.router)
 }
 
-func (m *Manager) routeHandlers(allowedOrigins []string) map[string]http.HandlerFunc {
-	handlers := map[string]http.HandlerFunc{
+func (m *Manager) routeHandlers() map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
 		"POST " + inference.ModelsPrefix + "/create":                          m.handleCreateModel,
 		"POST " + inference.ModelsPrefix + "/load":                            m.handleLoadModel,
 		"GET " + inference.ModelsPrefix:                                       m.handleGetModels,
@@ -135,16 +134,10 @@ func (m *Manager) routeHandlers(allowedOrigins []string) map[string]http.Handler
 		"GET " + inference.InferencePrefix + "/v1/models":                     m.handleOpenAIGetModels,
 		"GET " + inference.InferencePrefix + "/v1/models/{name...}":           m.handleOpenAIGetModel,
 	}
-	for route, handler := range handlers {
-		if strings.HasPrefix(route, "GET ") {
-			handlers[route] = inference.CorsMiddleware(allowedOrigins, handler).ServeHTTP
-		}
-	}
-	return handlers
 }
 
 func (m *Manager) GetRoutes() []string {
-	routeHandlers := m.routeHandlers(nil)
+	routeHandlers := m.routeHandlers()
 	routes := make([]string, 0, len(routeHandlers))
 	for route := range routeHandlers {
 		routes = append(routes, route)
@@ -578,7 +571,7 @@ func (m *Manager) GetDiskUsage() (int64, error, int) {
 func (m *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	m.router.ServeHTTP(w, r)
+	m.httpHandler.ServeHTTP(w, r)
 }
 
 // IsModelInStore checks if a given model is in the local store.

--- a/pkg/inference/scheduling/scheduler_test.go
+++ b/pkg/inference/scheduling/scheduler_test.go
@@ -1,0 +1,58 @@
+package scheduling
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/model-runner/pkg/inference"
+	"github.com/sirupsen/logrus"
+)
+
+type systemMemoryInfo struct{}
+
+func (i systemMemoryInfo) HaveSufficientMemory(req inference.RequiredMemory) bool {
+	return true
+}
+
+func (i systemMemoryInfo) GetTotalMemory() inference.RequiredMemory {
+	return inference.RequiredMemory{}
+}
+
+func TestCors(t *testing.T) {
+	// Verify that preflight requests work against non-existing handlers or
+	// method-specific handlers that do not support OPTIONS
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "root",
+			path: "/",
+		},
+		{
+			name: "status",
+			path: "/status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			discard := logrus.New()
+			discard.SetOutput(io.Discard)
+			log := logrus.NewEntry(discard)
+			s := NewScheduler(log, nil, nil, nil, nil, []string{"*"}, nil, systemMemoryInfo{})
+			req := httptest.NewRequest(http.MethodOptions, "http://model-runner.docker.internal"+tt.path, nil)
+			req.Header.Set("Origin", "docker.com")
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Errorf("Expected status code 204 for OPTIONS request, got %d", w.Code)
+			}
+		})
+	}
+}

--- a/pkg/middleware/cors.go
+++ b/pkg/middleware/cors.go
@@ -1,4 +1,4 @@
-package inference
+package middleware
 
 import (
 	"net/http"
@@ -34,7 +34,7 @@ func CorsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
 			w.Header().Set("Access-Control-Allow-Headers", "*")
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 

--- a/pkg/middleware/cors_test.go
+++ b/pkg/middleware/cors_test.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCorsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		allowedOrigins []string
+		method         string
+		origin         string
+		wantStatus     int
+		wantHeaders    map[string]string
+	}{
+		{
+			name:           "AllowAll",
+			allowedOrigins: []string{"*"},
+			method:         "GET",
+			origin:         "http://example.com",
+			wantStatus:     http.StatusOK,
+			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": "http://example.com"},
+		},
+		{
+			name:           "AllowSpecificOrigin",
+			allowedOrigins: []string{"http://foo.com"},
+			method:         "GET",
+			origin:         "http://foo.com",
+			wantStatus:     http.StatusOK,
+			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": "http://foo.com"},
+		},
+		{
+			name:           "DisallowOrigin",
+			allowedOrigins: []string{"http://foo.com"},
+			method:         "GET",
+			origin:         "http://bar.com",
+			wantStatus:     http.StatusOK,
+			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+		{
+			name:           "OptionsRequest",
+			allowedOrigins: []string{"http://foo.com"},
+			method:         "OPTIONS",
+			origin:         "http://foo.com",
+			wantStatus:     http.StatusNoContent,
+			wantHeaders: map[string]string{
+				"Access-Control-Allow-Credentials": "true",
+				"Access-Control-Allow-Methods":     "GET, POST",
+				"Access-Control-Allow-Headers":     "*",
+			},
+		},
+		{
+			name:           "NoOriginHeader",
+			allowedOrigins: []string{"http://foo.com"},
+			method:         "GET",
+			origin:         "",
+			wantStatus:     http.StatusOK,
+			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+		{
+			name:           "DisableAllOrigins",
+			allowedOrigins: nil,
+			method:         "GET",
+			origin:         "http://foo.com",
+			wantStatus:     http.StatusOK,
+			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler := CorsMiddleware(tt.allowedOrigins, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := httptest.NewRequest(tt.method, "/", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, rec.Code)
+			}
+			for k, v := range tt.wantHeaders {
+				if got := rec.Header().Get(k); got != v {
+					t.Errorf("expected %s to be %q, got %q", k, v, got)
+				}
+			}
+		})
+	}
+}
+
+func TestOriginAllowed(t *testing.T) {
+	t.Parallel()
+	set := map[string]struct{}{
+		"http://foo.com": {},
+	}
+	if !originAllowed("http://foo.com", set) {
+		t.Errorf("expected originAllowed to return true")
+	}
+	if originAllowed("http://bar.com", set) {
+		t.Errorf("expected originAllowed to return false")
+	}
+}


### PR DESCRIPTION
Previously, CORS preflight requests were not working because the CORS
middleware was nested within the inference package. Moving it to a
dedicated middleware package at the top level ensures preflight
requests are properly handled before reaching route handlers.

- Move CORS implementation from pkg/inference to pkg/middleware
- Add comprehensive test coverage for CORS middleware
- Add unit tests for inference models manager and scheduler

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
