### PR TITLE
metrics: avoid an unnecessary request shallow copy

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,10 +26,9 @@ type TrackerRoundTripper struct {
 }
 
 func (h *TrackerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	clonedReq := req.Clone(req.Context())
-	ctx, cancel := context.WithTimeout(clonedReq.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
 	defer cancel()
-	clonedReq = clonedReq.WithContext(ctx)
+	clonedReq := req.Clone(ctx)
 	clonedReq.Header.Set("x-docker-model-runner", "true")
 	return h.Transport.RoundTrip(clonedReq)
 }


### PR DESCRIPTION
This code can be simplified a little bit to avoid the additional shallow copy performed by `WithContext`; a single `Clone` operation is sufficient.