### PR TITLE
Implement llama.cpp sandboxing for macOS and Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/tools v0.32.0 // indirect
 	gonum.org/v1/gonum v0.15.1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
@@ -69,3 +69,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )
+
+replace github.com/kolesnikovae/go-winjob => github.com/docker/go-winjob v0.0.0-20250829235554-57b487ebcbc5

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-containerregistry v0.20.3
 	github.com/gpustack/gguf-parser-go v0.14.1
 	github.com/jaypipes/ghw v0.16.0
+	github.com/kolesnikovae/go-winjob v1.0.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
+github.com/docker/go-winjob v0.0.0-20250829235554-57b487ebcbc5 h1:dxSFEb0EEmvceIawSFNDMrvKakRz2t+2WYpY3dFAT04=
+github.com/docker/go-winjob v0.0.0-20250829235554-57b487ebcbc5/go.mod h1:ICOGmIXdwhfid7rQP+tLvDJqVg0lHdEk3pI5nsapTtg=
 github.com/docker/model-distribution v0.0.0-20250822172258-8fe9daa4a4da h1:ml99WBfcLnsy1frXQR4X+5WAC0DoGtwZyGoU/xBsDQM=
 github.com/docker/model-distribution v0.0.0-20250822172258-8fe9daa4a4da/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/elastic/go-sysinfo v1.15.3 h1:W+RnmhKFkqPTCRoFq2VCTmsT4p/fwpo+3gKNQsn1XU0=
@@ -78,8 +80,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/kolesnikovae/go-winjob v1.0.0 h1:OKEtCHB3sYNAiqNwGDhf08Y6luM7C8mP+42rp1N6SeE=
-github.com/kolesnikovae/go-winjob v1.0.0/go.mod h1:k0joOLP3/NBrRmDQjPV2+oN1TPmEWt6arTNtFjVeQuM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -157,10 +157,9 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/kolesnikovae/go-winjob v1.0.0 h1:OKEtCHB3sYNAiqNwGDhf08Y6luM7C8mP+42rp1N6SeE=
+github.com/kolesnikovae/go-winjob v1.0.0/go.mod h1:k0joOLP3/NBrRmDQjPV2+oN1TPmEWt6arTNtFjVeQuM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -155,6 +157,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -158,7 +158,7 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 	tailBuf := tailbuffer.NewTailBuffer(1024)
 	serverLogStream := l.serverLog.Writer()
 	out := io.MultiWriter(serverLogStream, tailBuf)
-	llamaCppSandbox, err := sandbox.New(
+	llamaCppSandbox, err := sandbox.Create(
 		ctx,
 		sandbox.ConfigurationLlamaCpp,
 		func(command *exec.Cmd) {
@@ -357,7 +357,7 @@ func (l *llamaCpp) checkGPUSupport(ctx context.Context) bool {
 		binPath = l.updatedServerStoragePath
 	}
 	var output bytes.Buffer
-	llamaCppSandbox, err := sandbox.New(
+	llamaCppSandbox, err := sandbox.Create(
 		ctx,
 		sandbox.ConfigurationLlamaCpp,
 		func(command *exec.Cmd) {

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -1,0 +1,13 @@
+package sandbox
+
+import (
+	"os/exec"
+)
+
+// Sandbox encapsulates a single running sandboxed process.
+type Sandbox interface {
+	// Command returns the sandboxed process handle.
+	Command() *exec.Cmd
+	// Close closes the sandbox, terminating the process if it's still running.
+	Close() error
+}

--- a/pkg/sandbox/sandbox_darwin.go
+++ b/pkg/sandbox/sandbox_darwin.go
@@ -110,13 +110,13 @@ func (s *sandbox) Close() error {
 	return nil
 }
 
-// New creates a new sandbox containing a single process that has been started.
+// Create creates a sandbox containing a single process that has been started.
 // The ctx, name, and arg arguments correspond to their counterparts in
 // os/exec.CommandContext. The configuration argument specifies the sandbox
 // configuration, for which a pre-defined value should be used. The modifier
 // function allows for an optional callback (which may be nil) to configure the
 // command before it is started.
-func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
 	// Look up the user's home directory.
 	currentUser, err := user.Current()
 	if err != nil {
@@ -149,7 +149,7 @@ func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), na
 	// Start the process.
 	if err := command.Start(); err != nil {
 		cancel()
-		return nil, fmt.Errorf("unabled to start sandboxed process: %w", err)
+		return nil, fmt.Errorf("unable to start sandboxed process: %w", err)
 	}
 	return &sandbox{
 		cancel:  cancel,

--- a/pkg/sandbox/sandbox_darwin.go
+++ b/pkg/sandbox/sandbox_darwin.go
@@ -1,0 +1,111 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+)
+
+// LlamaCppTemplate is the sandbox template to use for llama.cpp processes.
+const LlamaCppTemplate = `(version 1)
+
+;;; Keep a default allow policy (because encoding things like DYLD support and
+;;; device access is quite difficult), but deny critical exploitation targets
+;;; (generally aligned with the App Sandbox entitlements that aren't on by
+;;; default). In theory we'll be subject to the Docker.app sandbox as well
+;;; (unless we're running standalone), but even Docker.app has a very privileged
+;;; sandbox, so we need additional constraints.
+;;;
+;;; Note: The following are known to be required at some level for llama.cpp
+;;; (though we could further experiment to deny certain sub-permissions):
+;;;   - authorization
+;;;   - darwin
+;;;   - iokit
+;;;   - mach
+;;;   - socket
+;;;   - syscall
+;;;   - process
+(allow default)
+
+;;; Deny network access, except for our IPC sockets.
+(deny network*)
+(allow network-bind network-inbound
+    (regex #"inference-runner-[0-9]+\.sock$"))
+
+;;; Deny access to the camera and microphone.
+(deny device*)
+
+;;; Deny access to NVRAM settings.
+(deny nvram*)
+
+;;; Deny access to system-level privileges.
+(deny system*)
+
+;;; Deny access to job creation.
+(deny job-creation)
+
+;;; Don't allow new executable code to be created in memory at runtime.
+(deny dynamic-code-generation)
+
+;;; Disable access to user preferences.
+(deny user-preference*)
+
+;;; Restrict file access.
+;;; NOTE: For some reason, the (home-subpath "...") predicate used in system
+;;; sandbox profiles doesn't work with sandbox-exec.
+;;; NOTE: We have to allow access to the working directory for standalone mode.
+;;; NOTE: For some reason (deny file-read*) really doesn't like to play nice
+;;; with llama.cpp, so for that reason we'll avoid a blanket ban and just ban
+;;; directories that might contain sensitive data.
+(deny file-map-executable)
+(deny file-write*)
+(deny file-read*
+    (subpath "/Applications")
+    (subpath "/private/etc")
+	(subpath "/Library")
+	(subpath "/Users")
+	(subpath "/Volumes"))
+(allow file-read* file-map-executable
+    (subpath "/usr")
+    (subpath "/System")
+    (subpath "/Applications/Docker.app/Contents/Resources/model-runner")
+    (subpath "[HOMEDIR]/.docker/bin/inference")
+    (subpath "[HOMEDIR]/.docker/bin/lib"))
+(allow file-write*
+    (regex #"inference-runner-[0-9]+\.sock$")
+    (literal "/dev/null")
+    (subpath "/private/var")
+    (subpath "[WORKDIR]"))
+(allow file-read*
+    (subpath "[WORKDIR]")
+    (subpath "[HOMEDIR]/.docker/models"))
+`
+
+// CommandContext creates a sandboxed version of an os/exec.Cmd. On Darwin, we
+// use the sandbox-exec command to wrap the process.
+func CommandContext(ctx context.Context, template, name string, args ...string) (*exec.Cmd, error) {
+	// Look up the user's home directory.
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup user: %w", err)
+	}
+
+	// Look up the working directory.
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine working directory: %w", err)
+	}
+
+	// Compute the profile. Switch to text/template if this gets more complex.
+	profile := strings.ReplaceAll(template, "[HOMEDIR]", currentUser.HomeDir)
+	profile = strings.ReplaceAll(profile, "[WORKDIR]", currentDirectory)
+
+	// Create the sandboxed process.
+	sandboxedArgs := make([]string, 0, len(args)+3)
+	sandboxedArgs = append(sandboxedArgs, "-p", profile, name)
+	sandboxedArgs = append(sandboxedArgs, args...)
+	return exec.CommandContext(ctx, "sandbox-exec", sandboxedArgs...), nil
+}

--- a/pkg/sandbox/sandbox_other.go
+++ b/pkg/sandbox/sandbox_other.go
@@ -30,13 +30,13 @@ func (s *sandbox) Close() error {
 	return nil
 }
 
-// New creates a new sandbox containing a single process that has been started.
+// Create creates a sandbox containing a single process that has been started.
 // The ctx, name, and arg arguments correspond to their counterparts in
 // os/exec.CommandContext. The configuration argument specifies the sandbox
 // configuration, for which a pre-defined value should be used. The modifier
 // function allows for an optional callback (which may be nil) to configure the
 // command before it is started.
-func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
 	// Create a subcontext we can use to regulate the process lifetime.
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -49,7 +49,7 @@ func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), na
 	// Start the process.
 	if err := command.Start(); err != nil {
 		cancel()
-		return nil, fmt.Errorf("unabled to start process: %w", err)
+		return nil, fmt.Errorf("unable to start process: %w", err)
 	}
 	return &sandbox{
 		cancel:  cancel,

--- a/pkg/sandbox/sandbox_other.go
+++ b/pkg/sandbox/sandbox_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && !windows
+
+package sandbox
+
+import (
+	"context"
+	"os/exec"
+)
+
+// LlamaCppTemplate is the sandbox template to use for llama.cpp processes.
+const LlamaCppTemplate = ``
+
+// CommandContext creates a sandboxed version of an os/exec.Cmd. On Linux, we
+// don't currently support sandboxing since we already run inside containers, so
+// this function is a direct passthrough.
+func CommandContext(ctx context.Context, template, name string, args ...string) (*exec.Cmd, error) {
+	return exec.CommandContext(ctx, name, args...), nil
+}

--- a/pkg/sandbox/sandbox_other.go
+++ b/pkg/sandbox/sandbox_other.go
@@ -4,15 +4,55 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 )
 
-// LlamaCppTemplate is the sandbox template to use for llama.cpp processes.
-const LlamaCppTemplate = ``
+// ConfigurationLlamaCpp is the sandbox configuration for llama.cpp processes.
+const ConfigurationLlamaCpp = ``
 
-// CommandContext creates a sandboxed version of an os/exec.Cmd. On Linux, we
-// don't currently support sandboxing since we already run inside containers, so
-// this function is a direct passthrough.
-func CommandContext(ctx context.Context, template, name string, args ...string) (*exec.Cmd, error) {
-	return exec.CommandContext(ctx, name, args...), nil
+// sandbox is the non-Darwin POSIX sandbox implementation.
+type sandbox struct {
+	// cancel cancels the context associated with the process.
+	cancel context.CancelFunc
+	// command is the sandboxed process handle.
+	command *exec.Cmd
+}
+
+// Command implements Sandbox.Command.
+func (s *sandbox) Command() *exec.Cmd {
+	return s.command
+}
+
+// Command implements Sandbox.Close.
+func (s *sandbox) Close() error {
+	s.cancel()
+	return nil
+}
+
+// New creates a new sandbox containing a single process that has been started.
+// The ctx, name, and arg arguments correspond to their counterparts in
+// os/exec.CommandContext. The configuration argument specifies the sandbox
+// configuration, for which a pre-defined value should be used. The modifier
+// function allows for an optional callback (which may be nil) to configure the
+// command before it is started.
+func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+	// Create a subcontext we can use to regulate the process lifetime.
+	ctx, cancel := context.WithCancel(ctx)
+
+	// Create and configure the command.
+	command := exec.CommandContext(ctx, name, arg...)
+	if modifier != nil {
+		modifier(command)
+	}
+
+	// Start the process.
+	if err := command.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("unabled to start process: %w", err)
+	}
+	return &sandbox{
+		cancel:  cancel,
+		command: command,
+	}, nil
 }

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -1,12 +1,19 @@
 package sandbox
 
 import (
+	"runtime"
 	"testing"
 )
 
 // TestSandbox performs basic sandbox testing.
 func TestSandbox(t *testing.T) {
-	sandbox, err := New(t.Context(), ConfigurationLlamaCpp, nil, "date")
+	var sandbox Sandbox
+	var err error
+	if runtime.GOOS == "windows" {
+		sandbox, err = New(t.Context(), ConfigurationLlamaCpp, nil, "go", "version")
+	} else {
+		sandbox, err = New(t.Context(), ConfigurationLlamaCpp, nil, "date")
+	}
 	if err != nil {
 		t.Fatal("unable to create sandboxed process:", err)
 	}

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -10,9 +10,9 @@ func TestSandbox(t *testing.T) {
 	var sandbox Sandbox
 	var err error
 	if runtime.GOOS == "windows" {
-		sandbox, err = New(t.Context(), ConfigurationLlamaCpp, nil, "go", "version")
+		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "go", "version")
 	} else {
-		sandbox, err = New(t.Context(), ConfigurationLlamaCpp, nil, "date")
+		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "date")
 	}
 	if err != nil {
 		t.Fatal("unable to create sandboxed process:", err)

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,21 @@
+package sandbox
+
+import (
+	"testing"
+)
+
+// TestSandbox performs basic sandbox testing.
+func TestSandbox(t *testing.T) {
+	sandbox, err := New(t.Context(), ConfigurationLlamaCpp, nil, "date")
+	if err != nil {
+		t.Fatal("unable to create sandboxed process:", err)
+	}
+	err = sandbox.Command().Wait()
+	if err != nil {
+		t.Error("unable to wait for process completion:", err)
+	}
+	err = sandbox.Close()
+	if err != nil {
+		t.Error("sandbox closure failed:", err)
+	}
+}

--- a/pkg/sandbox/sandbox_windows.go
+++ b/pkg/sandbox/sandbox_windows.go
@@ -59,13 +59,13 @@ func (s *sandbox) Close() error {
 	return s.job.Close()
 }
 
-// New creates a new sandbox containing a single process that has been started.
+// Create creates a sandbox containing a single process that has been started.
 // The ctx, name, and arg arguments correspond to their counterparts in
 // os/exec.CommandContext. The configuration argument specifies the sandbox
 // configuration, for which a pre-defined value should be used. The modifier
 // function allows for an optional callback (which may be nil) to configure the
 // command before it is started.
-func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
 	// Parse the configuration and configure limits.
 	limits := []winjob.Limit{winjob.WithKillOnJobClose()}
 	tokens := limitTokenMatcher.FindAllString(configuration, -1)
@@ -86,7 +86,7 @@ func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), na
 	// Create the and start the job.
 	job, err := winjob.Start(command, limits...)
 	if err != nil {
-		return nil, fmt.Errorf("unabled to start sandboxed process: %w", err)
+		return nil, fmt.Errorf("unable to start sandboxed process: %w", err)
 	}
 	return &sandbox{
 		job:     job,

--- a/pkg/sandbox/sandbox_windows.go
+++ b/pkg/sandbox/sandbox_windows.go
@@ -1,0 +1,16 @@
+package sandbox
+
+import (
+	"context"
+	"os/exec"
+)
+
+// LlamaCppTemplate is the sandbox template to use for llama.cpp processes.
+const LlamaCppTemplate = ``
+
+// CommandContext creates a sandboxed version of an os/exec.Cmd. On Windows, we
+// use the wsb exec command to wrap the process.
+func CommandContext(ctx context.Context, template, name string, args ...string) (*exec.Cmd, error) {
+	// TODO: Implement.
+	return exec.CommandContext(ctx, name, args...), nil
+}

--- a/pkg/sandbox/sandbox_windows.go
+++ b/pkg/sandbox/sandbox_windows.go
@@ -2,15 +2,94 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"regexp"
+
+	"github.com/kolesnikovae/go-winjob"
 )
 
-// LlamaCppTemplate is the sandbox template to use for llama.cpp processes.
-const LlamaCppTemplate = ``
+// limitTokenMatcher finds limit tokens in a sandbox configuration.
+var limitTokenMatcher = regexp.MustCompile(`\(With[a-zA-Z]+\)`)
 
-// CommandContext creates a sandboxed version of an os/exec.Cmd. On Windows, we
-// use the wsb exec command to wrap the process.
-func CommandContext(ctx context.Context, template, name string, args ...string) (*exec.Cmd, error) {
-	// TODO: Implement.
-	return exec.CommandContext(ctx, name, args...), nil
+// limitTokenToGenerator maps limit tokens to their corresponding generators.
+var limitTokenToGenerator = map[string]func() winjob.Limit{
+	"(WithDesktopLimit)":            winjob.WithDesktopLimit,
+	"(WithDieOnUnhandledException)": winjob.WithDieOnUnhandledException,
+	"(WithDisplaySettingsLimit)":    winjob.WithDisplaySettingsLimit,
+	"(WithExitWindowsLimit)":        winjob.WithExitWindowsLimit,
+	"(WithGlobalAtomsLimit)":        winjob.WithGlobalAtomsLimit,
+	"(WithHandlesLimit)":            winjob.WithHandlesLimit,
+	"(WithDisableOutgoingNetworking)": func() winjob.Limit {
+		return winjob.WithOutgoingBandwidthLimit(0)
+	},
+	"(WithReadClipboardLimit)":    winjob.WithReadClipboardLimit,
+	"(WithSystemParametersLimit)": winjob.WithSystemParametersLimit,
+	"(WithWriteClipboardLimit)":   winjob.WithWriteClipboardLimit,
+}
+
+// ConfigurationLlamaCpp is the sandbox configuration for llama.cpp processes.
+const ConfigurationLlamaCpp = `(WithDesktopLimit)
+(WithDieOnUnhandledException)
+(WithDisplaySettingsLimit)
+(WithExitWindowsLimit)
+(WithGlobalAtomsLimit)
+(WithHandlesLimit)
+(WithDisableOutgoingNetworking)
+(WithReadClipboardLimit)
+(WithSystemParametersLimit)
+(WithWriteClipboardLimit)
+`
+
+// sandbox is the Windows sandbox implementation.
+type sandbox struct {
+	// job is the Windows Job object that encapsulates the process.
+	job *winjob.JobObject
+	// command is the sandboxed process handle.
+	command *exec.Cmd
+}
+
+// Command implements Sandbox.Command.
+func (s *sandbox) Command() *exec.Cmd {
+	return s.command
+}
+
+// Command implements Sandbox.Close.
+func (s *sandbox) Close() error {
+	return s.job.Close()
+}
+
+// New creates a new sandbox containing a single process that has been started.
+// The ctx, name, and arg arguments correspond to their counterparts in
+// os/exec.CommandContext. The configuration argument specifies the sandbox
+// configuration, for which a pre-defined value should be used. The modifier
+// function allows for an optional callback (which may be nil) to configure the
+// command before it is started.
+func New(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+	// Parse the configuration and configure limits.
+	limits := []winjob.Limit{winjob.WithKillOnJobClose()}
+	tokens := limitTokenMatcher.FindAllString(configuration, -1)
+	for _, token := range tokens {
+		if generator, ok := limitTokenToGenerator[token]; ok {
+			limits = append(limits, generator())
+		} else {
+			return nil, fmt.Errorf("unknown limit token: %q", token)
+		}
+	}
+
+	// Create and configure the command.
+	command := exec.CommandContext(ctx, name, arg...)
+	if modifier != nil {
+		modifier(command)
+	}
+
+	// Create the and start the job.
+	job, err := winjob.Start(command, limits...)
+	if err != nil {
+		return nil, fmt.Errorf("unabled to start sandboxed process: %w", err)
+	}
+	return &sandbox{
+		job:     job,
+		command: command,
+	}, nil
 }

--- a/pkg/sandbox/sandbox_windows_test.go
+++ b/pkg/sandbox/sandbox_windows_test.go
@@ -1,0 +1,35 @@
+package sandbox
+
+import (
+	"maps"
+	"slices"
+	"testing"
+)
+
+// configurationTesting supports TestConfigurationParsing.
+const configurationTesting = `   (WithDesktopLimit)
+Ignore this
+  (WithDieOnUnhandledException)
+;; Comments
+(WithDisplaySettingsLimit)
+		(WithExitWindowsLimit)
+  (WithGlobalAtomsLimit) (WithHandlesLimit)
+(WithDisableOutgoingNetworking)
+
+   (IgnoreMeToo!)
+(WithReadClipboardLimit)
+
+	(WithSystemParametersLimit)
+(WithWriteClipboardLimit)
+`
+
+// TestConfigurationParsing does some basic configuration parsing testing.
+func TestConfigurationParsing(t *testing.T) {
+	tokens := limitTokenMatcher.FindAllString(configurationTesting, -1)
+	slices.Sort(tokens)
+	keys := slices.Collect(maps.Keys(limitTokenToGenerator))
+	slices.Sort(keys)
+	if !slices.Equal(tokens, keys) {
+		t.Error("parsed configuration tokens don't match known values")
+	}
+}


### PR DESCRIPTION
This PR implements llama.cpp process sandboxing for macOS and Windows.  It defines an extensible sandboxing framework that we can use for other backends or critical processes.

On macOS, we use the `sandbox-exec` command with a strict profile (similar to [what Chromium does](https://www.chromium.org/developers/design-documents/sandbox/osx-sandboxing-design/)). This command is deprecated, but the only other option would be to use App Sandbox, which we can't do for a standalone process. In theory, we may inherit something of a sandbox from Docker Desktop (if not running standalone), but Docker Desktop's entitlements are *broad*, so they won't do much to contain a compromised llama.cpp server process.  We can refine this profile to be more aggressive over time by applying more granular system call restrictions, but this should already significantly boost security.  Unfortunately this API is deprecated, so defining sandbox profiles isn't documented (it uses a custom LISP dialect). The best option is to look in `/System/Library/Sandbox/Profiles` or Google a bit. (**Edit:** it looks like Chromium preserved the [documentation](http://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf)).

On Windows, we use the Job API (similar to [what Chromium does](https://chromium.googlesource.com/chromium/src/+/refs/heads/lkgr/docs/design/sandbox.md#The-Job-object)).  There is also a [Windows Sandbox](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/windows-sandbox/) mechanism available, but it isn't available by default and it uses virtualization.  It might be worth looking at in the future.  In the meantime, we can use a restricted Windows Job object to provide at least some encapsulation.  I've built a little DSL / parser for specifying configuration there, sort of in the spirit of the macOS sandbox profile DSL.

On Linux, we just pass through directly to `os/exec` (i.e. we don't currently use sandboxing).  There isn't a unified sandboxing API on Linux (ideally we'd want something like OpenBSD's `tame()`), so it's not easy to choose something.  However, we don't support Docker Model Runner on Docker Desktop for Linux, and on Docker CE / Offload, DMR runs inside a container, so there's not much need for additional sandboxing.