### PR TITLE
sandbox: Make updated resource path configurable

### DIFF
--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -171,6 +171,7 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 			command.Stdout = serverLogStream
 			command.Stderr = out
 		},
+		l.updatedServerStoragePath,
 		filepath.Join(binPath, "com.docker.llama-server"),
 		args...,
 	)

--- a/pkg/sandbox/sandbox_other.go
+++ b/pkg/sandbox/sandbox_other.go
@@ -36,7 +36,7 @@ func (s *sandbox) Close() error {
 // configuration, for which a pre-defined value should be used. The modifier
 // function allows for an optional callback (which may be nil) to configure the
 // command before it is started.
-func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), updatedBinPath, name string, arg ...string) (Sandbox, error) {
 	// Create a subcontext we can use to regulate the process lifetime.
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -10,9 +10,9 @@ func TestSandbox(t *testing.T) {
 	var sandbox Sandbox
 	var err error
 	if runtime.GOOS == "windows" {
-		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "go", "version")
+		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "/some/path/bin", "go", "version")
 	} else {
-		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "date")
+		sandbox, err = Create(t.Context(), ConfigurationLlamaCpp, nil, "/some/path/bin", "date")
 	}
 	if err != nil {
 		t.Fatal("unable to create sandboxed process:", err)

--- a/pkg/sandbox/sandbox_windows.go
+++ b/pkg/sandbox/sandbox_windows.go
@@ -65,7 +65,7 @@ func (s *sandbox) Close() error {
 // configuration, for which a pre-defined value should be used. The modifier
 // function allows for an optional callback (which may be nil) to configure the
 // command before it is started.
-func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), name string, arg ...string) (Sandbox, error) {
+func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd), updatedBinPath, name string, arg ...string) (Sandbox, error) {
 	// Parse the configuration and configure limits.
 	limits := []winjob.Limit{winjob.WithKillOnJobClose()}
 	tokens := limitTokenMatcher.FindAllString(configuration, -1)


### PR DESCRIPTION
Not decided yet if this is the best way to handle the issue. But this fixes sandboxing for local (dev) builds of DMR.

## Summary by Sourcery

Introduce a configurable resource path for sandboxed processes by adding an updatedBinPath parameter to sandbox creation across all platforms, replacing hard-coded Docker inference paths with [UPDATEDBINPATH] and [UPDATEDLIBPATH] placeholders, and propagating the new path into the llamacpp backend run command.

New Features:
- Add updatedBinPath argument to Create functions in sandbox implementations for Darwin, Windows, and other platforms
- Replace hard-coded Docker inference subpaths with [UPDATEDBINPATH] and [UPDATEDLIBPATH] placeholders in sandbox profiles
- Pass the configured updatedServerStoragePath into the llamacpp backend Run invocation

Tests:
- Update sandbox tests to supply a sample updatedBinPath to the Create function