### PR TITLE
fix(OpenAIRecorder): save last valid "choices"

### DIFF
--- a/pkg/metrics/openai_recorder.go
+++ b/pkg/metrics/openai_recorder.go
@@ -195,7 +195,7 @@ func (r *OpenAIRecorder) convertStreamingResponse(streamingBody string) string {
 	lines := strings.Split(streamingBody, "\n")
 	var contentBuilder strings.Builder
 	var reasoningContentBuilder strings.Builder
-	var lastChunk map[string]interface{}
+	var lastChoice, lastChunk map[string]interface{}
 
 	for _, line := range lines {
 		if strings.HasPrefix(line, "data: ") {
@@ -213,6 +213,7 @@ func (r *OpenAIRecorder) convertStreamingResponse(streamingBody string) string {
 
 			if choices, ok := chunk["choices"].([]interface{}); ok && len(choices) > 0 {
 				if choice, ok := choices[0].(map[string]interface{}); ok {
+					lastChoice = choice
 					if delta, ok := choice["delta"].(map[string]interface{}); ok {
 						if content, ok := delta["content"].(string); ok {
 							contentBuilder.WriteString(content)
@@ -235,6 +236,7 @@ func (r *OpenAIRecorder) convertStreamingResponse(streamingBody string) string {
 	for key, value := range lastChunk {
 		finalResponse[key] = value
 	}
+	finalResponse["choices"] = []interface{}{lastChoice}
 
 	if choices, ok := finalResponse["choices"].([]interface{}); ok && len(choices) > 0 {
 		if choice, ok := choices[0].(map[string]interface{}); ok {


### PR DESCRIPTION
Fix a bug where OpenAIRecorder doesn't properly capture a streaming response due to the fact that the last valid "choices" field comes in the second last chunk of the response.

The "choices" in the last chunk can be empty, so save the last non-empty in order to record the streaming response properly. Without this patch we don't properly record a streaming response after llama.cpp has been bumped to include https://github.com/ggml-org/llama.cpp/pull/15444.

You can try it out with:
```
MODEL_RUNNER_PORT=8080 make run
```

```
$ curl http://localhost:8080/engines/v1/chat/completions \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{
   "model": "ai/smollm2",
   "messages": [
     {
       "role": "user",
       "content": "Capital of Romania?"
     }
   ], "stream": true,
   "stream_options": {
     "include_usage": true
   }
 }'
 ```