### PR TITLE
Don't fail to pull when system (V)RAM is unknown

### DIFF
--- a/pkg/inference/memory/estimator.go
+++ b/pkg/inference/memory/estimator.go
@@ -44,5 +44,10 @@ func (m *memoryEstimator) HaveSufficientMemoryForModel(ctx context.Context, mode
 	if err != nil {
 		return false, inference.RequiredMemory{}, inference.RequiredMemory{}, fmt.Errorf("estimating required memory for model: %w", err)
 	}
-	return m.systemMemoryInfo.HaveSufficientMemory(req), req, m.systemMemoryInfo.GetTotalMemory(), nil
+
+	ok, err := m.systemMemoryInfo.HaveSufficientMemory(req)
+	if err != nil {
+		return false, req, inference.RequiredMemory{}, fmt.Errorf("checking if system has sufficient memory: %w", err)
+	}
+	return ok, req, m.systemMemoryInfo.GetTotalMemory(), nil
 }

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 		m.log.Infof("Will estimate memory required for %q", request.From)
 		proceed, req, totalMem, err := m.memoryEstimator.HaveSufficientMemoryForModel(r.Context(), request.From, nil)
 		if err != nil {
-			m.log.Warnf("Failed validate sufficient system memory for model %q: %s", request.From, err)
+			m.log.Warnf("Failed to validate sufficient system memory for model %q: %s", request.From, err)
 			// Prefer staying functional in case of unexpected estimation errors.
 			proceed = true
 		}

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 		m.log.Infof("Will estimate memory required for %q", request.From)
 		proceed, req, totalMem, err := m.memoryEstimator.HaveSufficientMemoryForModel(r.Context(), request.From, nil)
 		if err != nil {
-			m.log.Warnf("Failed to calculate memory required for model %q: %s", request.From, err)
+			m.log.Warnf("Failed validate sufficient system memory for model %q: %s", request.From, err)
 			// Prefer staying functional in case of unexpected estimation errors.
 			proceed = true
 		}

--- a/pkg/inference/scheduling/scheduler_test.go
+++ b/pkg/inference/scheduling/scheduler_test.go
@@ -12,8 +12,8 @@ import (
 
 type systemMemoryInfo struct{}
 
-func (i systemMemoryInfo) HaveSufficientMemory(req inference.RequiredMemory) bool {
-	return true
+func (i systemMemoryInfo) HaveSufficientMemory(req inference.RequiredMemory) (bool, error) {
+    return true, nil
 }
 
 func (i systemMemoryInfo) GetTotalMemory() inference.RequiredMemory {


### PR DESCRIPTION
If system memory fails to compute, allow model pulls to proceed with warning logs instead of failing due to insufficient memory.

## Summary by Sourcery

Allow model pulls to proceed with a warning when system RAM or VRAM is unknown instead of failing, by extending the memory check API to return errors and handling them gracefully.

Bug Fixes:
- Prevent model pulls from failing due to unknown system memory by treating unknown RAM/VRAM as a warning condition

Enhancements:
- Change HaveSufficientMemory to return (bool, error) and emit errors for unknown memory values
- Update memory estimator to handle sufficiency check errors and continue on failure

Tests:
- Adapt scheduler tests to the updated HaveSufficientMemory signature

Chores:
- Adjust log message in model manager to reflect memory validation errors