### PR TITLE
fix(scheduling): query "/" to check if a runner is ready

### DIFF
--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -205,7 +205,7 @@ func (r *runner) wait(ctx context.Context) error {
 		default:
 		}
 		// Create and execute a request targeting a known-valid endpoint.
-		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/v1/models", http.NoBody)
+		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/", http.NoBody)
 		if err != nil {
 			return fmt.Errorf("readiness request creation failed: %w", err)
 		}


### PR DESCRIPTION
The llama.cpp server returns an error if the model is still loading: https://github.com/ggml-org/llama.cpp/blob/459c0c2c1a400f960d7b8e8d94d31a8426f80986/tools/server/server.cpp#L4220. Wait for it to be loaded using the correct endpoint, as on /models it doesn't return 503.

## Summary by Sourcery

Bug Fixes:
- Change readiness probe from `/v1/models` to `/` to ensure a 503 is returned while the model is still loading