### PR TITLE
Add shellcheck to validate bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Run tests with race detection
         run: go test -race ./...
 
+      - name: validate
+        run: make validate
+
       - name: model-distribution # TODO: Create a single Makefile for the monorepo
         run: make -C ./pkg/distribution/ all

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,10 @@ ARG LLAMA_SERVER_VARIANT
 # Create non-root user
 RUN groupadd --system modelrunner && useradd --system --gid modelrunner --create-home --home-dir /home/modelrunner modelrunner
 
+COPY scripts/apt-install.sh apt-install.sh
+
 # Install ca-certificates for HTTPS and vulkan
-RUN apt-get update && \
-    packages="ca-certificates" && \
-    if [ "${LLAMA_SERVER_VARIANT}" = "generic" ] || [ "${LLAMA_SERVER_VARIANT}" = "cpu" ]; then \
-        packages="$packages libvulkan1"; \
-    fi && \
-    apt-get install -y --no-install-recommends $packages && \
-    rm -rf /var/lib/apt/lists/*
+RUN ./apt-install.sh
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MODELS_PATH := $(shell pwd)/models-store
 LLAMA_ARGS ?=
 
 # Main targets
-.PHONY: build run clean test docker-build docker-run help
+.PHONY: build run clean test docker-build docker-run help validate
 
 # Default target
 .DEFAULT_GOAL := help
@@ -33,6 +33,9 @@ clean:
 # Run tests
 test:
 	go test -v ./...
+
+validate:
+	find . -type f -name "*.sh" | xargs shellcheck
 
 # Build Docker image
 docker-build:

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+main() {
+  set -eux -o pipefail
+
+  apt-get update
+  local packages=("ca-certificates")
+  if [ "${LLAMA_SERVER_VARIANT}" = "generic" ] || [ "${LLAMA_SERVER_VARIANT}" = "cpu" ]; then
+      packages+=("libvulkan1")
+  fi
+
+  apt-get install -y --no-install-recommends "${packages[@]}"
+  rm -rf /var/lib/apt/lists/*
+}
+
+main "$@"
+


### PR DESCRIPTION
Help to avoid bugs

## Summary by Sourcery

Centralize apt package installation into a dedicated script and integrate shellcheck validation into the Makefile and Docker build

New Features:
- Add apt-install.sh script for centralized package installation
- Add Makefile validate target to run shellcheck on shell scripts

Enhancements:
- Update Dockerfile to use apt-install.sh for installing ca-certificates and Vulkan packages