### PR TITLE
Revert "fix(scheduling): query "/" to check if a runner is ready"

### DIFF
--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -205,7 +205,7 @@ func (r *runner) wait(ctx context.Context) error {
 		default:
 		}
 		// Create and execute a request targeting a known-valid endpoint.
-		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/", http.NoBody)
+		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/v1/models", http.NoBody)
 		if err != nil {
 			return fmt.Errorf("readiness request creation failed: %w", err)
 		}


### PR DESCRIPTION
Reverts docker/model-runner#170

## Summary by Sourcery

Bug Fixes:
- Restore the scheduling runner’s readiness probe to target /v1/models instead of /