### PR TITLE
Revert "Revert "fix(scheduling): query "/" to check if a runner is ready""

### DIFF
--- a/pkg/inference/scheduling/runner.go
+++ b/pkg/inference/scheduling/runner.go
@@ -205,7 +205,7 @@ func (r *runner) wait(ctx context.Context) error {
 		default:
 		}
 		// Create and execute a request targeting a known-valid endpoint.
-		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/v1/models", http.NoBody)
+		readyRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/", http.NoBody)
 		if err != nil {
 			return fmt.Errorf("readiness request creation failed: %w", err)
 		}


### PR DESCRIPTION
Reverts docker/model-runner#173 which reverted https://github.com/docker/model-runner/pull/170.

I reverted it because suddenly it stopped working, as in it was returning 404 instead of 503 and I wanted to make sure I correctly test it and not leave it on `main` like that. I was getting 404 because I was testing it with DD's `latest` tagged llama.cpp, which is expected to return 404.

From https://github.com/docker/model-runner/pull/170:
> The llama.cpp server returns an error if the model is still loading: https://github.com/ggml-org/llama.cpp/blob/459c0c2c1a400f960d7b8e8d94d31a8426f80986/tools/server/server.cpp#L4220. Wait for it to be loaded using the correct endpoint, as on /models it doesn't return 503.

In order to test this, run it, send a request to big model so it's getting loaded and look for `level=info msg="srv  log_server_r: request: GET /  503" component=llama.cpp` in the logs.
```
make docker-run LLAMA_SERVER_VERSION=v0.0.16-rc1
```

## Summary by Sourcery

Bug Fixes:
- Use GET "/" for the HTTP readiness probe instead of "/v1/models" to correctly detect a loading runner