### PR TITLE
fix(sandbox): use the binary path on create

### DIFF
--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -171,7 +171,7 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, mode inference
 			command.Stdout = serverLogStream
 			command.Stderr = out
 		},
-		l.updatedServerStoragePath,
+		binPath,
 		filepath.Join(binPath, "com.docker.llama-server"),
 		args...,
 	)


### PR DESCRIPTION
The vendored binary path can be overriden by setting the LLAMA_SERVER_PATH environment variable. Hence, let's allow using that for the sandbox. Moreover, the updated binary path should not be used if it is not chosen.

## Summary by Sourcery

Allow sandbox to respect the LLAMA_SERVER_PATH override when creating the server binary path and prevent using an updated path when the override is not set

Bug Fixes:
- Use the LLAMA_SERVER_PATH environment variable for the sandbox binary path
- Avoid applying the updated binary path if no override is provided