### PR TITLE
build: remove multi-platform build for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PORT := 8080
 MODELS_PATH := $(shell pwd)/models-store
 LLAMA_ARGS ?=
 DOCKER_BUILD_ARGS := \
+	--load \
 	--build-arg LLAMA_SERVER_VERSION=$(LLAMA_SERVER_VERSION) \
 	--build-arg LLAMA_SERVER_VARIANT=$(LLAMA_SERVER_VARIANT) \
 	--build-arg BASE_IMAGE=$(BASE_IMAGE) \


### PR DESCRIPTION
For local development people might not have containerd enabled, which is required for a multi-platform build.

## Summary by Sourcery

Build:
- Remove multi-platform build flag from docker-build target in Makefile to simplify local development without containerd