### PR TITLE
build: add target for model distribution tool in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+model-distribution-tool
 model-runner
 model-runner.sock
 # Default MODELS_PATH in Makefile

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ docker-run: docker-build
 help:
 	@echo "Available targets:"
 	@echo "  build				- Build the Go application"
-	@echo "  model-distribution-tool			- Build the model distribution tool"
+	@echo "  model-distribution-tool	- Build the model distribution tool"
 	@echo "  run				- Run the application locally"
 	@echo "  clean				- Clean build artifacts"
 	@echo "  test				- Run tests"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Project variables
 APP_NAME := model-runner
+MDL_TOOL_NAME := model-distribution-tool
 GO_VERSION := 1.23.7
 LLAMA_SERVER_VERSION := latest
 LLAMA_SERVER_VARIANT := cpu
@@ -27,7 +28,7 @@ build:
 
 # Build model-distribution-tool
 model-distribution-tool:
-	CGO_ENABLED=1 go build -ldflags="-s -w" -o model-distribution-tool ./cmd/mdltool
+	CGO_ENABLED=1 go build -ldflags="-s -w" -o $(MDL_TOOL_NAME) ./cmd/mdltool
 
 # Run the application locally
 run: build
@@ -37,7 +38,7 @@ run: build
 # Clean build artifacts
 clean:
 	rm -f $(APP_NAME)
-	rm -f model-distribution-tool
+	rm -f $(MDL_TOOL_NAME)
 	rm -f model-runner.sock
 	rm -rf $(MODELS_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Project variables
 APP_NAME := model-runner
-MDL_TOOL_NAME := model-distribution-tool
 GO_VERSION := 1.23.7
 LLAMA_SERVER_VERSION := latest
 LLAMA_SERVER_VARIANT := cpu
@@ -15,6 +14,13 @@ DOCKER_BUILD_ARGS := \
 	--build-arg LLAMA_SERVER_VARIANT=$(LLAMA_SERVER_VARIANT) \
 	--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 	-t $(DOCKER_IMAGE)
+
+# Model distribution tool configuration
+MDL_TOOL_NAME := model-distribution-tool
+STORE_PATH ?= ./model-store
+SOURCE ?=
+TAG ?=
+LICENSE ?=
 
 # Main targets
 .PHONY: build run clean test docker-build docker-build-multiplatform docker-run help validate model-distribution-tool
@@ -77,6 +83,35 @@ docker-run: docker-build
 		-e DEBUG=${DEBUG} \
 		$(DOCKER_IMAGE)
 
+# Model distribution tool operations
+mdl-pull: model-distribution-tool
+	@echo "Pulling model from $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) pull $(TAG)
+
+mdl-package: model-distribution-tool
+	@echo "Packaging model $(SOURCE) to $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) package $(SOURCE) --tag $(TAG) $(if $(LICENSE),--licenses $(LICENSE))
+
+mdl-list: model-distribution-tool
+	@echo "Listing models..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) list
+
+mdl-get: model-distribution-tool
+	@echo "Getting model $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) get $(TAG)
+
+mdl-get-path: model-distribution-tool
+	@echo "Getting path for model $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) get-path $(TAG)
+
+mdl-rm: model-distribution-tool
+	@echo "Removing model $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) rm $(TAG)
+
+mdl-tag: model-distribution-tool
+	@echo "Tagging model $(SOURCE) as $(TAG)..."
+	./$(MDL_TOOL_NAME) --store-path $(STORE_PATH) tag $(SOURCE) $(TAG)
+
 # Show help
 help:
 	@echo "Available targets:"
@@ -90,9 +125,24 @@ help:
 	@echo "  docker-run			- Run in Docker container with TCP port access and mounted model storage"
 	@echo "  help				- Show this help message"
 	@echo ""
+	@echo "Model distribution tool targets:"
+	@echo "  mdl-pull			- Pull a model (TAG=registry/model:tag)"
+	@echo "  mdl-package			- Package and push a model (SOURCE=path/to/model.gguf TAG=registry/model:tag LICENSE=path/to/license.txt)"
+	@echo "  mdl-list			- List all models"
+	@echo "  mdl-get			- Get model info (TAG=registry/model:tag)"
+	@echo "  mdl-get-path			- Get model path (TAG=registry/model:tag)"
+	@echo "  mdl-rm			- Remove a model (TAG=registry/model:tag)"
+	@echo "  mdl-tag			- Tag a model (SOURCE=registry/model:tag TAG=registry/model:newtag)"
+	@echo ""
 	@echo "Backend configuration options:"
 	@echo "  LLAMA_ARGS    - Arguments for llama.cpp (e.g., \"--verbose --jinja -ngl 999 --ctx-size 2048\")"
 	@echo ""
 	@echo "Example usage:"
 	@echo "  make run LLAMA_ARGS=\"--verbose --jinja -ngl 999 --ctx-size 2048\""
 	@echo "  make docker-run LLAMA_ARGS=\"--verbose --jinja -ngl 999 --threads 4 --ctx-size 2048\""
+	@echo ""
+	@echo "Model distribution tool examples:"
+	@echo "  make mdl-pull TAG=registry.example.com/models/llama:v1.0"
+	@echo "  make mdl-package SOURCE=./model.gguf TAG=registry.example.com/models/llama:v1.0 LICENSE=./license.txt"
+	@echo "  make mdl-list"
+	@echo "  make mdl-rm TAG=registry.example.com/models/llama:v1.0"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCKER_BUILD_ARGS := \
 	-t $(DOCKER_IMAGE)
 
 # Main targets
-.PHONY: build run clean test docker-build docker-build-multiplatform docker-run help validate
+.PHONY: build run clean test docker-build docker-build-multiplatform docker-run help validate model-distribution-tool
 
 # Default target
 .DEFAULT_GOAL := help
@@ -24,6 +24,10 @@ DOCKER_BUILD_ARGS := \
 # Build the Go application
 build:
 	CGO_ENABLED=1 go build -ldflags="-s -w" -o $(APP_NAME) ./main.go
+
+# Build model-distribution-tool
+model-distribution-tool:
+	CGO_ENABLED=1 go build -ldflags="-s -w" -o model-distribution-tool ./cmd/mdltool
 
 # Run the application locally
 run: build
@@ -33,6 +37,7 @@ run: build
 # Clean build artifacts
 clean:
 	rm -f $(APP_NAME)
+	rm -f model-distribution-tool
 	rm -f model-runner.sock
 	rm -rf $(MODELS_PATH)
 
@@ -75,6 +80,7 @@ docker-run: docker-build
 help:
 	@echo "Available targets:"
 	@echo "  build				- Build the Go application"
+	@echo "  model-distribution-tool			- Build the model distribution tool"
 	@echo "  run				- Run the application locally"
 	@echo "  clean				- Clean build artifacts"
 	@echo "  test				- Run tests"


### PR DESCRIPTION
```
make model-distribution-tool
CGO_ENABLED=1 go build -ldflags="-s -w" -o model-distribution-tool ./cmd/mdltool
ilopezluna@F2D5QD4D6C model-runner % ./model-distribution-tool   
Usage: model-distribution-tool [options] <command> [arguments]
```

## Summary by Sourcery

Build:
- Add model-distribution-tool target to Makefile with build, clean, and help support