### PR TITLE
fix(main): use LLAMA_SERVER_VERSION as it is defined in Makefile

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,9 +51,9 @@ func main() {
 		llamacpp.ShouldUpdateServerLock.Unlock()
 	}
 
-	desiredSeverVersion, ok := os.LookupEnv("LLAMACPP_SERVER_VERSION")
+	desiredServerVersion, ok := os.LookupEnv("LLAMA_SERVER_VERSION")
 	if ok {
-		llamacpp.SetDesiredServerVersion(desiredSeverVersion)
+		llamacpp.SetDesiredServerVersion(desiredServerVersion)
 	}
 
 	llamaServerPath := os.Getenv("LLAMA_SERVER_PATH")


### PR DESCRIPTION
Make `LLAMA_SERVER_VERSION` work for `make run` (almost) the same way it works for `make docker-run`.

```
$ MODEL_RUNNER_PORT=8080 make run LLAMA_SERVER_VERSION=v0.0.16-rc2
CGO_ENABLED=1 go build -ldflags="-s -w" -o model-runner ./main.go
LLAMA_ARGS="" \
	./model-runner
INFO[0000] Running on system with 10922 MB VRAM
INFO[0000] Running on system with 16384 MB RAM
INFO[0000] Successfully initialized store                component=model-manager
INFO[0000] LLAMA_SERVER_PATH: /Applications/Docker.app/Contents/Resources/model-runner/bin
INFO[0000] Metrics endpoint enabled at /metrics
INFO[0000] Listening on TCP port 8080
INFO[0000] downloadLatestLlamaCpp: v0.0.16-rc2, metal, /Applications/Docker.app/Contents/Resources/model-runner/bin, /Users/doringeman/workspace/model-runner/updated-inference/bin/com.docker.llama-server
INFO[0000] current llama.cpp version is already up to date
```

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model status
Docker Model Runner is running

Status:
llama.cpp: running llama.cpp v0.0.16-rc2-metal (sha256:f577c1cd0d10252a67d5e2b6df400dcd9ddf8e6ec5419bc110be23bee32cdda4) version: c610b6c
```

## Summary by Sourcery

Bug Fixes:
- Use LLAMA_SERVER_VERSION instead of LLAMACPP_SERVER_VERSION in main.go to make env var work for make run as defined in the Makefile.