### PR TITLE
test: update tests to support ARM architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ model-runner
 model-runner.sock
 # Default MODELS_PATH in Makefile
 models-store/
+# Default MODELS_PATH in mdltool
+model-store/
 # Directory where we store the updated llama.cpp
 updated-inference/
 vendor/

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -25,7 +25,7 @@ func NewDefaultLlamaCppConfig() *Config {
 		// Using a thread count equal to core count results in bad performance, and there seems to be little to no gain
 		// in going beyond core_count/2.
 		if !containsArg(args, "--threads") {
-			nThreads := min(2, runtime.NumCPU()/2)
+			nThreads := max(1, min(2, runtime.NumCPU()/2))
 			args = append(args, "--threads", strconv.Itoa(nThreads))
 		}
 	}

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -25,7 +25,7 @@ func NewDefaultLlamaCppConfig() *Config {
 		// Using a thread count equal to core count results in bad performance, and there seems to be little to no gain
 		// in going beyond core_count/2.
 		if !containsArg(args, "--threads") {
-			nThreads := max(1, min(2, runtime.NumCPU()/2))
+			nThreads := max(2, runtime.NumCPU()/2)
 			args = append(args, "--threads", strconv.Itoa(nThreads))
 		}
 	}

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -75,7 +75,7 @@ func TestGetArgs(t *testing.T) {
 	// Build base expected args based on architecture
 	baseArgs := []string{"--jinja", "-ngl", "999", "--metrics"}
 	if runtime.GOARCH == "arm64" {
-		nThreads := min(2, runtime.NumCPU()/2)
+		nThreads := max(1, min(2, runtime.NumCPU()/2))
 		baseArgs = append(baseArgs, "--threads", strconv.Itoa(nThreads))
 	}
 

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -76,7 +76,7 @@ func TestGetArgs(t *testing.T) {
 	// Build base expected args based on architecture
 	baseArgs := []string{"--jinja", "-ngl", "999", "--metrics"}
 	if runtime.GOARCH == "arm64" {
-		nThreads := max(1, min(2, runtime.NumCPU()/2))
+		nThreads := max(2, runtime.NumCPU()/2)
 		baseArgs = append(baseArgs, "--threads", strconv.Itoa(nThreads))
 	}
 

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -72,6 +72,13 @@ func TestGetArgs(t *testing.T) {
 	modelPath := "/path/to/model"
 	socket := "unix:///tmp/socket"
 
+	// Build base expected args based on architecture
+	baseArgs := []string{"--jinja", "-ngl", "999", "--metrics"}
+	if runtime.GOARCH == "arm64" {
+		nThreads := min(2, runtime.NumCPU()/2)
+		baseArgs = append(baseArgs, "--threads", strconv.Itoa(nThreads))
+	}
+
 	tests := []struct {
 		name     string
 		bundle   types.ModelBundle
@@ -85,14 +92,11 @@ func TestGetArgs(t *testing.T) {
 			bundle: &fakeBundle{
 				ggufPath: modelPath,
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--ctx-size", "4096",
-			},
+			),
 		},
 		{
 			name: "embedding mode",
@@ -100,15 +104,12 @@ func TestGetArgs(t *testing.T) {
 			bundle: &fakeBundle{
 				ggufPath: modelPath,
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "4096",
-			},
+			),
 		},
 		{
 			name: "context size from backend config",
@@ -119,15 +120,12 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				ContextSize: 1234,
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "1234", // should add this flag
-			},
+			),
 		},
 		{
 			name: "context size from model config",
@@ -141,15 +139,12 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				ContextSize: 1234,
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "2096", // model config takes precedence
-			},
+			),
 		},
 		{
 			name: "chat template from model artifact",
@@ -158,15 +153,12 @@ func TestGetArgs(t *testing.T) {
 				ggufPath:     modelPath,
 				templatePath: "/path/to/bundle/template.jinja",
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--chat-template-file", "/path/to/bundle/template.jinja",
 				"--ctx-size", "4096",
-			},
+			),
 		},
 		{
 			name: "raw flags from backend config",
@@ -177,16 +169,13 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				RuntimeFlags: []string{"--some", "flag"},
 			},
-			expected: []string{
-				"--jinja",
-				"-ngl", "999",
-				"--metrics",
+			expected: append(append([]string{}, baseArgs...),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "4096",
 				"--some", "flag", // model config takes precedence
-			},
+			),
 		},
 	}
 

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -2,6 +2,7 @@ package llamacpp
 
 import (
 	"runtime"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -92,7 +93,7 @@ func TestGetArgs(t *testing.T) {
 			bundle: &fakeBundle{
 				ggufPath: modelPath,
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--ctx-size", "4096",
@@ -104,7 +105,7 @@ func TestGetArgs(t *testing.T) {
 			bundle: &fakeBundle{
 				ggufPath: modelPath,
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
@@ -120,7 +121,7 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				ContextSize: 1234,
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
@@ -139,7 +140,7 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				ContextSize: 1234,
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
@@ -153,7 +154,7 @@ func TestGetArgs(t *testing.T) {
 				ggufPath:     modelPath,
 				templatePath: "/path/to/bundle/template.jinja",
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--chat-template-file", "/path/to/bundle/template.jinja",
@@ -169,7 +170,7 @@ func TestGetArgs(t *testing.T) {
 			config: &inference.BackendConfiguration{
 				RuntimeFlags: []string{"--some", "flag"},
 			},
-			expected: append(append([]string{}, baseArgs...),
+			expected: append(slices.Clone(baseArgs),
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",


### PR DESCRIPTION
The test was failing because it didn't account for ARM64-specific arguments that are automatically added by `NewDefaultLlamaCppConfig()` when running on ARM64 architecture (like Apple Silicon Macs).

## Solution:

Updated the test to be architecture-aware by:

1. Building base expected arguments dynamically based on `runtime.GOARCH`
2. Adding `--threads` argument when on ARM64 (matching the behavior in `llamacpp_config.go`)
3. Using these base arguments consistently across all test cases

## Summary by Sourcery

Tests:
- Update TestGetArgs to generate base expected args dynamically and append ARM64-specific --threads flag for ARM64 architecture