### PR TITLE
Windows: consider GPU shared memory in run pre-check 

### DIFF
--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -418,8 +418,8 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 		l.log.Warnf("VRAM size unknown. Assume model will fit, but only one.")
 		memory.VRAM = 1
 	}
-	// Validate if model coul fit
-	//windows (on windows llamacpp use gpu share memory if it run out of gpu vram)
+	// Validate if model could fit
+	//windows (on windows llamacpp use gpu shared memory (half of system memory) if it run out of gpu vram)
 	if runtime.GOOS == "windows" && (memory.RAM > l.totalMemory.RAM || memory.VRAM > (l.totalMemory.VRAM+(l.totalMemory.RAM/2))) {
 		return nil, errModelTooBig
 	}

--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -417,7 +417,7 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 		l.log.Warnf("VRAM size unknown. Assume model will fit, but only one.")
 		memory.VRAM = 1
 	}
-	if memory.RAM > l.totalMemory.RAM || memory.VRAM > l.totalMemory.VRAM {
+	if memory.RAM > l.totalMemory.RAM || memory.VRAM > l.totalMemory.VRAM &&  runtime.GOOS != "windows" || runtime.GOOS == "windows" && memory.VRAM > (l.totalMemory.VRAM + l.totalMemory.RAM) {
 		return nil, errModelTooBig
 	}
 
@@ -464,12 +464,12 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 
 		// If there's not sufficient memory or all slots are full, then try
 		// evicting unused runners.
-		if memory.RAM > l.availableMemory.RAM || memory.VRAM > l.availableMemory.VRAM || len(l.runners) == len(l.slots) {
+		if memory.RAM > l.availableMemory.RAM ||  memory.VRAM > l.availableMemory.VRAM && runtime.GOOS != "windows" || runtime.GOOS == "windows" && memory.VRAM > (l.availableMemory.VRAM + l.availableMemory.RAM) || len(l.runners) == len(l.slots) {
 			l.evict(false)
 		}
 
 		// If there's sufficient memory and a free slot, then find the slot.
-		if memory.RAM <= l.availableMemory.RAM && memory.VRAM <= l.availableMemory.VRAM && len(l.runners) < len(l.slots) {
+		if memory.RAM <= l.availableMemory.RAM && (memory.VRAM <= l.availableMemory.VRAM && runtime.GOOS != "windows" || runtime.GOOS == "windows" && memory.VRAM <= (l.availableMemory.VRAM + l.availableMemory.RAM)) && len(l.runners) < len(l.slots) {
 			for s, runner := range l.slots {
 				if runner == nil {
 					slot = s

--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -445,6 +445,7 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 	// Loop until we can satisfy the request or an error occurs.
 	for {
 		slot := -1
+		availableVRAM := l.availableMemory.VRAM
 
 		// If loads are disabled, then there's nothing we can do.
 		if !l.loadsEnabled {
@@ -469,7 +470,6 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 			}
 		}
 		
-		availableVRAM := l.availableMemory.VRAM
 		if runtime.GOOS == "windows" {
 			// On Windows, we can use up to half of the total system RAM as shared GPU memory,
 			// limited by the currently available RAM.

--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -469,7 +469,7 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 		}
 
 		// If there's sufficient memory and a free slot, then find the slot.
-		if memory.RAM <= l.availableMemory.RAM && (memory.VRAM <= l.availableMemory.VRAM && runtime.GOOS != "windows" || runtime.GOOS == "windows" && memory.VRAM <= (l.availableMemory.VRAM + l.availableMemory.RAM)) && len(l.runners) < len(l.slots) {
+		if memory.RAM <= l.availableMemory.RAM && ((memory.VRAM <= l.availableMemory.VRAM && runtime.GOOS != "windows") || (runtime.GOOS == "windows" && memory.VRAM <= (l.availableMemory.VRAM + l.availableMemory.RAM))) && len(l.runners) < len(l.slots) {
 			for s, runner := range l.slots {
 				if runner == nil {
 					slot = s

--- a/pkg/inference/scheduling/loader.go
+++ b/pkg/inference/scheduling/loader.go
@@ -418,13 +418,14 @@ func (l *loader) load(ctx context.Context, backendName, modelID, modelRef string
 		l.log.Warnf("VRAM size unknown. Assume model will fit, but only one.")
 		memory.VRAM = 1
 	}
-	// Validate if model could fit
-	//windows (on windows llamacpp use gpu shared memory (half of system memory) if it run out of gpu vram)
-	if runtime.GOOS == "windows" && (memory.RAM > l.totalMemory.RAM || memory.VRAM > (l.totalMemory.VRAM+(l.totalMemory.RAM/2))) {
-		return nil, errModelTooBig
+	// Validate if model could fit.
+	// On Windows, llamacpp can use up to half of system RAM as shared GPU memory
+	// if it runs out of dedicated VRAM.
+	totalVRAM := l.totalMemory.VRAM
+	if runtime.GOOS == "windows" {
+		totalVRAM += l.totalMemory.RAM / 2
 	}
-	// not windows
-	if runtime.GOOS != "windows" && (memory.RAM > l.totalMemory.RAM || memory.VRAM > l.totalMemory.VRAM) {
+	if memory.RAM > l.totalMemory.RAM || memory.VRAM > totalVRAM {
 		return nil, errModelTooBig
 	}
 


### PR DESCRIPTION
Under Windows, shared GPU memory could be leveraged by llamacpp (and other backend) but the pre-check stop the execution if the model is bigger than the native GPU VRAM. This modification take the shared memory in consideration in the calculation.

resolve : #182

## Summary by Sourcery

Consider Windows GPU shared memory in VRAM checks to prevent false "model too big" errors and enable proper scheduling using shared memory

Enhancements:
- Account for half of system RAM as GPU shared memory in the loader’s pre-check when running on Windows
- Include shared memory in available VRAM calculations for evictions and slot allocation on Windows by adjusting scheduling logic