### PR TITLE
fix(scripts): handle unset gpu_device_flag array safely

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -22,7 +22,7 @@ main() {
     -e DMR_ORIGINS="$DMR_ORIGINS" \
     -e DO_NOT_TRACK="$DO_NOT_TRACK" \
     -e DEBUG="$DEBUG" \
-    "${gpu_device_flag[@]}" \
+    "${gpu_device_flag[@]+"${gpu_device_flag[@]}"}" \
     "$DOCKER_IMAGE"
 }
 


### PR DESCRIPTION
This syntax only expands the array if it's set and non-empty, avoiding the "unbound variable" error when the array is empty.

Follow-up to https://github.com/docker/model-runner/pull/171 which can make `make docker-run` fail:
```
scripts/docker-run.sh: line 15: gpu_device_flag[@]: unbound variable
make: *** [docker-run] Error 1
```