### PR TITLE
feat: add error handling for unsupported model formats in manager

### DIFF
--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/model-runner/pkg/diskusage"
 	"github.com/docker/model-runner/pkg/distribution/distribution"
 	"github.com/docker/model-runner/pkg/distribution/registry"
 	"github.com/docker/model-runner/pkg/distribution/types"
-	"github.com/docker/model-runner/pkg/diskusage"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/inference/memory"
 	"github.com/docker/model-runner/pkg/logging"
@@ -194,6 +194,11 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, registry.ErrModelNotFound) {
 			m.log.Warnf("Failed to pull model %q: %v", request.From, err)
 			http.Error(w, "Model not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, distribution.ErrUnsupportedFormat) {
+			m.log.Warnf("Unsupported model format for %q: %v", request.From, err)
+			http.Error(w, distribution.ErrUnsupportedFormat.Error(), http.StatusBadRequest)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Before:
```
MODEL_RUNNER_HOST=http://localhost:13434 docker model pull aistaging/smollm2-vllm
Failed to pull model: pulling aistaging/smollm2-vllm failed with status 500 Internal Server Error: error while pulling model: safetensors models are not currently supported - this runner only supports GGUF format models
```

After:
```
MODEL_RUNNER_HOST=http://localhost:13434 docker model pull aistaging/smollm2-vllm
Failed to pull model: pulling aistaging/smollm2-vllm failed with status 400 Bad Request: safetensors models are not currently supported - this runner only supports GGUF format models
```