### PR TITLE
fix: also register OPTIONS for CORS preflight

### DIFF
--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -101,6 +101,14 @@ func NewManager(log logging.Logger, c ClientConfig, allowedOrigins []string, mem
 
 	for route, handler := range m.routeHandlers() {
 		m.router.HandleFunc(route, handler)
+		// Also register OPTIONS for CORS preflight.
+		for _, method := range []string{"GET ", "POST ", "DELETE "} {
+			if strings.HasPrefix(route, method) {
+				optionsRoute := "OPTIONS " + strings.TrimPrefix(route, method)
+				m.router.HandleFunc(optionsRoute, func(w http.ResponseWriter, r *http.Request) {})
+				break
+			}
+		}
 	}
 
 	m.RebuildRoutes(allowedOrigins)

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,6 +85,14 @@ func NewScheduler(
 
 	for route, handler := range s.routeHandlers() {
 		s.router.HandleFunc(route, handler)
+		// Also register OPTIONS for CORS preflight.
+		for _, method := range []string{"GET ", "POST ", "DELETE "} {
+			if strings.HasPrefix(route, method) {
+				optionsRoute := "OPTIONS " + strings.TrimPrefix(route, method)
+				s.router.HandleFunc(optionsRoute, func(w http.ResponseWriter, r *http.Request) {})
+				break
+			}
+		}
 	}
 
 	s.RebuildRoutes(allowedOrigins)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Automatically register empty OPTIONS handlers for GET, POST, and DELETE routes to support CORS preflight in scheduler and manager