### PR TITLE
Conditionally include --jinja

### DIFF
--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -18,7 +18,7 @@ type Config struct {
 
 // NewDefaultLlamaCppConfig creates a new LlamaCppConfig with default values.
 func NewDefaultLlamaCppConfig() *Config {
-	args := append([]string{"--jinja", "-ngl", "999", "--metrics"})
+	args := append([]string{"-ngl", "999", "--metrics"})
 
 	// Special case for ARM64
 	if runtime.GOARCH == "arm64" {
@@ -69,9 +69,11 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 		args = append(args, config.RuntimeFlags...)
 	}
 
-	// Add arguments for Multimodal projector
+	// Add arguments for Multimodal projector or jinja (they are mutually exclusive)
 	if path := bundle.MMPROJPath(); path != "" {
 		args = append(args, "--mmproj", path)
+	} else {
+		args = append(args, "--jinja")
 	}
 
 	return args, nil

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/docker/model-runner/pkg/distribution/types"
-
 	"github.com/docker/model-runner/pkg/inference"
 )
 

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -14,9 +14,9 @@ import (
 func TestNewDefaultLlamaCppConfig(t *testing.T) {
 	config := NewDefaultLlamaCppConfig()
 
-	// Test default arguments
-	if !containsArg(config.Args, "--jinja") {
-		t.Error("Expected --jinja argument to be present")
+	// Test that --jinja is NOT in default args (it will be added conditionally in GetArgs)
+	if containsArg(config.Args, "--jinja") {
+		t.Error("Did not expect --jinja argument in default config (it should be added conditionally)")
 	}
 
 	// Test -ngl argument and its value
@@ -74,7 +74,7 @@ func TestGetArgs(t *testing.T) {
 	socket := "unix:///tmp/socket"
 
 	// Build base expected args based on architecture
-	baseArgs := []string{"--jinja", "-ngl", "999", "--metrics"}
+	baseArgs := []string{"-ngl", "999", "--metrics"}
 	if runtime.GOARCH == "arm64" {
 		nThreads := max(2, runtime.NumCPU()/2)
 		baseArgs = append(baseArgs, "--threads", strconv.Itoa(nThreads))
@@ -97,6 +97,7 @@ func TestGetArgs(t *testing.T) {
 				"--model", modelPath,
 				"--host", socket,
 				"--ctx-size", "4096",
+				"--jinja",
 			),
 		},
 		{
@@ -110,6 +111,7 @@ func TestGetArgs(t *testing.T) {
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "4096",
+				"--jinja",
 			),
 		},
 		{
@@ -125,7 +127,8 @@ func TestGetArgs(t *testing.T) {
 				"--model", modelPath,
 				"--host", socket,
 				"--embeddings",
-				"--ctx-size", "1234", // should add this flag
+				"--ctx-size", "1234",
+				"--jinja",
 			),
 		},
 		{
@@ -145,6 +148,7 @@ func TestGetArgs(t *testing.T) {
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "2096", // model config takes precedence
+				"--jinja",
 			),
 		},
 		{
@@ -159,6 +163,7 @@ func TestGetArgs(t *testing.T) {
 				"--host", socket,
 				"--chat-template-file", "/path/to/bundle/template.jinja",
 				"--ctx-size", "4096",
+				"--jinja",
 			),
 		},
 		{
@@ -175,8 +180,31 @@ func TestGetArgs(t *testing.T) {
 				"--host", socket,
 				"--embeddings",
 				"--ctx-size", "4096",
-				"--some", "flag", // model config takes precedence
+				"--some", "flag",
+				"--jinja",
 			),
+		},
+		{
+			name: "multimodal projector removes jinja",
+			mode: inference.BackendModeCompletion,
+			bundle: &fakeBundle{
+				ggufPath:   modelPath,
+				mmprojPath: "/path/to/model.mmproj",
+			},
+			expected: func() []string {
+				// Build expected args without --jinja since --mmproj is present
+				args := []string{"-ngl", "999", "--metrics"}
+				if runtime.GOARCH == "arm64" {
+					nThreads := max(2, runtime.NumCPU()/2)
+					args = append(args, "--threads", strconv.Itoa(nThreads))
+				}
+				return append(args,
+					"--model", modelPath,
+					"--host", socket,
+					"--ctx-size", "4096",
+					"--mmproj", "/path/to/model.mmproj",
+				)
+			}(),
 		},
 	}
 
@@ -261,6 +289,7 @@ type fakeBundle struct {
 	ggufPath     string
 	config       types.Config
 	templatePath string
+	mmprojPath   string
 }
 
 func (f *fakeBundle) ChatTemplatePath() string {
@@ -276,7 +305,7 @@ func (f *fakeBundle) GGUFPath() string {
 }
 
 func (f *fakeBundle) MMPROJPath() string {
-	return ""
+	return f.mmprojPath
 }
 
 func (f *fakeBundle) SafetensorsPath() string {

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -191,20 +191,12 @@ func TestGetArgs(t *testing.T) {
 				ggufPath:   modelPath,
 				mmprojPath: "/path/to/model.mmproj",
 			},
-			expected: func() []string {
-				// Build expected args without --jinja since --mmproj is present
-				args := []string{"-ngl", "999", "--metrics"}
-				if runtime.GOARCH == "arm64" {
-					nThreads := max(2, runtime.NumCPU()/2)
-					args = append(args, "--threads", strconv.Itoa(nThreads))
-				}
-				return append(args,
-					"--model", modelPath,
-					"--host", socket,
-					"--ctx-size", "4096",
-					"--mmproj", "/path/to/model.mmproj",
-				)
-			}(),
+			expected: append(slices.Clone(baseArgs),
+				"--model", modelPath,
+				"--host", socket,
+				"--ctx-size", "4096",
+				"--mmproj", "/path/to/model.mmproj",
+			),
 		},
 	}
 


### PR DESCRIPTION
This pull request updates the logic for handling the `--jinja` and `--mmproj` command-line arguments in the Llama.cpp backend configuration. The main improvement is that `--jinja` is now added only when a multimodal projector is not present, making the arguments mutually exclusive. The tests and supporting code have been updated to reflect and validate this behavior.

## Summary by Sourcery