### PR TITLE
fix: restore /v1/models endpoint routes

### DIFF
--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -114,10 +114,10 @@ func (s *Scheduler) routeHandlers() map[string]http.HandlerFunc {
 	}
 
 	// Register /v1/models routes - these delegate to the model manager
-	m["GET "+inference.InferencePrefix+"/{backend}/v1/models"] = s.handleOpenAIGetModels
-	m["GET "+inference.InferencePrefix+"/{backend}/v1/models/{name...}"] = s.handleOpenAIGetModel
-	m["GET "+inference.InferencePrefix+"/v1/models"] = s.handleOpenAIGetModels
-	m["GET "+inference.InferencePrefix+"/v1/models/{name...}"] = s.handleOpenAIGetModel
+	m["GET "+inference.InferencePrefix+"/{backend}/v1/models"] = s.handleModels
+	m["GET "+inference.InferencePrefix+"/{backend}/v1/models/{name...}"] = s.handleModels
+	m["GET "+inference.InferencePrefix+"/v1/models"] = s.handleModels
+	m["GET "+inference.InferencePrefix+"/v1/models/{name...}"] = s.handleModels
 
 	m["GET "+inference.InferencePrefix+"/status"] = s.GetBackendStatus
 	m["GET "+inference.InferencePrefix+"/ps"] = s.GetRunningBackends
@@ -509,15 +509,9 @@ func parseBackendMode(mode string) inference.BackendMode {
 	}
 }
 
-// handleOpenAIGetModels handles GET /engines/{backend}/v1/models requests
+// handleModels handles GET /engines/{backend}/v1/models* requests
 // by delegating to the model manager
-func (s *Scheduler) handleOpenAIGetModels(w http.ResponseWriter, r *http.Request) {
-	s.modelManager.ServeHTTP(w, r)
-}
-
-// handleOpenAIGetModel handles GET /engines/{backend}/v1/models/{name...} requests
-// by delegating to the model manager
-func (s *Scheduler) handleOpenAIGetModel(w http.ResponseWriter, r *http.Request) {
+func (s *Scheduler) handleModels(w http.ResponseWriter, r *http.Request) {
 	s.modelManager.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
## Problem
The `/engines/{backend}/v1/models` endpoint stopped working after commit c7fe66a8, which changed routing from individual route registration to prefix-based routing.

## Solution  
Added missing `/v1/models` route handlers to the scheduler that delegate to the modelManager.

## Changes
- Added 4 routes to `scheduler.routeHandlers()`: 
  - `GET /engines/{backend}/v1/models`
  - `GET /engines/{backend}/v1/models/{name...}`
  - `GET /engines/v1/models`
  - `GET /engines/v1/models/{name...}`
- Implemented `handleOpenAIGetModels()` and `handleOpenAIGetModel()` handlers

## Summary by Sourcery

Restore and handle the missing OpenAI-compatible /v1/models endpoints in the scheduler by re-registering their routes and delegating requests to the model manager.

Bug Fixes:
- Re-add GET routes for /engines/{backend}/v1/models and /engines/v1/models with and without model name segments in the scheduler's routeHandlers map.

Enhancements:
- Implement handleOpenAIGetModels and handleOpenAIGetModel handlers to forward model listing and retrieval requests to the modelManager.