### PR TITLE
Use lunar vulkan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,13 @@ ENV HOME=/home/modelrunner
 ENV MODELS_PATH=/models
 ENV LD_LIBRARY_PATH=/app/lib
 
+# Set environment variables for vulkan
+ENV VULKAN_SDK=/opt/vulkan
+ENV PATH=$VULKAN_SDK/bin:$PATH
+ENV LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
+ENV CMAKE_PREFIX_PATH=$VULKAN_SDK:$CMAKE_PREFIX_PATH
+ENV PKG_CONFIG_PATH=$VULKAN_SDK/lib/pkgconfig:$PKG_CONFIG_PATH
+
 # Label the image so that it's hidden on cloud engines.
 LABEL com.docker.desktop.service="model-runner"
 

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -5,8 +5,16 @@ main() {
 
   apt-get update
   local packages=("ca-certificates")
-  if [ "${LLAMA_SERVER_VARIANT}" = "generic" ] || [ "${LLAMA_SERVER_VARIANT}" = "cpu" ]; then
-      packages+=("libvulkan1")
+  if [ "$LLAMA_SERVER_VARIANT" = "generic" ] || [ "$LLAMA_SERVER_VARIANT" = "cpu" ]; then
+    # Install Vulkan SDK
+    local vulkan_version=1.4.321.1
+    local arch
+    arch=$(uname -m)
+    wget -qO /tmp/vulkan-sdk.tar.xz https://sdk.lunarg.com/sdk/download/$vulkan_version/linux/vulkan-sdk-linux-"$arch"-$vulkan_version.tar.xz
+    mkdir -p /opt/vulkan
+    tar -xf /tmp/vulkan-sdk.tar.xz -C /tmp --strip-components=1
+    mv /tmp/"$arch"/* /opt/vulkan/
+    rm -rf /tmp/*
   fi
 
   apt-get install -y "${packages[@]}"


### PR DESCRIPTION
I think we have a mismatch here

## Summary by Sourcery

Switch from installing the system libvulkan1 package to downloading and installing the LunarG Vulkan SDK in the setup script for generic and CPU variants, and expose the SDK via environment variables in the Docker image

Enhancements:
- Use LunarG Vulkan SDK (version 1.4.321.1) instead of system libvulkan1 in the apt-install script
- Configure Vulkan SDK environment variables in the Dockerfile