### PR TITLE
Minor change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Model Runner
+# Docker Model Runner
 
 Docker Model Runner (DMR) makes it easy to manage, run, and deploy AI models using Docker. Designed for developers, Docker Model Runner streamlines the process of pulling, running, and serving large language models (LLMs) and other AI models directly from Docker Hub or any OCI-compliant registry.
 


### PR DESCRIPTION
Consistency we call it DMR everywhere, except for the github repos, which makes sense as docker/ is already at the start.

## Summary by Sourcery

Documentation:
- Change README title from 'Model Runner' to 'Docker Model Runner' for naming consistency.