### PR TITLE
Use 25.10 vulkan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ARG GO_VERSION=1.24
 ARG LLAMA_SERVER_VERSION=latest
 ARG LLAMA_SERVER_VARIANT=cpu
 ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.${LLAMA_SERVER_VARIANT}.${TARGETARCH}
-ARG BASE_IMAGE=ubuntu:24.04
+
+# only 25.10 for cpu variant for max hardware support with vulkan
+ARG BASE_IMAGE=ubuntu:25.10
 
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS builder
 

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -6,7 +6,7 @@ main() {
   apt-get update
   local packages=("ca-certificates")
   if [ "$LLAMA_SERVER_VARIANT" = "generic" ] || [ "$LLAMA_SERVER_VARIANT" = "cpu" ]; then
-    apt-get install -y libvulkan1
+    packages+=("libvulkan1" "mesa-vulkan-drivers"))
   fi
 
   apt-get install -y "${packages[@]}"


### PR DESCRIPTION
It should have half decent hardware support and supports ARM.

## Summary by Sourcery

Simplify Vulkan support by installing the libvulkan1 package and removing manual SDK download, build logic, and related Dockerfile environment variables

Enhancements:
- Replace manual Vulkan SDK download and build with installation of the libvulkan1 apt package

Build:
- Remove VULKAN_SDK environment variable settings from the Dockerfile

Chores:
- Delete custom Vulkan SDK installation and associated build dependencies from the installation script