### PR TITLE
Remove double bracket

### DIFF
--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -6,7 +6,7 @@ main() {
   apt-get update
   local packages=("ca-certificates")
   if [ "$LLAMA_SERVER_VARIANT" = "generic" ] || [ "$LLAMA_SERVER_VARIANT" = "cpu" ]; then
-    packages+=("libvulkan1" "mesa-vulkan-drivers"))
+    packages+=("libvulkan1" "mesa-vulkan-drivers")
   fi
 
   apt-get install -y "${packages[@]}"


### PR DESCRIPTION
Script is broken

## Summary by Sourcery

Bug Fixes:
- Remove double closing parenthesis in packages+=() call to correct array append syntax