### PR TITLE
standalone: Allow specifying controller image variant via env

### DIFF
--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -219,14 +219,7 @@ func ensureContainerStarted(ctx context.Context, dockerClient client.ContainerAP
 
 // CreateControllerContainer creates and starts a controller container.
 func CreateControllerContainer(ctx context.Context, dockerClient *client.Client, port uint16, host string, environment string, doNotTrack bool, gpu gpupkg.GPUSupport, modelStorageVolume string, printer StatusPrinter, engineKind types.ModelRunnerEngineKind) error {
-	// Determine the target image.
-	var imageName string
-	switch gpu {
-	case gpupkg.GPUSupportCUDA:
-		imageName = ControllerImage + ":" + controllerImageTagCUDA()
-	default:
-		imageName = ControllerImage + ":" + controllerImageTagCPU()
-	}
+	imageName := controllerImageName(gpu)
 
 	// Set up the container configuration.
 	portStr := strconv.Itoa(int(port))

--- a/cmd/cli/pkg/standalone/controller_image.go
+++ b/cmd/cli/pkg/standalone/controller_image.go
@@ -1,0 +1,48 @@
+package standalone
+
+import (
+	"os"
+
+	gpupkg "github.com/docker/model-runner/cmd/cli/pkg/gpu"
+)
+
+const (
+	// ControllerImage is the image used for the controller container.
+	ControllerImage = "docker/model-runner"
+	// defaultControllerImageVersion is the image version used for the controller container
+	defaultControllerImageVersion = "latest"
+)
+
+func controllerImageVersion() string {
+	if version, ok := os.LookupEnv("MODEL_RUNNER_CONTROLLER_VERSION"); ok && version != "" {
+		return version
+	}
+	return defaultControllerImageVersion
+}
+
+func controllerImageVariant(detectedGPU gpupkg.GPUSupport) string {
+	if variant, ok := os.LookupEnv("MODEL_RUNNER_CONTROLLER_VARIANT"); ok {
+		if variant == "cpu" || variant == "generic" {
+			return ""
+		}
+		return variant
+	}
+	switch detectedGPU {
+	case gpupkg.GPUSupportCUDA:
+		return "cuda"
+	default:
+		return ""
+	}
+}
+
+func fmtControllerImageName(repo, version, variant string) string {
+	tag := repo + ":" + version
+	if len(variant) > 0 {
+		tag += "-" + variant
+	}
+	return tag
+}
+
+func controllerImageName(detectedGPU gpupkg.GPUSupport) string {
+	return fmtControllerImageName(ControllerImage, controllerImageVersion(), controllerImageVariant(detectedGPU))
+}


### PR DESCRIPTION
## Summary by Sourcery

Simplify and centralize controller image handling by extracting version and variant logic into utilities and enabling environment-driven image variant configuration

New Features:
- Allow overriding the controller image variant via the MODEL_RUNNER_CONTROLLER_VARIANT environment variable

Enhancements:
- Add controller_image.go with helpers for determining image version, variant, and formatted image tags
- Refactor EnsureControllerImage, PruneControllerImages, and CreateControllerContainer to use the new image naming utilities
- Remove inline tag constants and logic in favor of the centralized helper functions