### PR TITLE
Add --host flag to docker model install-runner command

### DIFF
--- a/cmd/cli/commands/install-runner_test.go
+++ b/cmd/cli/commands/install-runner_test.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestInstallRunnerHostFlag(t *testing.T) {
+	// Create the install-runner command
+	cmd := newInstallRunner()
+
+	// Verify the --host flag exists
+	hostFlag := cmd.Flags().Lookup("host")
+	if hostFlag == nil {
+		t.Fatal("--host flag not found")
+	}
+
+	// Verify the default value
+	if hostFlag.DefValue != "127.0.0.1" {
+		t.Errorf("Expected default host value to be '127.0.0.1', got '%s'", hostFlag.DefValue)
+	}
+
+	// Verify the flag type
+	if hostFlag.Value.Type() != "string" {
+		t.Errorf("Expected host flag type to be 'string', got '%s'", hostFlag.Value.Type())
+	}
+
+	// Test setting the flag value
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"localhost", "127.0.0.1"},
+		{"all interfaces", "0.0.0.0"},
+		{"specific IP", "192.168.1.100"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the command for each test
+			cmd := newInstallRunner()
+			err := cmd.Flags().Set("host", tc.value)
+			if err != nil {
+				t.Errorf("Failed to set host flag to '%s': %v", tc.value, err)
+			}
+
+			// Verify the value was set
+			hostValue, err := cmd.Flags().GetString("host")
+			if err != nil {
+				t.Errorf("Failed to get host flag value: %v", err)
+			}
+			if hostValue != tc.value {
+				t.Errorf("Expected host value to be '%s', got '%s'", tc.value, hostValue)
+			}
+		})
+	}
+}
+
+func TestInstallRunnerCommandFlags(t *testing.T) {
+	cmd := newInstallRunner()
+
+	// Verify all expected flags exist
+	expectedFlags := []string{"port", "host", "gpu", "do-not-track"}
+	for _, flagName := range expectedFlags {
+		if cmd.Flags().Lookup(flagName) == nil {
+			t.Errorf("Expected flag '--%s' not found", flagName)
+		}
+	}
+}
+
+func TestInstallRunnerCommandType(t *testing.T) {
+	cmd := newInstallRunner()
+
+	// Verify command properties
+	if cmd.Use != "install-runner" {
+		t.Errorf("Expected command Use to be 'install-runner', got '%s'", cmd.Use)
+	}
+
+	if cmd.Short != "Install Docker Model Runner (Docker Engine only)" {
+		t.Errorf("Unexpected command Short description: %s", cmd.Short)
+	}
+
+	// Verify RunE is set
+	if cmd.RunE == nil {
+		t.Error("Expected RunE to be set")
+	}
+}
+
+func TestInstallRunnerValidArgsFunction(t *testing.T) {
+	cmd := newInstallRunner()
+
+	// The install-runner command should not accept any arguments
+	// So ValidArgsFunction should be set to handle no arguments
+	if cmd.ValidArgsFunction == nil {
+		t.Error("Expected ValidArgsFunction to be set")
+	}
+}

--- a/cmd/cli/docs/reference/model_install-runner.md
+++ b/cmd/cli/docs/reference/model_install-runner.md
@@ -5,11 +5,12 @@ Install Docker Model Runner (Docker Engine only)
 
 ### Options
 
-| Name             | Type     | Default | Description                                                                                        |
-|:-----------------|:---------|:--------|:---------------------------------------------------------------------------------------------------|
-| `--do-not-track` | `bool`   |         | Do not track models usage in Docker Model Runner                                                   |
-| `--gpu`          | `string` | `auto`  | Specify GPU support (none\|auto\|cuda)                                                             |
-| `--port`         | `uint16` | `0`     | Docker container port for Docker Model Runner (default: 12434 for Docker CE, 12435 for Cloud mode) |
+| Name             | Type     | Default     | Description                                                                                        |
+|:-----------------|:---------|:------------|:---------------------------------------------------------------------------------------------------|
+| `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                   |
+| `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda)                                                             |
+| `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                           |
+| `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker CE, 12435 for Cloud mode) |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
Add clarifying comment about host security for auto-installation

Add tests for --host flag in install-runner command

## Summary by Sourcery

Introduce a --host flag to the install-runner command to let users specify the host address for binding the Docker Model Runner, defaulting to localhost for security.

New Features:
- Add --host flag to install-runner command with default value 127.0.0.1
- Expose host parameter in CreateControllerContainer to bind Docker ports to a custom host

Enhancements:
- Bind to custom host in port bindings and only include bridge gateway IP when host is localhost
- Add clarifying comment about default localhost binding for auto-installation

Documentation:
- Update model_install-runner reference to include the new --host option

Tests:
- Add unit tests to verify --host flag presence, default, type, and value setting
- Add tests for install-runner command flags, usage, and argument validation