### PR TITLE
Add vLLM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
             echo "docker/model-runner:latest-cuda" >> "$GITHUB_OUTPUT"
           fi
           echo 'EOF' >> "$GITHUB_OUTPUT"
+          echo "vllm-cuda<<EOF" >> "$GITHUB_OUTPUT"
+          echo "docker/model-runner:${{ inputs.releaseTag }}-vllm-cuda" >> "$GITHUB_OUTPUT"
+          if [ "${{ inputs.pushLatest }}" == "true" ]; then
+            echo "docker/model-runner:latest-vllm-cuda" >> "$GITHUB_OUTPUT"
+          fi
+          echo 'EOF' >> "$GITHUB_OUTPUT"
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -99,3 +105,16 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: ${{ steps.tags.outputs.cuda }}
+
+      - name: Build vLLM CUDA image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64
+          build-args: |
+            "BACKEND=vllm"
+            "VLLM_VERSION=v0.11.0"
+          push: true
+          sbom: true
+          provenance: mode=max
+          tags: ${{ steps.tags.outputs.vllm-cuda }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG GO_VERSION=1.24
 ARG LLAMA_SERVER_VERSION=latest
 ARG LLAMA_SERVER_VARIANT=cpu
 ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.${LLAMA_SERVER_VARIANT}.${TARGETARCH}
+ARG BACKEND=llamacpp
+ARG VLLM_VERSION=v0.11.0
 
 # only 25.10 for cpu variant for max hardware support with vulkan
 ARG BASE_IMAGE=ubuntu:25.10
@@ -34,36 +36,51 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # --- Get llama.cpp binary ---
 FROM docker/docker-model-backend-llamacpp:${LLAMA_SERVER_VERSION}-${LLAMA_SERVER_VARIANT} AS llama-server
 
-# --- Final image ---
-FROM docker.io/${BASE_IMAGE} AS final
+# --- Common setup stage ---
+FROM scratch AS setup-files
+COPY scripts/setup-modelrunner.sh /tmp/setup-modelrunner.sh
+
+# --- Final image for llama.cpp ---
+FROM docker.io/${BASE_IMAGE} AS final-llamacpp
 
 ARG LLAMA_SERVER_VARIANT
 
-# Create non-root user
-RUN groupadd --system modelrunner && useradd --system --gid modelrunner -G video --create-home --home-dir /home/modelrunner modelrunner
-# TODO: if the render group ever gets a fixed GID add modelrunner to it
-
 COPY scripts/apt-install.sh apt-install.sh
-
 # Install ca-certificates for HTTPS and vulkan
 RUN ./apt-install.sh
 
 WORKDIR /app
-
-# Create directories for the socket file and llama.cpp binary, and set proper permissions
-RUN mkdir -p /var/run/model-runner /app/bin /models && \
-    chown -R modelrunner:modelrunner /var/run/model-runner /app /models && \
-    chmod -R 755 /models
-
-# Copy the built binary from builder
-COPY --from=builder /app/model-runner /app/model-runner
 
 # Copy the llama.cpp binary from the llama-server stage
 ARG LLAMA_BINARY_PATH
 COPY --from=llama-server ${LLAMA_BINARY_PATH}/ /app/.
 RUN chmod +x /app/bin/com.docker.llama-server
 
+# Setup modelrunner user, directories and permissions
+COPY --from=setup-files /tmp/setup-modelrunner.sh /tmp/setup-modelrunner.sh
+RUN chmod +x /tmp/setup-modelrunner.sh && /tmp/setup-modelrunner.sh && rm /tmp/setup-modelrunner.sh
+
+# Copy the built binary from builder
+COPY --from=builder /app/model-runner /app/model-runner
+
 USER modelrunner
+
+# --- Final image for vLLM ---
+FROM vllm/vllm-openai:${VLLM_VERSION} AS final-vllm
+
+WORKDIR /app
+
+# Setup modelrunner user, directories and permissions
+COPY --from=setup-files /tmp/setup-modelrunner.sh /tmp/setup-modelrunner.sh
+RUN chmod +x /tmp/setup-modelrunner.sh && /tmp/setup-modelrunner.sh && rm /tmp/setup-modelrunner.sh
+
+# Copy the built binary from builder
+COPY --from=builder /app/model-runner /app/model-runner
+
+USER modelrunner
+
+# --- Select final stage based on backend ---
+FROM final-${BACKEND} AS final
 
 # Set the environment variable for the socket path and LLaMA server binary path
 ENV MODEL_RUNNER_SOCK=/var/run/model-runner/model-runner.sock

--- a/scripts/setup-modelrunner.sh
+++ b/scripts/setup-modelrunner.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Create modelrunner user if it doesn't exist
+if ! id -u modelrunner >/dev/null 2>&1; then
+    groupadd --system modelrunner
+    # Add to video group for GPU access (if it exists)
+    # TODO: if the render group ever gets a fixed GID add modelrunner to it
+    if getent group video >/dev/null 2>&1; then
+        useradd --system --gid modelrunner -G video --create-home --home-dir /home/modelrunner modelrunner
+    else
+        useradd --system --gid modelrunner --create-home --home-dir /home/modelrunner modelrunner
+    fi
+fi
+
+# Create directories and set proper permissions
+mkdir -p /var/run/model-runner /app/bin /models
+chown -R modelrunner:modelrunner /var/run/model-runner /app /models
+chmod -R 755 /models


### PR DESCRIPTION
## Summary by Sourcery

Add support for vLLM as an alternative to llama.cpp in the Docker build and release pipeline by refactoring the Dockerfile into separate final stages, parameterizing the backend, and updating CI to build and push vLLM CUDA images.

New Features:
- Add vLLM backend option to Docker build, selectable via BACKEND build argument
- Introduce setup-modelrunner.sh script to standardize modelrunner user creation and directory permissions

Enhancements:
- Refactor Dockerfile into distinct final stages for llama.cpp and vLLM and unify common setup steps
- Parameterize builds with BACKEND and VLLM_VERSION arguments and employ a multi-stage setup-files stage

CI:
- Update GitHub Actions release workflow to generate tags and build-push vLLM CUDA images