### PR TITLE
Remove this line

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -52,7 +52,6 @@ Run `./model --help` to see all commands and options.
 Or enter chat mode:
 ```bash
 ./model run llama.cpp
-Interactive chat mode started. Type '/bye' to exit.
 > """
 Tell me a joke.
 """

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -390,8 +390,6 @@ func newRunCmd() *cobra.Command {
 			}
 
 			scanner := bufio.NewScanner(os.Stdin)
-			cmd.Println("Interactive chat mode started. Type '/bye' to exit.")
-
 			for {
 				userInput, err := readMultilineInput(cmd, scanner)
 				if err != nil {

--- a/cmd/cli/docs/reference/docker_model_run.yaml
+++ b/cmd/cli/docs/reference/docker_model_run.yaml
@@ -72,7 +72,6 @@ examples: |-
     Output:
 
     ```console
-    Interactive chat mode started. Type '/bye' to exit.
     > Hi
     Hi there! It's SmolLM, AI assistant. How can I help you today?
     > /bye

--- a/cmd/cli/docs/reference/model_run.md
+++ b/cmd/cli/docs/reference/model_run.md
@@ -45,7 +45,6 @@ docker model run ai/smollm2
 Output:
 
 ```console
-Interactive chat mode started. Type '/bye' to exit.
 > Hi
 Hi there! It's SmolLM, AI assistant. How can I help you today?
 > /bye


### PR DESCRIPTION
No other tool related does this, it's too verbose

## Summary by Sourcery

Remove the verbose interactive chat start message from the CLI and documentation

Enhancements:
- Remove the print statement "Interactive chat mode started. Type '/bye' to exit." from the run command

Documentation:
- Remove references to the removed chat mode prompt from CLI README and reference docs