### PR TITLE
Add --detach flag to docker model run command

### DIFF
--- a/cmd/cli/commands/run_test.go
+++ b/cmd/cli/commands/run_test.go
@@ -113,3 +113,46 @@ func TestReadMultilineInputUnclosed(t *testing.T) {
 		t.Errorf("readMultilineInput() error should mention unclosed multiline input, got: %v", err)
 	}
 }
+
+func TestRunCmdDetachFlag(t *testing.T) {
+	// Create the run command
+	cmd := newRunCmd()
+
+	// Verify the --detach flag exists
+	detachFlag := cmd.Flags().Lookup("detach")
+	if detachFlag == nil {
+		t.Fatal("--detach flag not found")
+	}
+
+	// Verify the shorthand flag exists
+	detachFlagShort := cmd.Flags().ShorthandLookup("d")
+	if detachFlagShort == nil {
+		t.Fatal("-d shorthand flag not found")
+	}
+
+	// Verify the default value is false
+	if detachFlag.DefValue != "false" {
+		t.Errorf("Expected default detach value to be 'false', got '%s'", detachFlag.DefValue)
+	}
+
+	// Verify the flag type
+	if detachFlag.Value.Type() != "bool" {
+		t.Errorf("Expected detach flag type to be 'bool', got '%s'", detachFlag.Value.Type())
+	}
+
+	// Test setting the flag value
+	err := cmd.Flags().Set("detach", "true")
+	if err != nil {
+		t.Errorf("Failed to set detach flag: %v", err)
+	}
+
+	// Verify the value was set
+	detachValue, err := cmd.Flags().GetBool("detach")
+	if err != nil {
+		t.Errorf("Failed to get detach flag value: %v", err)
+	}
+
+	if !detachValue {
+		t.Errorf("Expected detach flag value to be true, got false")
+	}
+}

--- a/cmd/cli/docs/reference/docker_model_run.yaml
+++ b/cmd/cli/docs/reference/docker_model_run.yaml
@@ -39,6 +39,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: detach
+      shorthand: d
+      value_type: bool
+      default_value: "false"
+      description: Load the model in the background without interaction
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: ignore-runtime-memory-check
       value_type: bool
       default_value: "false"
@@ -78,6 +89,14 @@ examples: |-
     > /bye
     Chat session ended.
     ```
+
+    ### Pre-load a model
+
+    ```console
+    docker model run --detach ai/smollm2
+    ```
+
+    This loads the model into memory without interaction, ensuring maximum performance for subsequent requests.
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/model_run.md
+++ b/cmd/cli/docs/reference/model_run.md
@@ -9,6 +9,7 @@ Run a model and interact with it using a submitted prompt or chat mode
 |:--------------------------------|:---------|:--------|:----------------------------------------------------------------------------------|
 | `--color`                       | `string` | `auto`  | Use colored output (auto\|yes\|no)                                                |
 | `--debug`                       | `bool`   |         | Enable debug logging                                                              |
+| `-d`, `--detach`                | `bool`   |         | Load the model in the background without interaction                              |
 | `--ignore-runtime-memory-check` | `bool`   |         | Do not block pull if estimated runtime memory for model exceeds system resources. |
 
 
@@ -51,3 +52,11 @@ Hi there! It's SmolLM, AI assistant. How can I help you today?
 > /bye
 Chat session ended.
 ```
+
+### Pre-load a model
+
+```console
+docker model run --detach ai/smollm2
+```
+
+This loads the model into memory without interaction, ensuring maximum performance for subsequent requests.


### PR DESCRIPTION
So we can load models in the background without interaction

## Summary by Sourcery

Add a `--detach`/`-d` option to `docker model run` to load models in the background without interaction, update command behavior, and include supporting tests and documentation.

New Features:
- Introduce `--detach`/`-d` flag on the run command to enable background model loading without user input.

Enhancements:
- Adjust run command logic to skip stdin reading and perform a silent preload when the `--detach` flag is set.

Documentation:
- Document the `--detach` flag in the reference and provide an example for pre-loading models.

Tests:
- Add `TestRunCmdDetachFlag` to validate the presence, default state, type, and behavior of the `--detach` flag.