### PR TITLE
runner: Make runtime memory checking opt-in

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,10 @@ func main() {
 		log.Fatalf("unable to initialize %s backend: %v", llamacpp.Name, err)
 	}
 
+	if os.Getenv("MODEL_RUNNER_RUNTIME_MEMORY_CHECK") == "1" {
+		memory.SetRuntimeMemoryCheck(true)
+	}
+
 	memEstimator.SetDefaultBackend(llamaCppBackend)
 
 	scheduler := scheduling.NewScheduler(

--- a/pkg/inference/memory/settings.go
+++ b/pkg/inference/memory/settings.go
@@ -1,0 +1,18 @@
+package memory
+
+import "sync"
+
+var runtimeMemoryCheck bool
+var runtimeMemoryCheckLock sync.Mutex
+
+func SetRuntimeMemoryCheck(enabled bool) {
+	runtimeMemoryCheckLock.Lock()
+	defer runtimeMemoryCheckLock.Unlock()
+	runtimeMemoryCheck = enabled
+}
+
+func RuntimeMemoryCheckEnabled() bool {
+	runtimeMemoryCheckLock.Lock()
+	defer runtimeMemoryCheckLock.Unlock()
+	return runtimeMemoryCheck
+}

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -152,7 +152,7 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 
 	// Pull the model. In the future, we may support additional operations here
 	// besides pulling (such as model building).
-	if !request.IgnoreRuntimeMemoryCheck {
+	if memory.RuntimeMemoryCheckEnabled() && !request.IgnoreRuntimeMemoryCheck {
 		m.log.Infof("Will estimate memory required for %q", request.From)
 		proceed, req, totalMem, err := m.memoryEstimator.HaveSufficientMemoryForModel(r.Context(), request.From, nil)
 		if err != nil {


### PR DESCRIPTION
The current model memory requirement checking routines are limited to llama.cpp, and because a separate library is used to do the estimation it is likely to lag behind llama.cpp in terms of supported models. This significantly complicates delivering a good experience for users of the feature. So make it opt-in, for now.

## Summary by Sourcery

Make runtime model memory requirement checking opt-in via an environment variable

New Features:
- Introduce MODEL_RUNNER_RUNTIME_MEMORY_CHECK environment variable to enable runtime memory checks

Enhancements:
- Add memory/settings package with SetRuntimeMemoryCheck and RuntimeMemoryEnabled to manage the check flag
- Guard the model memory estimation logic behind the runtime memory check toggle