### PR TITLE
hide configure command and update documentation

### DIFF
--- a/cmd/cli/commands/configure.go
+++ b/cmd/cli/commands/configure.go
@@ -13,8 +13,9 @@ func newConfigureCmd() *cobra.Command {
 	var opts scheduling.ConfigureRequest
 
 	c := &cobra.Command{
-		Use:   "configure [--context-size=<n>] MODEL [-- <runtime-flags...>]",
-		Short: "Configure runtime options for a model",
+		Use:    "configure [--context-size=<n>] MODEL [-- <runtime-flags...>]",
+		Short:  "Configure runtime options for a model",
+		Hidden: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			argsBeforeDash := cmd.ArgsLenAtDash()
 			if argsBeforeDash == -1 {

--- a/cmd/cli/docs/reference/docker_model.yaml
+++ b/cmd/cli/docs/reference/docker_model.yaml
@@ -6,7 +6,6 @@ long: |-
 pname: docker
 plink: docker.yaml
 cname:
-    - docker model configure
     - docker model df
     - docker model inspect
     - docker model install-runner
@@ -29,7 +28,6 @@ cname:
     - docker model unload
     - docker model version
 clink:
-    - docker_model_configure.yaml
     - docker_model_df.yaml
     - docker_model_inspect.yaml
     - docker_model_install-runner.yaml

--- a/cmd/cli/docs/reference/docker_model_configure.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure.yaml
@@ -16,7 +16,7 @@ options:
       kubernetes: false
       swarm: false
 deprecated: false
-hidden: false
+hidden: true
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/cmd/cli/docs/reference/model.md
+++ b/cmd/cli/docs/reference/model.md
@@ -7,7 +7,6 @@ Docker Model Runner
 
 | Name                                            | Description                                                                    |
 |:------------------------------------------------|:-------------------------------------------------------------------------------|
-| [`configure`](model_configure.md)               | Configure runtime options for a model                                          |
 | [`df`](model_df.md)                             | Show Docker Model Runner disk usage                                            |
 | [`inspect`](model_inspect.md)                   | Display detailed information on one model                                      |
 | [`install-runner`](model_install-runner.md)     | Install Docker Model Runner (Docker Engine only)                               |


### PR DESCRIPTION
This pull request hides the `configure` command for Docker Model Runner from both the CLI and documentation. The most important changes include marking the command as hidden in code, updating documentation to remove references to the command, and ensuring the command does not appear in any user-facing lists.

Configure command allows to change the context size of a model but it does not persist and it adds additional issues related to model identity. To configure a model we will use #243 instead.

## Summary by Sourcery

Hide the `configure` command from the CLI and user documentation to prevent its usage and references until it is replaced by the new #243 implementation.

Enhancements:
- Set the `configure` command’s Hidden flag in the CLI code
- Remove `configure` entries from Docker Model Runner reference docs and navigation
- Mark the `configure` documentation file as hidden in its YAML metadata