### PR TITLE
metrics: always use default User-Agent and add action to model tracking

### DIFF
--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -231,7 +231,7 @@ func (s *Scheduler) handleOpenAIInference(w http.ResponseWriter, r *http.Request
 			return
 		}
 		// Non-blocking call to track the model usage.
-		s.tracker.TrackModel(model, r.UserAgent())
+		s.tracker.TrackModel(model, r.UserAgent(), "inference/"+backendMode.String())
 	}
 
 	modelID := s.modelManager.ResolveModelID(request.Model)
@@ -415,7 +415,7 @@ func (s *Scheduler) Configure(w http.ResponseWriter, r *http.Request) {
 
 	if model, err := s.modelManager.GetModel(configureRequest.Model); err == nil {
 		// Configure is called by compose for each model.
-		s.tracker.TrackModel(model, r.UserAgent())
+		s.tracker.TrackModel(model, r.UserAgent(), "configure/"+mode.String())
 	}
 	modelID := s.modelManager.ResolveModelID(configureRequest.Model)
 	if err := s.loader.setRunnerConfig(r.Context(), backend.Name(), modelID, mode, runnerConfig); err != nil {


### PR DESCRIPTION
Always use default User-Agent and add action to model tracking.

E.g.,
```
$ DEBUG=1 MODEL_RUNNER_PORT=8080 make run 2>&1 | grep "Tracked "

time="2025-10-17T16:10:12+03:00" level=debug msg="Tracked index.docker.io/ai/smollm2:latest latest with user agent: docker-model-runner docker-model-cli/v0.1.42 configure/completion" component=metrics

time="2025-10-17T16:10:24+03:00" level=debug msg="Tracked index.docker.io/ai/smollm2:latest latest with user agent: docker-model-runner docker-model-cli/v0.1.42 inference/completion" component=metrics

time="2025-10-17T16:10:29+03:00" level=debug msg="Tracked index.docker.io/ai/embeddinggemma:300M-Q8_0 300M-Q8_0 with user agent: docker-model-runner curl/8.7.1 inference/embedding" component=metrics
```
These logs are from the following commands.
```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model configure ai/smollm2 --context-size 1024

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run ai/smollm2 hi

$ curl http://localhost:8080/engines/llama.cpp/v1/embeddings -X POST -d '{"model": "ai/embeddinggemma:300M-Q8_0", "input": "hello"}'
```

## Summary by Sourcery

Ensure the default User-Agent is always used for metrics tracking and enrich model tracking with an action label to distinguish configure and inference events

New Features:
- Add an action parameter to model tracking to record the operation context

Enhancements:
- Always append the default User-Agent to tracking requests
- Update TrackModel API and calls to include action labels for inference and configure operations