### PR TITLE
Add step to add user to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For Linux, install Docker Engine:
 
 ```bash
 curl -fsSL https://get.docker.com | sudo bash
+sudo usermod -aG docker $USER # give user permission to access docker daemon, relogin to take effect
 ```
 
 Docker Model Runner is included in the above tools.


### PR DESCRIPTION
A user complained they could not access docker after installation.

## Summary by Sourcery

Documentation:
- Add a step in README to run 'sudo usermod -aG docker $USER' so users can access Docker without sudo