### PR TITLE
Add proxy support for model pulling behind firewall

### DIFF
--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -230,6 +230,14 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 	if doNotTrack {
 		env = append(env, "DO_NOT_TRACK=1")
 	}
+	
+	// Pass proxy environment variables to the container if they are set
+	proxyEnvVars := []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"}
+	for _, proxyVar := range proxyEnvVars {
+		if value, ok := os.LookupEnv(proxyVar); ok {
+			env = append(env, proxyVar+"="+value)
+		}
+	}
 	config := &container.Config{
 		Image: imageName,
 		Env:   env,

--- a/main.go
+++ b/main.go
@@ -70,12 +70,22 @@ func main() {
 
 	memEstimator := memory.NewEstimator(sysMemInfo)
 
+	// Create a proxy-aware HTTP transport
+	// Use a safe type assertion with fallback, and explicitly set Proxy to http.ProxyFromEnvironment
+	var baseTransport *http.Transport
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		baseTransport = t.Clone()
+	} else {
+		baseTransport = &http.Transport{}
+	}
+	baseTransport.Proxy = http.ProxyFromEnvironment
+
 	modelManager := models.NewManager(
 		log,
 		models.ClientConfig{
 			StoreRootPath: modelPath,
 			Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
-			Transport:     resumable.New(http.DefaultTransport),
+			Transport:     resumable.New(baseTransport),
 		},
 		nil,
 		memEstimator,


### PR DESCRIPTION
- Pass proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) to docker-model-runner container
- Configure HTTP transport to use ProxyFromEnvironment for model pulling
- Add tests for proxy configuration in both container creation and transport

## Summary by Sourcery

Enable HTTP(S) proxy support for model pulling behind a firewall by configuring the HTTP transport with ProxyFromEnvironment and passing proxy environment variables into spawned containers, with accompanying unit tests.

New Features:
- Enable HTTP(S) proxy support for model pulling via ProxyFromEnvironment in the HTTP transport

Enhancements:
- Pass proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY and lowercase equivalents) into the docker-model-runner container

Tests:
- Add unit tests for proxy-aware HTTP transport configuration
- Add unit tests to verify proxy environment variables are correctly passed to container creation