### PR TITLE
fix(cors): validate Origin header

### DIFF
--- a/pkg/middleware/cors_test.go
+++ b/pkg/middleware/cors_test.go
@@ -38,7 +38,7 @@ func TestCorsMiddleware(t *testing.T) {
 			allowedOrigins: []string{"http://foo.com"},
 			method:         "GET",
 			origin:         "http://bar.com",
-			wantStatus:     http.StatusOK,
+			wantStatus:     http.StatusForbidden,
 			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
 		},
 		{
@@ -74,7 +74,7 @@ func TestCorsMiddleware(t *testing.T) {
 			allowedOrigins: nil,
 			method:         "GET",
 			origin:         "http://foo.com",
-			wantStatus:     http.StatusOK,
+			wantStatus:     http.StatusForbidden,
 			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
 		},
 	}


### PR DESCRIPTION
Remove insecure bypass that allowed all requests when `allowedOrigins` was nil/empty.

## Summary by Sourcery

Strengthen CORS middleware by enforcing Origin header validation and removing the insecure bypass when no allowed origins are configured

Bug Fixes:
- Remove the bypass that allowed all requests when allowedOrigins was nil or empty
- Return HTTP 403 for requests with an invalid or missing Origin header instead of silently passing them through

Enhancements:
- Consolidate origin allowance logic into a single boolean flag for clearer checks
- Require valid Origin header for preflight OPTIONS requests to prevent unauthorized access