### PR TITLE
Cherry-pick fix(cors): validate Origin header

### DIFF
--- a/pkg/middleware/cors_test.go
+++ b/pkg/middleware/cors_test.go
@@ -38,7 +38,7 @@ func TestCorsMiddleware(t *testing.T) {
 			allowedOrigins: []string{"http://foo.com"},
 			method:         "GET",
 			origin:         "http://bar.com",
-			wantStatus:     http.StatusOK,
+			wantStatus:     http.StatusForbidden,
 			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
 		},
 		{
@@ -74,7 +74,7 @@ func TestCorsMiddleware(t *testing.T) {
 			allowedOrigins: nil,
 			method:         "GET",
 			origin:         "http://foo.com",
-			wantStatus:     http.StatusOK,
+			wantStatus:     http.StatusForbidden,
 			wantHeaders:    map[string]string{"Access-Control-Allow-Origin": ""},
 		},
 	}


### PR DESCRIPTION
Cherry-pick fix(cors): validate Origin header https://github.com/docker/model-runner/pull/270.

## Summary by Sourcery

Cherry-pick a fix to enforce Origin header validation in the CORS middleware, remove the nil allowedOrigins bypass, and adjust tests to expect 403 responses for invalid origins

Bug Fixes:
- Validate the Origin header in CORS middleware and return 403 Forbidden for disallowed origins

Enhancements:
- Remove special-case bypass for nil allowedOrigins and unify allowed-origin logic

Tests:
- Update CORS tests to expect 403 Forbidden for requests with disallowed origins