### PR TITLE
Slack link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,6 @@ discussion on the issue tracker.
 
 ## Community
 
-For general questions and discussion, please use [Docker Model Runner's Slack channel](https://app.slack.com/client/T0JK1PCN6/C09H9P5E57B).
+For general questions and discussion, please use [Docker Model Runner's Slack channel](https://dockercommunity.slack.com/archives/C09H9P5E57B).
 
 For discussions about issues/bugs and features, you can use GitHub Issues and Pull requests.


### PR DESCRIPTION
This is the correct one. Users could not access.

## Summary by Sourcery

Documentation:
- Update the Slack channel URL in README.md to the correct dockercommunity.slack.com link