### PR TITLE
fix(cli): show "in use" for active runners in ps command

### DIFF
--- a/cmd/cli/commands/ps.go
+++ b/cmd/cli/commands/ps.go
@@ -58,11 +58,21 @@ func psTable(ps []desktop.BackendStatus) string {
 			// Strip default "ai/" prefix and ":latest" tag for display
 			modelName = stripDefaultsFromModelName(modelName)
 		}
+
+		lastUsed := "in use"
+		if !status.LastUsed.IsZero() {
+			duration := time.Since(status.LastUsed)
+			if duration < 0 {
+				duration = 0
+			}
+			lastUsed = units.HumanDuration(duration) + " ago"
+		}
+
 		table.Append([]string{
 			modelName,
 			status.BackendName,
 			status.Mode,
-			units.HumanDuration(time.Since(status.LastUsed)) + " ago",
+			lastUsed,
 		})
 	}
 


### PR DESCRIPTION
Display "in use" instead of "292 years ago" when LastUsed is zero, which indicates the runner is currently serving requests. See the backend here: https://github.com/docker/model-runner/blob/b0b6ccc020210eec5042933a8a7c5ff0137f58f6/pkg/inference/scheduling/scheduler.go#L324.

Before:
```
$ docker model ps
MODEL NAME  BACKEND    MODE        LAST USED
smollm2     llama.cpp  completion  292 years ago
```

Now:
```
docker model ps
MODEL NAME  BACKEND    MODE        LAST USED
smollm2     llama.cpp  completion  in use
```

## Summary by Sourcery

Bug Fixes:
- Display "in use" when LastUsed timestamp is zero to indicate a runner is currently serving requests