### PR TITLE
docker ps sometimes lists years ago

### DIFF
--- a/cmd/cli/commands/ps.go
+++ b/cmd/cli/commands/ps.go
@@ -59,13 +59,22 @@ func psTable(ps []desktop.BackendStatus) string {
 			modelName = stripDefaultsFromModelName(modelName)
 		}
 
-		lastUsed := "in use"
-		if !status.LastUsed.IsZero() {
+		var lastUsed string
+		if status.InUse {
+			lastUsed = "in use"
+		} else if !status.LastUsed.IsZero() {
 			duration := time.Since(status.LastUsed)
 			if duration < 0 {
 				duration = 0
 			}
-			lastUsed = units.HumanDuration(duration) + " ago"
+			if duration < time.Second {
+				lastUsed = "just now"
+			} else {
+				lastUsed = units.HumanDuration(duration) + " ago"
+			}
+		} else {
+			// This case should not happen if InUse is properly set, but fallback to "in use" for zero time
+			lastUsed = "in use"
 		}
 
 		table.Append([]string{

--- a/cmd/cli/desktop/desktop.go
+++ b/cmd/cli/desktop/desktop.go
@@ -586,6 +586,8 @@ type BackendStatus struct {
 	Mode string `json:"mode"`
 	// LastUsed represents when this backend was last used (if it's idle)
 	LastUsed time.Time `json:"last_used,omitempty"`
+	// InUse indicates whether this backend is currently handling a request
+	InUse bool `json:"in_use,omitempty"`
 }
 
 func (c *Client) PS() ([]BackendStatus, error) {

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -64,6 +64,8 @@ type BackendStatus struct {
 	Mode string `json:"mode"`
 	// LastUsed represents when this (backend, model, mode) tuple was last used
 	LastUsed time.Time `json:"last_used,omitempty"`
+	// InUse indicates whether this backend is currently handling a request
+	InUse bool `json:"in_use,omitempty"`
 }
 
 // DiskUsage represents the disk usage of the models and default backend.

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -319,6 +319,7 @@ func (s *Scheduler) getLoaderStatus(ctx context.Context) []BackendStatus {
 				ModelName:   runnerInfo.modelRef,
 				Mode:        key.mode.String(),
 				LastUsed:    time.Time{},
+				InUse:       s.loader.references[runnerInfo.slot] > 0,
 			}
 
 			if s.loader.references[runnerInfo.slot] == 0 {


### PR DESCRIPTION
This should be more accurate

## Summary by Sourcery

Introduce an InUse indicator and leverage it in the ps command to accurately display backend usage status and avoid incorrect time computations.

New Features:
- Add an InUse flag to BackendStatus in both the CLI and scheduling API

Bug Fixes:
- Prevent ‘docker ps’ from showing large ‘years ago’ durations for backends with a zero LastUsed timestamp

Enhancements:
- Update the ps command to display ‘in use’ for active backends or as a fallback, and only compute humanized durations for idle backends