### PR TITLE
Second version of slack channel link that was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ MODEL_RUNNER_HOST=http://localhost:13434 ./model-cli list
 - [Model Runner Documentation](https://docs.docker.com/desktop/features/model-runner/)
 - [Model CLI README](./cmd/cli/README.md)
 - [Model Specification](https://github.com/docker/model-spec/blob/main/spec.md)
-- [Community Slack Channel](https://app.slack.com/client/T0JK1PCN6/C09H9P5E57B)
+- [Community Slack Channel](https://dockercommunity.slack.com/archives/C09H9P5E57B)
 
 ## Using the Makefile
 


### PR DESCRIPTION
Now it's fixed

## Summary by Sourcery

Documentation:
- Update the Community Slack Channel URL to the correct dockercommunity.slack.com address