### PR TITLE
The docker model status command was showing an invalid endpoint

### DIFF
--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -82,6 +82,14 @@ func jsonStatus(standalone *standaloneRunner, status desktop.Status, backendStat
 	case types.ModelRunnerEngineKindCloud:
 		fallthrough
 	case types.ModelRunnerEngineKindMoby:
+		if standalone.gatewayIP == "" {
+			standalone.gatewayIP = "127.0.0.1"
+		}
+
+		if standalone.gatewayPort == 0 {
+			standalone.gatewayPort = 12434
+		}
+
 		endpoint = fmt.Sprintf("http://%s:%d/engines/v1/", standalone.gatewayIP, standalone.gatewayPort)
 	default:
 		return fmt.Errorf("unhandled engine kind: %v", kind)


### PR DESCRIPTION
http://:0/engines/v1/ where the host was empty and the port was 0.