### PR TITLE
fix(scripts): skip getent on macOS in docker-run.sh

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -7,7 +7,11 @@ add_accelerators() {
       args+=("--device" "$i")
     fi
   done
-  args+=("--group-add" "$(getent group render | cut -d: -f3)")
+
+  # Add render group on Linux only (macOS doesn't have getent)
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    args+=("--group-add" "$(getent group render | cut -d: -f3)")
+  fi
 }
 
 add_optional_args() {


### PR DESCRIPTION
On macOS with Docker Desktop, Docker runs in a Linux VM so host-level device groups aren't relevant. This allows the script to work on both Linux and macOS.