### PR TITLE
chore(deps): organize dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,23 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      go-modules-root:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /cmd/cli
+    schedule:
+      interval: weekly
+    groups:
+      go-modules-cli:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yaml` configuration to group dependency updates by ecosystem and directory, making it easier to manage and review updates.