### PR TITLE
Provide clearer error message for unsupported platform in Install method

### DIFF
--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -70,7 +70,7 @@ func (v *vLLM) UsesExternalModelManagement() bool {
 
 func (v *vLLM) Install(_ context.Context, _ *http.Client) error {
 	if !platform.SupportsVLLM() {
-		return errors.New("not implemented")
+		return errors.New("vLLM backend is not yet supported on this platform")
 	}
 
 	vllmBinaryPath := v.binaryPath()


### PR DESCRIPTION
This pull request makes a minor improvement to the error message returned when the vLLM backend is not supported on the current platform. The new message is more descriptive, clarifying that the vLLM backend is not yet supported.