### PR TITLE
feat(vllm): handle binary not found

### DIFF
--- a/cmd/cli/commands/df.go
+++ b/cmd/cli/commands/df.go
@@ -17,8 +17,7 @@ func newDFCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			df, err := desktopClient.DF()
 			if err != nil {
-				err = handleClientError(err, "Failed to list running models")
-				return handleNotRunningError(err)
+				return handleClientError(err, "Failed to list running models")
 			}
 			cmd.Print(diskUsageTable(df))
 			return nil

--- a/cmd/cli/commands/inspect.go
+++ b/cmd/cli/commands/inspect.go
@@ -53,15 +53,13 @@ func inspectModel(args []string, openai bool, remote bool, desktopClient *deskto
 	if openai {
 		model, err := desktopClient.InspectOpenAI(modelName)
 		if err != nil {
-			err = handleClientError(err, "Failed to get model "+modelName)
-			return "", handleNotRunningError(err)
+			return "", handleClientError(err, "Failed to get model "+modelName)
 		}
 		return formatter.ToStandardJSON(model)
 	}
 	model, err := desktopClient.Inspect(modelName, remote)
 	if err != nil {
-		err = handleClientError(err, "Failed to get model "+modelName)
-		return "", handleNotRunningError(err)
+		return "", handleClientError(err, "Failed to get model "+modelName)
 	}
 	return formatter.ToStandardJSON(model)
 }

--- a/cmd/cli/commands/list.go
+++ b/cmd/cli/commands/list.go
@@ -60,15 +60,13 @@ func listModels(openai bool, desktopClient *desktop.Client, quiet bool, jsonForm
 	if openai {
 		models, err := desktopClient.ListOpenAI()
 		if err != nil {
-			err = handleClientError(err, "Failed to list models")
-			return "", handleNotRunningError(err)
+			return "", handleClientError(err, "Failed to list models")
 		}
 		return formatter.ToStandardJSON(models)
 	}
 	models, err := desktopClient.List()
 	if err != nil {
-		err = handleClientError(err, "Failed to list models")
-		return "", handleNotRunningError(err)
+		return "", handleClientError(err, "Failed to list models")
 	}
 
 	if modelFilter != "" {

--- a/cmd/cli/commands/ps.go
+++ b/cmd/cli/commands/ps.go
@@ -19,8 +19,7 @@ func newPSCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ps, err := desktopClient.PS()
 			if err != nil {
-				err = handleClientError(err, "Failed to list running models")
-				return handleNotRunningError(err)
+				return handleClientError(err, "Failed to list running models")
 			}
 			cmd.Print(psTable(ps))
 			return nil

--- a/cmd/cli/commands/pull.go
+++ b/cmd/cli/commands/pull.go
@@ -58,7 +58,7 @@ func pullModel(cmd *cobra.Command, desktopClient *desktop.Client, model string, 
 	}
 
 	if err != nil {
-		return handleNotRunningError(handleClientError(err, "Failed to pull model"))
+		return handleClientError(err, "Failed to pull model")
 	}
 
 	cmd.Println(response)

--- a/cmd/cli/commands/push.go
+++ b/cmd/cli/commands/push.go
@@ -45,7 +45,7 @@ func pushModel(cmd *cobra.Command, desktopClient *desktop.Client, model string) 
 	}
 
 	if err != nil {
-		return handleNotRunningError(handleClientError(err, "Failed to push model"))
+		return handleClientError(err, "Failed to push model")
 	}
 
 	cmd.Println(response)

--- a/cmd/cli/commands/requests.go
+++ b/cmd/cli/commands/requests.go
@@ -35,8 +35,7 @@ func newRequestsCmd() *cobra.Command {
 				if model != "" {
 					errMsg = errMsg + " for " + model
 				}
-				err = handleClientError(err, errMsg)
-				return handleNotRunningError(err)
+				return handleClientError(err, errMsg)
 			}
 			defer cancel()
 

--- a/cmd/cli/commands/rm.go
+++ b/cmd/cli/commands/rm.go
@@ -38,8 +38,7 @@ func newRemoveCmd() *cobra.Command {
 				cmd.Print(response)
 			}
 			if err != nil {
-				err = handleClientError(err, "Failed to remove model")
-				return handleNotRunningError(err)
+				return handleClientError(err, "Failed to remove model")
 			}
 			return nil
 		},

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -257,7 +257,7 @@ func generateInteractiveWithReadline(cmd *cobra.Command, desktopClient *desktop.
 				if errors.Is(err, context.Canceled) {
 					cmd.Println()
 				} else {
-					cmd.PrintErr(handleClientError(err, "Failed to generate a response"))
+					cmd.PrintErrln(handleClientError(err, "Failed to generate a response"))
 				}
 				sb.Reset()
 				continue
@@ -317,7 +317,7 @@ func generateInteractiveBasic(cmd *cobra.Command, desktopClient *desktop.Client,
 			if errors.Is(err, context.Canceled) {
 				fmt.Println("\nUse Ctrl + d or /bye to exit.")
 			} else {
-				cmd.PrintErr(handleClientError(err, "Failed to generate a response"))
+				cmd.PrintErrln(handleClientError(err, "Failed to generate a response"))
 			}
 			continue
 		}
@@ -628,17 +628,17 @@ func newRunCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to create Docker client: %w", err)
 				}
-				
+
 				// Run the NIM model
 				if err := runNIMModel(cmd.Context(), dockerClient, model, cmd); err != nil {
 					return fmt.Errorf("failed to run NIM model: %w", err)
 				}
-				
+
 				// If no prompt provided, enter interactive mode
 				if prompt == "" {
 					scanner := bufio.NewScanner(os.Stdin)
 					cmd.Println("Interactive chat mode started. Type '/bye' to exit.")
-					
+
 					for {
 						userInput, err := readMultilineInput(cmd, scanner)
 						if err != nil {
@@ -648,26 +648,26 @@ func newRunCmd() *cobra.Command {
 							}
 							return fmt.Errorf("Error reading input: %v", err)
 						}
-						
+
 						if strings.ToLower(strings.TrimSpace(userInput)) == "/bye" {
 							cmd.Println("Chat session ended.")
 							break
 						}
-						
+
 						if strings.TrimSpace(userInput) == "" {
 							continue
 						}
-						
+
 						if err := chatWithNIM(cmd, model, userInput); err != nil {
 							cmd.PrintErr(fmt.Errorf("failed to chat with NIM: %w", err))
 							continue
 						}
-						
+
 						cmd.Println()
 					}
 					return nil
 				}
-				
+
 				// Single prompt mode
 				if err := chatWithNIM(cmd, model, prompt); err != nil {
 					return fmt.Errorf("failed to chat with NIM: %w", err)
@@ -683,7 +683,7 @@ func newRunCmd() *cobra.Command {
 			_, err := desktopClient.Inspect(model, false)
 			if err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
-					return handleNotRunningError(handleClientError(err, "Failed to inspect model"))
+					return handleClientError(err, "Failed to inspect model")
 				}
 				cmd.Println("Unable to find model '" + model + "' locally. Pulling from the server.")
 				if err := pullModel(cmd, desktopClient, model, ignoreRuntimeMemoryCheck); err != nil {

--- a/cmd/cli/commands/unload.go
+++ b/cmd/cli/commands/unload.go
@@ -25,8 +25,7 @@ func newUnloadCmd() *cobra.Command {
 			}
 			unloadResp, err := desktopClient.Unload(desktop.UnloadRequest{All: all, Backend: backend, Models: normalizedModels})
 			if err != nil {
-				err = handleClientError(err, "Failed to unload models")
-				return handleNotRunningError(err)
+				return handleClientError(err, "Failed to unload models")
 			}
 			unloaded := unloadResp.UnloadedRunners
 			if unloaded == 0 {

--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -29,6 +29,8 @@ const (
 	vllmDir = "/opt/vllm-env/bin"
 )
 
+var StatusNotFound = errors.New("vLLM binary not found")
+
 // vLLM is the vLLM-based backend implementation.
 type vLLM struct {
 	// log is the associated logger.
@@ -76,7 +78,8 @@ func (v *vLLM) Install(_ context.Context, _ *http.Client) error {
 	vllmBinaryPath := v.binaryPath()
 	if _, err := os.Stat(vllmBinaryPath); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("vLLM binary not found at %s", vllmBinaryPath)
+			v.status = StatusNotFound.Error()
+			return StatusNotFound
 		}
 		return fmt.Errorf("failed to check vLLM binary: %w", err)
 	}

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -247,6 +247,8 @@ func (s *Scheduler) handleOpenAIInference(w http.ResponseWriter, r *http.Request
 			// shutting down (since that will also cancel the request context).
 			// Either way, provide a response, even if it's ignored.
 			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		} else if errors.Is(err, vllm.StatusNotFound) {
+			http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		} else {
 			http.Error(w, fmt.Errorf("backend installation failed: %w", err).Error(), http.StatusServiceUnavailable)
 		}


### PR DESCRIPTION
Record a `vLLM binary not found` status and show a hint on `docker model run`.

This can happen when somebody attempts to use a model for vLLM with DMR with the llama.cpp backend installed only with Docker CE.

The next improvement is to add a `--backend vllm` flag to `docker model install-runner`.

```
$ docker model run aistaging/smollm2-vllm hi
error response: status=412 body=vLLM binary not found


What's next:
    It looks like you're trying to use a model for vLLM → docker model install-runner --vllm
```