### PR TITLE
Speculative decoding support

### DIFF
--- a/cmd/cli/docs/reference/docker_model_compose_up.yaml
+++ b/cmd/cli/docs/reference/docker_model_compose_up.yaml
@@ -42,6 +42,35 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: speculative-draft-model
+      value_type: string
+      description: draft model for speculative decoding
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: speculative-min-acceptance-rate
+      value_type: float64
+      default_value: "0"
+      description: minimum acceptance rate for speculative decoding
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: speculative-num-tokens
+      value_type: int
+      default_value: "0"
+      description: number of tokens to predict speculatively
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: project-name
       value_type: string

--- a/cmd/cli/docs/reference/docker_model_configure.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure.yaml
@@ -1,7 +1,7 @@
 command: docker model configure
 short: Configure runtime options for a model
 long: Configure runtime options for a model
-usage: docker model configure [--context-size=<n>] MODEL [-- <runtime-flags...>]
+usage: docker model configure [--context-size=<n>] [--speculative-draft-model=<model>] MODEL [-- <runtime-flags...>]
 pname: docker model
 plink: docker_model.yaml
 options:
@@ -9,6 +9,35 @@ options:
       value_type: int64
       default_value: "-1"
       description: context size (in tokens)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: speculative-draft-model
+      value_type: string
+      description: draft model for speculative decoding
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: speculative-min-acceptance-rate
+      value_type: float64
+      default_value: "0"
+      description: minimum acceptance rate for speculative decoding
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: speculative-num-tokens
+      value_type: int
+      default_value: "0"
+      description: number of tokens to predict speculatively
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -37,9 +37,16 @@ func (m BackendMode) String() string {
 	}
 }
 
+type SpeculativeDecodingConfig struct {
+	DraftModel        string  `json:"draft_model,omitempty"`
+	NumTokens         int     `json:"num_tokens,omitempty"`
+	MinAcceptanceRate float64 `json:"min_acceptance_rate,omitempty"`
+}
+
 type BackendConfiguration struct {
-	ContextSize  int64    `json:"context-size,omitempty"`
-	RuntimeFlags []string `json:"runtime-flags,omitempty"`
+	ContextSize  int64                       `json:"context-size,omitempty"`
+	RuntimeFlags []string                    `json:"runtime-flags,omitempty"`
+	Speculative  *SpeculativeDecodingConfig `json:"speculative,omitempty"`
 }
 
 type RequiredMemory struct {

--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -2,6 +2,7 @@ package vllm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/docker/model-runner/pkg/diskusage"
+	"github.com/docker/model-runner/pkg/distribution/types"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/inference/models"
 	"github.com/docker/model-runner/pkg/inference/platform"
@@ -105,18 +107,45 @@ func (v *vLLM) Run(ctx context.Context, socket, model string, modelRef string, m
 		return fmt.Errorf("failed to get model: %w", err)
 	}
 
+	var draftBundle types.ModelBundle
+	if backendConfig != nil && backendConfig.Speculative != nil && backendConfig.Speculative.DraftModel != "" {
+		draftBundle, err = v.modelManager.GetBundle(backendConfig.Speculative.DraftModel)
+		if err != nil {
+			return fmt.Errorf("failed to get draft model: %w", err)
+		}
+	}
+
 	if err := os.RemoveAll(socket); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		v.log.Warnf("failed to remove socket file %s: %v\n", socket, err)
 		v.log.Warnln("vLLM may not be able to start")
 	}
 
-	// Get arguments from config
 	args, err := v.config.GetArgs(bundle, socket, mode, backendConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get vLLM arguments: %w", err)
 	}
 
-	// Add served model name
+	if draftBundle != nil && backendConfig != nil && backendConfig.Speculative != nil {
+		draftPath := draftBundle.SafetensorsPath()
+		if draftPath != "" {
+			// vLLM uses --speculative_config with a JSON string
+			// Dynamically construct JSON, omitting num_speculative_tokens if not set
+			speculativeConfigMap := map[string]interface{}{
+				"model": filepath.Dir(draftPath),
+			}
+			if backendConfig.Speculative.NumTokens > 0 {
+				speculativeConfigMap["num_speculative_tokens"] = backendConfig.Speculative.NumTokens
+			}
+			speculativeConfigBytes, err := json.Marshal(speculativeConfigMap)
+			if err != nil {
+				return fmt.Errorf("failed to marshal speculative config for vLLM: %w", err)
+			}
+			speculativeConfig := string(speculativeConfigBytes)
+			args = append(args, "--speculative_config", speculativeConfig)
+			args = append(args, "--use-v2-block-manager")
+		}
+	}
+
 	args = append(args, "--served-model-name", model, modelRef)
 
 	// Sanitize args for safe logging

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -88,8 +88,9 @@ type UnloadResponse struct {
 
 // ConfigureRequest specifies per-model runtime configuration options.
 type ConfigureRequest struct {
-	Model           string   `json:"model"`
-	ContextSize     int64    `json:"context-size,omitempty"`
-	RuntimeFlags    []string `json:"runtime-flags,omitempty"`
-	RawRuntimeFlags string   `json:"raw-runtime-flags,omitempty"`
+	Model           string                              `json:"model"`
+	ContextSize     int64                               `json:"context-size,omitempty"`
+	RuntimeFlags    []string                            `json:"runtime-flags,omitempty"`
+	RawRuntimeFlags string                              `json:"raw-runtime-flags,omitempty"`
+	Speculative     *inference.SpeculativeDecodingConfig `json:"speculative,omitempty"`
 }

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -427,6 +427,7 @@ func (s *Scheduler) Configure(w http.ResponseWriter, r *http.Request) {
 	var runnerConfig inference.BackendConfiguration
 	runnerConfig.ContextSize = configureRequest.ContextSize
 	runnerConfig.RuntimeFlags = runtimeFlags
+	runnerConfig.Speculative = configureRequest.Speculative
 
 	mode := inference.BackendModeCompletion
 	if slices.Contains(runnerConfig.RuntimeFlags, "--embeddings") {
@@ -462,26 +463,25 @@ func (s *Scheduler) GetAllActiveRunners() []metrics.ActiveRunner {
 	defer s.loader.unlock()
 
 	for _, backend := range runningBackends {
+		mode := parseBackendMode(backend.Mode)
 		// Find the runner slot for this backend/model combination
-		key := runnerKey{
-			backend: backend.BackendName,
-			modelID: backend.ModelName,
-			mode:    parseBackendMode(backend.Mode),
-		}
+		// We iterate through all runners since we don't know the draftModelID
+		for key, runnerInfo := range s.loader.runners {
+			if key.backend == backend.BackendName && key.modelID == backend.ModelName && key.mode == mode {
+				socket, err := RunnerSocketPath(runnerInfo.slot)
+				if err != nil {
+					s.log.Warnf("Failed to get socket path for runner %s/%s (%s): %v", backend.BackendName, backend.ModelName, key.modelID, err)
+					continue
+				}
 
-		if runnerInfo, exists := s.loader.runners[key]; exists {
-			socket, err := RunnerSocketPath(runnerInfo.slot)
-			if err != nil {
-				s.log.Warnf("Failed to get socket path for runner %s/%s (%s): %v", backend.BackendName, backend.ModelName, key.modelID, err)
-				continue
+				activeRunners = append(activeRunners, metrics.ActiveRunner{
+					BackendName: backend.BackendName,
+					ModelName:   backend.ModelName,
+					Mode:        backend.Mode,
+					Socket:      socket,
+				})
+				break // Found the runner, no need to continue iterating
 			}
-
-			activeRunners = append(activeRunners, metrics.ActiveRunner{
-				BackendName: backend.BackendName,
-				ModelName:   backend.ModelName,
-				Mode:        backend.Mode,
-				Socket:      socket,
-			})
 		}
 	}
 
@@ -500,16 +500,14 @@ func (s *Scheduler) GetLlamaCppSocket() (string, error) {
 	// Look for an active llama.cpp backend
 	for _, backend := range runningBackends {
 		if backend.BackendName == "llama.cpp" {
+			mode := parseBackendMode(backend.Mode)
 			// Find the runner slot for this backend/model combination
-			key := runnerKey{
-				backend: backend.BackendName,
-				modelID: backend.ModelName,
-				mode:    parseBackendMode(backend.Mode),
-			}
-
-			if runnerInfo, exists := s.loader.runners[key]; exists {
-				// Use the RunnerSocketPath function to get the socket path
-				return RunnerSocketPath(runnerInfo.slot)
+			// We iterate through all runners since we don't know the draftModelID
+			for key, runnerInfo := range s.loader.runners {
+				if key.backend == backend.BackendName && key.modelID == backend.ModelName && key.mode == mode {
+					// Use the RunnerSocketPath function to get the socket path
+					return RunnerSocketPath(runnerInfo.slot)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Speculative decoding

Howdy folks! I like speculative decoding and wanted to try it out with DMR, so i made a quick attempt at adding initial support for it for both the `llama.cpp` and `vllm` backends.

With the `llama.cpp` backend it does seem to work quite nicely, but i haven't tried on `vllm` yet.

I don't consider this to be done or anything, just let me know if this PR is of interest to the team and, if so,  what may need to be changed before it can be merged. 

Give it a try, let me know! :heart: 

### Example usage 
```sh
docker model configure \
    --speculative-draft-model "ai/llama3.2:1B-Q4_0" \
    --speculative-num-tokens 16 \
    --speculative-min-acceptance-rate 0.8 \
    ai/llama3.3:70B-Q4_K_M

docker model run ai/llama3.3:70B-Q4_K_M
```

### Example inference speed changes

Model tested: `ai/llama3.3:70B-Q4_K_M`

*without speculative decoding*
```sh 
time="2025-10-27T18:41:57Z" level=info msg="prompt eval time =    1630.37 ms /    43 tokens (   37.92 ms per token,    26.37 tokens per second)" component=llama.cpp
time="2025-10-27T18:41:57Z" level=info msg="       eval time =  300258.64 ms /  1483 tokens (  202.47 ms per token,     4.94 tokens per second)" component=llama.cpp
time="2025-10-27T18:41:57Z" level=info msg="      total time =  301889.01 ms /  1526 tokens" component=llama.cpp
```

*with speculative decoding (the config in the example above)*:
```sh
time="2025-10-27T18:54:18Z" level=info msg="prompt eval time =    1597.63 ms /    43 tokens (   37.15 ms per token,    26.91 tokens per second)" component=llama.cpp
time="2025-10-27T18:54:18Z" level=info msg="       eval time =  177347.45 ms /  1326 tokens (  133.75 ms per token,     7.48 tokens per second)" component=llama.cpp
time="2025-10-27T18:54:18Z" level=info msg="      total time =  178945.08 ms /  1369 tokens" component=llama.cpp
time="2025-10-27T18:54:18Z" level=info msg="draft acceptance rate = 0.76389 (  660 accepted /   864 generated)" component=llama.cpp
```

All tests done on a Framework Desktop 128gb (strix halo gpu) with the following prompt: "tell me a long story about sad computers"