### PR TITLE
Install vllm

### DIFF
--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -116,7 +116,7 @@ func ensureStandaloneRunnerAvailable(ctx context.Context, printer standalone.Sta
 	}
 
 	// Ensure that we have an up-to-date copy of the image.
-	if err := standalone.EnsureControllerImage(ctx, dockerClient, gpu, false, printer); err != nil {
+	if err := standalone.EnsureControllerImage(ctx, dockerClient, gpu, "", printer); err != nil {
 		return nil, fmt.Errorf("unable to pull latest standalone model runner image: %w", err)
 	}
 
@@ -136,7 +136,7 @@ func ensureStandaloneRunnerAvailable(ctx context.Context, printer standalone.Sta
 		port = standalone.DefaultControllerPortCloud
 		environment = "cloud"
 	}
-	if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, false, modelStorageVolume, printer, engineKind); err != nil {
+	if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, "", modelStorageVolume, printer, engineKind); err != nil {
 		return nil, fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 
@@ -166,7 +166,7 @@ type runnerOptions struct {
 	port            uint16
 	host            string
 	gpuMode         string
-	vllm            bool
+	backend         string
 	doNotTrack      bool
 	pullImage       bool
 	pruneContainers bool
@@ -255,14 +255,19 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions) error {
 		return fmt.Errorf("unknown GPU specification: %q", opts.gpuMode)
 	}
 
-	// Validate vLLM usage - only supported with CUDA
-	if opts.vllm && gpu != gpupkg.GPUSupportCUDA {
-		return fmt.Errorf("--vllm flag requires CUDA GPU support (--gpu=cuda or auto-detected CUDA)")
+	// Validate backend selection
+	if opts.backend != "" && opts.backend != "llama.cpp" && opts.backend != "vllm" {
+		return fmt.Errorf("unknown backend: %q (supported: llama.cpp, vllm)", opts.backend)
+	}
+
+	// Validate backend-GPU compatibility
+	if opts.backend == "vllm" && gpu != gpupkg.GPUSupportCUDA {
+		return fmt.Errorf("--backend vllm requires CUDA GPU support (--gpu=cuda or auto-detected CUDA)")
 	}
 
 	// Ensure that we have an up-to-date copy of the image, if requested.
 	if opts.pullImage {
-		if err := standalone.EnsureControllerImage(cmd.Context(), dockerClient, gpu, opts.vllm, cmd); err != nil {
+		if err := standalone.EnsureControllerImage(cmd.Context(), dockerClient, gpu, opts.backend, cmd); err != nil {
 			return fmt.Errorf("unable to pull latest standalone model runner image: %w", err)
 		}
 	}
@@ -273,7 +278,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions) error {
 		return fmt.Errorf("unable to initialize standalone model storage: %w", err)
 	}
 	// Create the model runner container.
-	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.vllm, modelStorageVolume, cmd, engineKind); err != nil {
+	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.backend, modelStorageVolume, cmd, engineKind); err != nil {
 		return fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 
@@ -285,7 +290,7 @@ func newInstallRunner() *cobra.Command {
 	var port uint16
 	var host string
 	var gpuMode string
-	var vllm bool
+	var backend string
 	var doNotTrack bool
 	c := &cobra.Command{
 		Use:   "install-runner",
@@ -295,7 +300,7 @@ func newInstallRunner() *cobra.Command {
 				port:            port,
 				host:            host,
 				gpuMode:         gpuMode,
-				vllm:            vllm,
+				backend:         backend,
 				doNotTrack:      doNotTrack,
 				pullImage:       true,
 				pruneContainers: false,
@@ -307,7 +312,7 @@ func newInstallRunner() *cobra.Command {
 		"Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)")
 	c.Flags().StringVar(&host, "host", "127.0.0.1", "Host address to bind Docker Model Runner")
 	c.Flags().StringVar(&gpuMode, "gpu", "auto", "Specify GPU support (none|auto|cuda|rocm|musa)")
-	c.Flags().BoolVar(&vllm, "vllm", false, "Use vLLM backend (requires CUDA GPU support)")
+	c.Flags().StringVar(&backend, "backend", "", "Specify backend (llama.cpp|vllm). Default: llama.cpp")
 	c.Flags().BoolVar(&doNotTrack, "do-not-track", false, "Do not track models usage in Docker Model Runner")
 	return c
 }

--- a/cmd/cli/commands/install-runner_test.go
+++ b/cmd/cli/commands/install-runner_test.go
@@ -59,7 +59,7 @@ func TestInstallRunnerCommandFlags(t *testing.T) {
 	cmd := newInstallRunner()
 
 	// Verify all expected flags exist
-	expectedFlags := []string{"port", "host", "gpu", "vllm", "do-not-track"}
+	expectedFlags := []string{"port", "host", "gpu", "backend", "do-not-track"}
 	for _, flagName := range expectedFlags {
 		if cmd.Flags().Lookup(flagName) == nil {
 			t.Errorf("Expected flag '--%s' not found", flagName)
@@ -67,38 +67,52 @@ func TestInstallRunnerCommandFlags(t *testing.T) {
 	}
 }
 
-func TestInstallRunnerVLLMFlag(t *testing.T) {
+func TestInstallRunnerBackendFlag(t *testing.T) {
 	cmd := newInstallRunner()
 
-	// Verify the --vllm flag exists
-	vllmFlag := cmd.Flags().Lookup("vllm")
-	if vllmFlag == nil {
-		t.Fatal("--vllm flag not found")
+	// Verify the --backend flag exists
+	backendFlag := cmd.Flags().Lookup("backend")
+	if backendFlag == nil {
+		t.Fatal("--backend flag not found")
 	}
 
 	// Verify the default value
-	if vllmFlag.DefValue != "false" {
-		t.Errorf("Expected default vllm value to be 'false', got '%s'", vllmFlag.DefValue)
+	if backendFlag.DefValue != "" {
+		t.Errorf("Expected default backend value to be empty, got '%s'", backendFlag.DefValue)
 	}
 
 	// Verify the flag type
-	if vllmFlag.Value.Type() != "bool" {
-		t.Errorf("Expected vllm flag type to be 'bool', got '%s'", vllmFlag.Value.Type())
+	if backendFlag.Value.Type() != "string" {
+		t.Errorf("Expected backend flag type to be 'string', got '%s'", backendFlag.Value.Type())
 	}
 
-	// Test setting the flag value
-	err := cmd.Flags().Set("vllm", "true")
+	// Test setting the flag to vllm
+	err := cmd.Flags().Set("backend", "vllm")
 	if err != nil {
-		t.Errorf("Failed to set vllm flag: %v", err)
+		t.Errorf("Failed to set backend flag: %v", err)
 	}
 
 	// Verify the value was set
-	vllmValue, err := cmd.Flags().GetBool("vllm")
+	backendValue, err := cmd.Flags().GetString("backend")
 	if err != nil {
-		t.Errorf("Failed to get vllm flag value: %v", err)
+		t.Errorf("Failed to get backend flag value: %v", err)
 	}
-	if !vllmValue {
-		t.Error("Expected vllm value to be true")
+	if backendValue != "vllm" {
+		t.Errorf("Expected backend value to be 'vllm', got '%s'", backendValue)
+	}
+
+	// Test setting the flag to llama.cpp
+	err = cmd.Flags().Set("backend", "llama.cpp")
+	if err != nil {
+		t.Errorf("Failed to set backend flag to llama.cpp: %v", err)
+	}
+
+	backendValue, err = cmd.Flags().GetString("backend")
+	if err != nil {
+		t.Errorf("Failed to get backend flag value: %v", err)
+	}
+	if backendValue != "llama.cpp" {
+		t.Errorf("Expected backend value to be 'llama.cpp', got '%s'", backendValue)
 	}
 }
 

--- a/cmd/cli/commands/reinstall-runner.go
+++ b/cmd/cli/commands/reinstall-runner.go
@@ -9,7 +9,7 @@ func newReinstallRunner() *cobra.Command {
 	var port uint16
 	var host string
 	var gpuMode string
-	var vllm bool
+	var backend string
 	var doNotTrack bool
 	c := &cobra.Command{
 		Use:   "reinstall-runner",
@@ -19,7 +19,7 @@ func newReinstallRunner() *cobra.Command {
 				port:            port,
 				host:            host,
 				gpuMode:         gpuMode,
-				vllm:            vllm,
+				backend:         backend,
 				doNotTrack:      doNotTrack,
 				pullImage:       true,
 				pruneContainers: true,
@@ -31,7 +31,7 @@ func newReinstallRunner() *cobra.Command {
 		"Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)")
 	c.Flags().StringVar(&host, "host", "127.0.0.1", "Host address to bind Docker Model Runner")
 	c.Flags().StringVar(&gpuMode, "gpu", "auto", "Specify GPU support (none|auto|cuda|musa)")
-	c.Flags().BoolVar(&vllm, "vllm", false, "Use vLLM backend (requires CUDA GPU support)")
+	c.Flags().StringVar(&backend, "backend", "", "Specify backend (llama.cpp|vllm). Default: llama.cpp")
 	c.Flags().BoolVar(&doNotTrack, "do-not-track", false, "Do not track models usage in Docker Model Runner")
 	return c
 }

--- a/cmd/cli/commands/reinstall-runner_test.go
+++ b/cmd/cli/commands/reinstall-runner_test.go
@@ -39,7 +39,7 @@ func TestReinstallRunnerCommandFlags(t *testing.T) {
 	cmd := newReinstallRunner()
 
 	// Verify all expected flags exist
-	expectedFlags := []string{"port", "host", "gpu", "vllm", "do-not-track"}
+	expectedFlags := []string{"port", "host", "gpu", "backend", "do-not-track"}
 	for _, flagName := range expectedFlags {
 		if cmd.Flags().Lookup(flagName) == nil {
 			t.Errorf("Expected flag '--%s' not found", flagName)

--- a/cmd/cli/commands/start-runner.go
+++ b/cmd/cli/commands/start-runner.go
@@ -8,7 +8,7 @@ import (
 func newStartRunner() *cobra.Command {
 	var port uint16
 	var gpuMode string
-	var vllm bool
+	var backend string
 	var doNotTrack bool
 	c := &cobra.Command{
 		Use:   "start-runner",
@@ -17,7 +17,7 @@ func newStartRunner() *cobra.Command {
 			return runInstallOrStart(cmd, runnerOptions{
 				port:       port,
 				gpuMode:    gpuMode,
-				vllm:       vllm,
+				backend:    backend,
 				doNotTrack: doNotTrack,
 				pullImage:  false,
 			})
@@ -27,7 +27,7 @@ func newStartRunner() *cobra.Command {
 	c.Flags().Uint16Var(&port, "port", 0,
 		"Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)")
 	c.Flags().StringVar(&gpuMode, "gpu", "auto", "Specify GPU support (none|auto|cuda|musa)")
-	c.Flags().BoolVar(&vllm, "vllm", false, "Use vLLM backend (requires CUDA GPU support)")
+	c.Flags().StringVar(&backend, "backend", "", "Specify backend (llama.cpp|vllm). Default: llama.cpp")
 	c.Flags().BoolVar(&doNotTrack, "do-not-track", false, "Do not track models usage in Docker Model Runner")
 	return c
 }

--- a/cmd/cli/docs/reference/docker_model_install-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_install-runner.yaml
@@ -6,6 +6,15 @@ usage: docker model install-runner
 pname: docker model
 plink: docker_model.yaml
 options:
+    - option: backend
+      value_type: string
+      description: 'Specify backend (llama.cpp|vllm). Default: llama.cpp'
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: do-not-track
       value_type: bool
       default_value: "false"
@@ -41,16 +50,6 @@ options:
       default_value: "0"
       description: |
         Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
-    - option: vllm
-      value_type: bool
-      default_value: "false"
-      description: Use vLLM backend (requires CUDA GPU support)
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
@@ -6,6 +6,15 @@ usage: docker model reinstall-runner
 pname: docker model
 plink: docker_model.yaml
 options:
+    - option: backend
+      value_type: string
+      description: 'Specify backend (llama.cpp|vllm). Default: llama.cpp'
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: do-not-track
       value_type: bool
       default_value: "false"
@@ -41,16 +50,6 @@ options:
       default_value: "0"
       description: |
         Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
-    - option: vllm
-      value_type: bool
-      default_value: "false"
-      description: Use vLLM backend (requires CUDA GPU support)
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/docker_model_start-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_start-runner.yaml
@@ -8,6 +8,15 @@ usage: docker model start-runner
 pname: docker model
 plink: docker_model.yaml
 options:
+    - option: backend
+      value_type: string
+      description: 'Specify backend (llama.cpp|vllm). Default: llama.cpp'
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: do-not-track
       value_type: bool
       default_value: "false"
@@ -33,16 +42,6 @@ options:
       default_value: "0"
       description: |
         Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
-    - option: vllm
-      value_type: bool
-      default_value: "false"
-      description: Use vLLM backend (requires CUDA GPU support)
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/model_install-runner.md
+++ b/cmd/cli/docs/reference/model_install-runner.md
@@ -7,11 +7,11 @@ Install Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default     | Description                                                                                            |
 |:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
+| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm). Default: llama.cpp                                                  |
 | `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa)                                                     |
 | `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
 | `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
-| `--vllm`         | `bool`   |             | Use vLLM backend (requires CUDA GPU support)                                                           |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_reinstall-runner.md
+++ b/cmd/cli/docs/reference/model_reinstall-runner.md
@@ -7,11 +7,11 @@ Reinstall Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default     | Description                                                                                            |
 |:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
+| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm). Default: llama.cpp                                                  |
 | `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|musa)                                                           |
 | `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
 | `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
-| `--vllm`         | `bool`   |             | Use vLLM backend (requires CUDA GPU support)                                                           |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_start-runner.md
+++ b/cmd/cli/docs/reference/model_start-runner.md
@@ -7,10 +7,10 @@ Start Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default | Description                                                                                            |
 |:-----------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------|
+| `--backend`      | `string` |         | Specify backend (llama.cpp\|vllm). Default: llama.cpp                                                  |
 | `--do-not-track` | `bool`   |         | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`  | Specify GPU support (none\|auto\|cuda\|musa)                                                           |
 | `--port`         | `uint16` | `0`     | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
-| `--vllm`         | `bool`   |         | Use vLLM backend (requires CUDA GPU support)                                                           |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -233,8 +233,8 @@ func isRootless(ctx context.Context, dockerClient *client.Client) bool {
 }
 
 // CreateControllerContainer creates and starts a controller container.
-func CreateControllerContainer(ctx context.Context, dockerClient *client.Client, port uint16, host string, environment string, doNotTrack bool, gpu gpupkg.GPUSupport, vllm bool, modelStorageVolume string, printer StatusPrinter, engineKind types.ModelRunnerEngineKind) error {
-	imageName := controllerImageName(gpu, vllm)
+func CreateControllerContainer(ctx context.Context, dockerClient *client.Client, port uint16, host string, environment string, doNotTrack bool, gpu gpupkg.GPUSupport, backend string, modelStorageVolume string, printer StatusPrinter, engineKind types.ModelRunnerEngineKind) error {
+	imageName := controllerImageName(gpu, backend)
 
 	// Set up the container configuration.
 	portStr := strconv.Itoa(int(port))

--- a/cmd/cli/pkg/standalone/controller_image.go
+++ b/cmd/cli/pkg/standalone/controller_image.go
@@ -20,17 +20,18 @@ func controllerImageVersion() string {
 	return defaultControllerImageVersion
 }
 
-func controllerImageVariant(detectedGPU gpupkg.GPUSupport, vllm bool) string {
+func controllerImageVariant(detectedGPU gpupkg.GPUSupport, backend string) string {
 	if variant, ok := os.LookupEnv("MODEL_RUNNER_CONTROLLER_VARIANT"); ok {
 		if variant == "cpu" || variant == "generic" {
 			return ""
 		}
 		return variant
 	}
-	// If vLLM is requested, return vllm-cuda variant
-	if vllm {
+	// If vLLM backend is requested, return vllm-cuda variant
+	if backend == "vllm" {
 		return "vllm-cuda"
 	}
+	// Default to llama.cpp backend behavior
 	switch detectedGPU {
 	case gpupkg.GPUSupportCUDA:
 		return "cuda"
@@ -51,6 +52,6 @@ func fmtControllerImageName(repo, version, variant string) string {
 	return tag
 }
 
-func controllerImageName(detectedGPU gpupkg.GPUSupport, vllm bool) string {
-	return fmtControllerImageName(ControllerImage, controllerImageVersion(), controllerImageVariant(detectedGPU, vllm))
+func controllerImageName(detectedGPU gpupkg.GPUSupport, backend string) string {
+	return fmtControllerImageName(ControllerImage, controllerImageVersion(), controllerImageVariant(detectedGPU, backend))
 }

--- a/cmd/cli/pkg/standalone/images.go
+++ b/cmd/cli/pkg/standalone/images.go
@@ -13,8 +13,8 @@ import (
 )
 
 // EnsureControllerImage ensures that the controller container image is pulled.
-func EnsureControllerImage(ctx context.Context, dockerClient client.ImageAPIClient, gpu gpupkg.GPUSupport, vllm bool, printer StatusPrinter) error {
-	imageName := controllerImageName(gpu, vllm)
+func EnsureControllerImage(ctx context.Context, dockerClient client.ImageAPIClient, gpu gpupkg.GPUSupport, backend string, printer StatusPrinter) error {
+	imageName := controllerImageName(gpu, backend)
 
 	// Perform the pull.
 	out, err := dockerClient.ImagePull(ctx, imageName, image.PullOptions{})


### PR DESCRIPTION
This pull request adds support for a new `--vllm` flag to the Docker Model Runner CLI commands (`install-runner`, `reinstall-runner`, and `start-runner`). The flag enables the use of the vLLM backend, but only when CUDA GPU support is available.