### PR TITLE
feat(cli): show context size in docker model ls

### DIFF
--- a/cmd/cli/commands/list.go
+++ b/cmd/cli/commands/list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -118,7 +119,7 @@ func prettyPrintModels(models []dmrm.Model) string {
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
 
-	table.SetHeader([]string{"MODEL NAME", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "CREATED", "SIZE"})
+	table.SetHeader([]string{"MODEL NAME", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "CREATED", "CONTEXT", "SIZE"})
 
 	table.SetBorder(false)
 	table.SetColumnSeparator("")
@@ -127,13 +128,14 @@ func prettyPrintModels(models []dmrm.Model) string {
 	table.SetNoWhiteSpace(true)
 
 	table.SetColumnAlignment([]int{
-		tablewriter.ALIGN_LEFT, // MODEL
-		tablewriter.ALIGN_LEFT, // PARAMETERS
-		tablewriter.ALIGN_LEFT, // QUANTIZATION
-		tablewriter.ALIGN_LEFT, // ARCHITECTURE
-		tablewriter.ALIGN_LEFT, // MODEL ID
-		tablewriter.ALIGN_LEFT, // CREATED
-		tablewriter.ALIGN_LEFT, // SIZE
+		tablewriter.ALIGN_LEFT,  // MODEL
+		tablewriter.ALIGN_LEFT,  // PARAMETERS
+		tablewriter.ALIGN_LEFT,  // QUANTIZATION
+		tablewriter.ALIGN_LEFT,  // ARCHITECTURE
+		tablewriter.ALIGN_LEFT,  // MODEL ID
+		tablewriter.ALIGN_LEFT,  // CREATED
+		tablewriter.ALIGN_RIGHT, // CONTEXT
+		tablewriter.ALIGN_LEFT,  // SIZE
 	})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 
@@ -158,6 +160,17 @@ func appendRow(table *tablewriter.Table, tag string, model dmrm.Model) {
 	}
 	// Strip default "ai/" prefix and ":latest" tag for display
 	displayTag := stripDefaultsFromModelName(tag)
+	contextSize := "-"
+	if model.Config.ContextSize != nil {
+		contextSize = fmt.Sprintf("%d", *model.Config.ContextSize)
+	} else if model.Config.GGUF != nil {
+		if v, ok := model.Config.GGUF["llama.context_length"]; ok {
+			if parsed, err := strconv.ParseUint(v, 10, 64); err == nil {
+				contextSize = fmt.Sprintf("%d", parsed)
+			}
+		}
+	}
+
 	table.Append([]string{
 		displayTag,
 		model.Config.Parameters,
@@ -165,6 +178,7 @@ func appendRow(table *tablewriter.Table, tag string, model dmrm.Model) {
 		model.Config.Architecture,
 		model.ID[7:19],
 		units.HumanDuration(time.Since(time.Unix(model.Created, 0))) + " ago",
+		contextSize,
 		model.Config.Size,
 	})
 }


### PR DESCRIPTION
  - Add a CONTEXT column to docker model ls so it’s easy to see each model’s window size.
  - Show the value from `config.context_size` when it exists, and fall back to `gguf["llama.context_length"]` for older models.
  - Right-align the new column so the table stays neat.

  ### Testing

  - `GOCACHE=/tmp/go-cache GOWORK=off go test ./...`
  - `docker model pull ai/smolvlm && make -C cmd/cli build && docker model ls`

  Closes #246.