### PR TITLE
Fix/store consistency

### DIFF
--- a/pkg/distribution/internal/store/blobs.go
+++ b/pkg/distribution/internal/store/blobs.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -180,15 +179,17 @@ func (s *LocalStore) writeConfigFile(mdl v1.Image) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("get digest: %w", err)
 	}
+	hasBlob, err := s.hasBlob(hash)
+	if err != nil {
+		return false, fmt.Errorf("check config existence: %w", err)
+	}
+	if hasBlob {
+		return false, nil
+	}
+
 	path, err := s.blobPath(hash)
 	if err != nil {
 		return false, fmt.Errorf("get blob path: %w", err)
-	}
-	if _, err := os.Stat(path); err == nil {
-		// Config already exists in the store.
-		return false, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, fmt.Errorf("stat config blob: %w", err)
 	}
 
 	rcf, err := mdl.RawConfigFile()

--- a/pkg/distribution/internal/store/store_test.go
+++ b/pkg/distribution/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/docker/model-runner/pkg/distribution/internal/partial"
 	"github.com/docker/model-runner/pkg/distribution/internal/store"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // TestStoreAPI tests the store API directly
@@ -462,6 +464,116 @@ func TestWriteRollsBackOnTagFailure(t *testing.T) {
 	if strings.Contains(string(content), digest.Hex) {
 		t.Fatalf("models index still references failed digest %s", digest.Hex)
 	}
+}
+
+func TestWriteRollsBackOnConfigFailure(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "store-config-failure")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storePath := filepath.Join(tempDir, "config-failure-store")
+	s, err := store.New(store.Options{RootPath: storePath})
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	mdl := newTestModel(t)
+	cfgFailModel := configErrorModel{ModelArtifact: mdl}
+
+	if err := s.Write(cfgFailModel, []string{"cfg-failure:latest"}, nil); err == nil {
+		t.Fatalf("expected write to fail due to config overwrite")
+	}
+
+	assertStoreClean(t, s, storePath, mdl)
+}
+
+func TestWriteRollsBackOnLayerFailure(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "store-layer-failure")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storePath := filepath.Join(tempDir, "layer-failure-store")
+	s, err := store.New(store.Options{RootPath: storePath})
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	mdl := newTestModel(t)
+	layers, err := mdl.Layers()
+	if err != nil {
+		t.Fatalf("Layers failed: %v", err)
+	}
+	if len(layers) == 0 {
+		t.Fatalf("expected at least one layer")
+	}
+	newHash, err := v1.NewHash("sha256:" + strings.Repeat("c", 64))
+	if err != nil {
+		t.Fatalf("failed to build hash: %v", err)
+	}
+	failing := failingLayer{Layer: layers[0], hash: newHash}
+	mdl = mutate.AppendLayers(mdl, failing)
+
+	if err := s.Write(mdl, []string{"layer-failure:latest"}, nil); err == nil {
+		t.Fatalf("expected write to fail due to layer overwrite")
+	}
+
+	assertStoreClean(t, s, storePath, mdl)
+}
+
+func assertStoreClean(t *testing.T, s *store.LocalStore, storePath string, mdl types.ModelArtifact) {
+	t.Helper()
+
+	if models, err := s.List(); err != nil {
+		t.Fatalf("List failed: %v", err)
+	} else if len(models) != 0 {
+		t.Fatalf("expected no models in store after failed write, found %d", len(models))
+	}
+
+	manifestDigest, err := mdl.Digest()
+	if err != nil {
+		t.Fatalf("Digest failed: %v", err)
+	}
+	manifestPath := filepath.Join(storePath, "manifests", manifestDigest.Algorithm, manifestDigest.Hex)
+	if _, err := os.Stat(manifestPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected manifest %s to be cleaned up, stat error: %v", manifestPath, err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(storePath, "models.json"))
+	if err != nil {
+		t.Fatalf("failed to read models index: %v", err)
+	}
+	if strings.Contains(string(content), manifestDigest.Hex) {
+		t.Fatalf("models index still references failed digest %s", manifestDigest.Hex)
+	}
+}
+
+type configErrorModel struct {
+	types.ModelArtifact
+}
+
+func (configErrorModel) RawConfigFile() ([]byte, error) {
+	return nil, fmt.Errorf("forced config failure")
+}
+
+type failingLayer struct {
+	v1.Layer
+	hash v1.Hash
+}
+
+func (f failingLayer) DiffID() (v1.Hash, error) {
+	return f.hash, nil
+}
+
+func (f failingLayer) Digest() (v1.Hash, error) {
+	return f.hash, nil
+}
+
+func (f failingLayer) Uncompressed() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("forced layer failure")
 }
 
 // TestIncompleteFileHandling tests that files are created with .incomplete suffix and renamed on success


### PR DESCRIPTION
  - make the store resilient to partial failures when writing models: the config, layers, manifest, and index now land only on success.
  - the new helper writes files through a temp-and-rename flow so updates are atomic, and Write/WriteLightweight capture cleanup actions if something fails mid-flight.
  - add `TestWriteRollsBackOnTagFailure` to prove that a broken tagging step leaves no blobs, manifests, or index entries behind.

  ### Testing

  - `GOCACHE=/tmp/go-cache GOWORK=off go test ./... `(full suite)
  - `GOCACHE=/tmp/go-cache GOWORK=off go test ./pkg/distribution/internal/store -run TestWriteRollsBackOnTagFailure -v` (explicit regression to show rollback works)

  Closes #267.