### PR TITLE
feat(cli): use git describe for dev build versions

### DIFF
--- a/cmd/cli/Makefile
+++ b/cmd/cli/Makefile
@@ -14,7 +14,7 @@ all: build
 
 build:
 	@echo "Building $(BINARY_NAME)..."
-	go build -ldflags="-s -w" -o $(BINARY_NAME) .
+	go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=$(shell git describe --tags --always --dirty)" -o $(BINARY_NAME) .
 
 link:
 	@if [ ! -f $(BINARY_NAME) ]; then \


### PR DESCRIPTION
This would show something like:
  - v1.2.3 (if on a tagged release)
  - v1.2.3-14-g2414721 (14 commits after v1.2.3)
  - 2414721 (just commit hash if no tags)
  - 2414721-dirty (if uncommitted changes)

E.g.,
```
$ make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=cmd/cli/v0.1.46-48-g9fb52f73-dirty" -o model-cli .
Using existing binary model-cli
Linking model-cli to Docker CLI plugins directory...
Link created: /Users/doringeman/.docker/cli-plugins/docker-model

$ docker model version
Docker Model Runner version cmd/cli/v0.1.46-48-g9fb52f73-dirty
Docker Engine Kind: Docker Desktop

$ git commit ...

$ make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=cmd/cli/v0.1.46-49-g857af9af" -o model-cli .
Using existing binary model-cli
Linking model-cli to Docker CLI plugins directory...
Link created: /Users/doringeman/.docker/cli-plugins/docker-model

$ docker model version
Docker Model Runner version cmd/cli/v0.1.46-49-g857af9af
Docker Engine Kind: Docker Desktop
```