### PR TITLE
feat(build): add vLLM Docker targets and improve build workflow

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 add_accelerators() {
+  # Add NVIDIA GPU support for CUDA variants
+  if [[ "${DOCKER_IMAGE-}" == *"-cuda" ]]; then
+    args+=("--gpus" "all" "--runtime=nvidia")
+  fi
+
   # Add GPU/accelerator devices if present
   for i in /dev/dri /dev/kfd /dev/accel /dev/davinci* /dev/devmm_svm /dev/hisi_hdc; do
     if [ -e "$i" ]; then


### PR DESCRIPTION
Add docker-build-vllm and docker-run-vllm targets with automatic GPU flag injection for CUDA images. Build for Docker server architecture and use recursive make for variable overrides.

E.g.,
```
$ make docker-run
docker buildx build --load --platform linux/amd64 --build-arg LLAMA_SERVER_VERSION=latest --build-arg LLAMA_SERVER_VARIANT=cpu --build-arg BASE_IMAGE=ubuntu:24.04 --target final-llamacpp -t docker/model-runner:latest .
```

```
$ make docker-run-vllm
docker buildx build --load --platform linux/amd64 --build-arg LLAMA_SERVER_VERSION=latest --build-arg LLAMA_SERVER_VARIANT=cuda --build-arg BASE_IMAGE=nvidia/cuda:12.9.0-runtime-ubuntu24.04 --target final-vllm -t docker/model-runner:latest-vllm-cuda .

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model ls
MODEL NAME  PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       CONTEXT  SIZE
smollm2     361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  7 months ago           256.35 MiB

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run aistaging/smollm2-vllm hi
Unable to find model 'aistaging/smollm2-vllm:latest' locally. Pulling from the server.
Downloaded 272.53MB of 272.53MB
Model pulled successfully
Hello there! I’m here to help with an interesting task. What can I assist you with?
```