### PR TITLE
fix(scripts): skip getent if it doesn't exist in docker-run.sh

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -13,9 +13,10 @@ add_accelerators() {
     fi
   done
 
-  # Add render group on Linux only (macOS doesn't have getent)
-  if [[ "$OSTYPE" != "darwin"* ]]; then
-    args+=("--group-add" "$(getent group render | cut -d: -f3)")
+  local render_gid
+  render_gid=$(command getent group render 2>/dev/null | cut -d: -f3)
+  if [[ -n "$render_gid" ]]; then
+    args+=("--group-add" "$render_gid")
   fi
 }
 


### PR DESCRIPTION
Addresses https://github.com/docker/model-runner/issues/306#issuecomment-3465906533.