### PR TITLE
refactor(standalone): display full pull progress on install-runner

### DIFF
--- a/cmd/cli/commands/inspect.go
+++ b/cmd/cli/commands/inspect.go
@@ -27,7 +27,7 @@ func newInspectCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 			if openai && remote {

--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -223,7 +223,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions) error {
 
 	// If pruning containers (reinstall), remove any existing model runner containers.
 	if opts.pruneContainers {
-		if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, false, cmd); err != nil {
+		if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, false, asPrinter(cmd)); err != nil {
 			return fmt.Errorf("unable to remove model runner container(s): %w", err)
 		}
 	} else {
@@ -271,18 +271,18 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions) error {
 
 	// Ensure that we have an up-to-date copy of the image, if requested.
 	if opts.pullImage {
-		if err := standalone.EnsureControllerImage(cmd.Context(), dockerClient, gpu, opts.backend, cmd); err != nil {
+		if err := standalone.EnsureControllerImage(cmd.Context(), dockerClient, gpu, opts.backend, asPrinter(cmd)); err != nil {
 			return fmt.Errorf("unable to pull latest standalone model runner image: %w", err)
 		}
 	}
 
 	// Ensure that we have a model storage volume.
-	modelStorageVolume, err := standalone.EnsureModelStorageVolume(cmd.Context(), dockerClient, cmd)
+	modelStorageVolume, err := standalone.EnsureModelStorageVolume(cmd.Context(), dockerClient, asPrinter(cmd))
 	if err != nil {
 		return fmt.Errorf("unable to initialize standalone model storage: %w", err)
 	}
 	// Create the model runner container.
-	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.backend, modelStorageVolume, cmd, engineKind); err != nil {
+	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.backend, modelStorageVolume, asPrinter(cmd), engineKind); err != nil {
 		return fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 

--- a/cmd/cli/commands/list.go
+++ b/cmd/cli/commands/list.go
@@ -34,7 +34,7 @@ func newListCmd() *cobra.Command {
 			// status if it won't corrupt machine-readable output.
 			var standaloneInstallPrinter standalone.StatusPrinter
 			if !jsonFormat && !openai && !quiet {
-				standaloneInstallPrinter = cmd
+				standaloneInstallPrinter = asPrinter(cmd)
 			}
 			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), standaloneInstallPrinter); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)

--- a/cmd/cli/commands/pull.go
+++ b/cmd/cli/commands/pull.go
@@ -28,7 +28,7 @@ func newPullCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 			return pullModel(cmd, desktopClient, args[0], ignoreRuntimeMemoryCheck)

--- a/cmd/cli/commands/push.go
+++ b/cmd/cli/commands/push.go
@@ -24,7 +24,7 @@ func newPushCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 			return pushModel(cmd, desktopClient, args[0])

--- a/cmd/cli/commands/requests.go
+++ b/cmd/cli/commands/requests.go
@@ -25,7 +25,7 @@ func newRequestsCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 

--- a/cmd/cli/commands/rm.go
+++ b/cmd/cli/commands/rm.go
@@ -25,7 +25,7 @@ func newRemoveCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 			response, err := desktopClient.Remove(args, force)

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -675,7 +675,7 @@ func newRunCmd() *cobra.Command {
 				return nil
 			}
 
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 

--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -3,8 +3,9 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/docker/model-runner/cmd/cli/pkg/types"
 	"os"
+
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
 
 	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
@@ -18,7 +19,7 @@ func newStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Check if the Docker Model Runner is running",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			standalone, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd)
+			standalone, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd))
 			if err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}

--- a/cmd/cli/commands/tag.go
+++ b/cmd/cli/commands/tag.go
@@ -26,7 +26,7 @@ func newTagCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), cmd); err != nil {
+			if _, err := ensureStandaloneRunnerAvailable(cmd.Context(), asPrinter(cmd)); err != nil {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 			return tagModel(cmd, desktopClient, args[0], args[1])

--- a/cmd/cli/commands/uninstall-runner.go
+++ b/cmd/cli/commands/uninstall-runner.go
@@ -38,20 +38,20 @@ func runUninstallOrStop(cmd *cobra.Command, opts cleanupOptions) error {
 	}
 
 	// Remove any model runner containers.
-	if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, false, cmd); err != nil {
+	if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, false, asPrinter(cmd)); err != nil {
 		return fmt.Errorf("unable to remove model runner container(s): %w", err)
 	}
 
 	// Remove model runner images, if requested.
 	if opts.removeImages {
-		if err := standalone.PruneControllerImages(cmd.Context(), dockerClient, cmd); err != nil {
+		if err := standalone.PruneControllerImages(cmd.Context(), dockerClient, asPrinter(cmd)); err != nil {
 			return fmt.Errorf("unable to remove model runner image(s): %w", err)
 		}
 	}
 
 	// Remove model storage, if requested.
 	if opts.models {
-		if err := standalone.PruneModelStorageVolumes(cmd.Context(), dockerClient, cmd); err != nil {
+		if err := standalone.PruneModelStorageVolumes(cmd.Context(), dockerClient, asPrinter(cmd)); err != nil {
 			return fmt.Errorf("unable to remove model storage volume(s): %w", err)
 		}
 	}

--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
 	"github.com/docker/model-runner/pkg/inference/backends/vllm"
+	"github.com/moby/term"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -37,6 +41,45 @@ func handleClientError(err error, message string) error {
 		return fmt.Errorf("%w\n%s", err, strings.TrimRight(buf.String(), "\n"))
 	}
 	return fmt.Errorf("%s: %w", message, err)
+}
+
+// commandPrinter wraps a cobra.Command to implement standalone.StatusPrinter
+type commandPrinter struct {
+	cmd *cobra.Command
+}
+
+// Printf implements StatusPrinter.Printf by delegating to cobra.Command.Printf
+func (cp *commandPrinter) Printf(format string, args ...any) {
+	cp.cmd.Printf(format, args...)
+}
+
+// Println implements StatusPrinter.Println by delegating to cobra.Command.Println
+func (cp *commandPrinter) Println(args ...any) {
+	cp.cmd.Println(args...)
+}
+
+// Write implements StatusPrinter.Write by delegating to cobra.Command's output writer
+func (cp *commandPrinter) Write(p []byte) (n int, err error) {
+	return cp.cmd.OutOrStdout().Write(p)
+}
+
+// GetFdInfo returns the file descriptor and terminal status of the command's output
+func (cp *commandPrinter) GetFdInfo() (fd uintptr, isTerminal bool) {
+	out := cp.cmd.OutOrStdout()
+
+	if file, ok := out.(*os.File); ok {
+		return term.GetFdInfo(file)
+	}
+
+	// For progress display, we care about whether stdout is a terminal
+	// Even if cobra wraps the output, checking os.Stdout directly is appropriate
+	// because that's where the visual progress bars should be displayed
+	return term.GetFdInfo(os.Stdout)
+}
+
+// asPrinter wraps a cobra.Command to implement standalone.StatusPrinter
+func asPrinter(cmd *cobra.Command) standalone.StatusPrinter {
+	return &commandPrinter{cmd: cmd}
 }
 
 // stripDefaultsFromModelName removes the default "ai/" prefix and ":latest" tag for display.

--- a/cmd/cli/go.mod
+++ b/cmd/cli/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-containerregistry v0.20.6
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.16
+	github.com/moby/term v0.5.2
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
@@ -85,7 +86,6 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/cmd/cli/pkg/standalone/status.go
+++ b/cmd/cli/pkg/standalone/status.go
@@ -6,6 +6,10 @@ type StatusPrinter interface {
 	Printf(format string, args ...any)
 	// Println should perform line-based printing.
 	Println(args ...any)
+	// Write implements io.Writer for stream-based output.
+	Write(p []byte) (n int, err error)
+	// GetFdInfo returns the file descriptor and terminal status for the output.
+	GetFdInfo() (fd uintptr, isTerminal bool)
 }
 
 // noopPrinter is used to silence auto-install progress if desired.
@@ -16,6 +20,16 @@ func (*noopPrinter) Printf(format string, args ...any) {}
 
 // Println implements StatusPrinter.Println.
 func (*noopPrinter) Println(args ...any) {}
+
+// Write implements StatusPrinter.Write.
+func (*noopPrinter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+// GetFdInfo implements StatusPrinter.GetFdInfo.
+func (*noopPrinter) GetFdInfo() (fd uintptr, isTerminal bool) {
+	return 0, false
+}
 
 // NoopPrinter returns a StatusPrinter that does nothing.
 func NoopPrinter() StatusPrinter {


### PR DESCRIPTION
Display the full progress of the `docker/model-runner` image pull.

Now:
<img width="700" height="273" alt="Screenshot 2025-11-03 at 16 53 26" src="https://github.com/user-attachments/assets/297910fe-9f99-40c5-830b-268840db0445" />
