### PR TITLE
fix(standalone): use StatusPrinter in tryGetBindAscendMounts

### DIFF
--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -58,6 +58,11 @@ func (cp *commandPrinter) Println(args ...any) {
 	cp.cmd.Println(args...)
 }
 
+// PrintErrf implements StatusPrinter.PrintErrf by delegating to cobra.Command.PrintErrf
+func (cp *commandPrinter) PrintErrf(format string, args ...any) {
+	cp.cmd.PrintErrf(format, args...)
+}
+
 // Write implements StatusPrinter.Write by delegating to cobra.Command's output writer
 func (cp *commandPrinter) Write(p []byte) (n int, err error) {
 	return cp.cmd.OutOrStdout().Write(p)

--- a/cmd/cli/pkg/standalone/status.go
+++ b/cmd/cli/pkg/standalone/status.go
@@ -2,10 +2,12 @@ package standalone
 
 // StatusPrinter is the interface used to print status updates.
 type StatusPrinter interface {
-	// Printf should perform formatted printing.
+	// Printf should perform formatted printing to stdout.
 	Printf(format string, args ...any)
-	// Println should perform line-based printing.
+	// Println should perform line-based printing to stdout.
 	Println(args ...any)
+	// PrintErrf should perform formatted printing to stderr.
+	PrintErrf(format string, args ...any)
 	// Write implements io.Writer for stream-based output.
 	Write(p []byte) (n int, err error)
 	// GetFdInfo returns the file descriptor and terminal status for the output.
@@ -20,6 +22,9 @@ func (*noopPrinter) Printf(format string, args ...any) {}
 
 // Println implements StatusPrinter.Println.
 func (*noopPrinter) Println(args ...any) {}
+
+// PrintErrf implements StatusPrinter.PrintErrf.
+func (*noopPrinter) PrintErrf(format string, args ...any) {}
 
 // Write implements StatusPrinter.Write.
 func (*noopPrinter) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
Replace `fmt` with `StatusPrinter`, print errors to stderr, and only show "NOT FOUND" messages when `DEBUG=1` is set.

<img width="717" height="393" alt="Screenshot 2025-11-03 at 17 24 21" src="https://github.com/user-attachments/assets/1cecd086-6f16-421c-9892-757e8edfbccd" />

@leo-pony We don't print such logs for other bind mounts we attempt. WDYT?