### PR TITLE
Initialize termenv with color caching for interactive terminals

### DIFF
--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/cmd/cli/readline"
+	"github.com/muesli/termenv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -715,6 +716,12 @@ func newRunCmd() *cobra.Command {
 
 			// Use enhanced readline-based interactive mode when terminal is available
 			if term.IsTerminal(int(os.Stdin.Fd())) {
+				// Initialize termenv with color caching before starting interactive session.
+				// This queries the terminal background color once and caches it, preventing
+				// OSC response sequences from appearing in stdin during the interactive loop.
+				termenv.SetDefaultOutput(
+					termenv.NewOutput(asPrinter(cmd), termenv.WithColorCache(true)),
+				)
 				return generateInteractiveWithReadline(cmd, desktopClient, model)
 			}
 

--- a/cmd/cli/go.mod
+++ b/cmd/cli/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/moby/term v0.5.2
+	github.com/muesli/termenv v0.16.0
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
@@ -90,7 +91,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect


### PR DESCRIPTION
I noticed the interactive CLI would often behave weirdly and also spill OSC codes into the input prompt, in particular `11;rgb:0000/0000/0000R`

This happens when using `WithAutoStyle` in glamour because it queries the terminal to find out the background color. The fix here is to cache the term color via termenv at the very start of the function

---

**Screenshot**
<img width="1287" height="722" alt="image" src="https://github.com/user-attachments/assets/6377279d-c30d-481f-8f64-742dbf890e45" />
