### PR TITLE
build: use PyPI installation for ARM64 vLLM instead of wheel URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,16 +92,16 @@ RUN mkdir -p /opt/vllm-env && chown -R modelrunner:modelrunner /opt/vllm-env
 
 USER modelrunner
 
-# Install uv and vLLM wheel as modelrunner user
+# Install uv and vLLM as modelrunner user
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
  && ~/.local/bin/uv venv --python /usr/bin/python3 /opt/vllm-env \
  && if [ "$TARGETARCH" = "amd64" ]; then \
       WHEEL_ARCH="manylinux1_x86_64"; \
+      WHEEL_URL="https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}%2B${VLLM_CUDA_VERSION}-${VLLM_PYTHON_TAG}-${WHEEL_ARCH}.whl"; \
+      ~/.local/bin/uv pip install --python /opt/vllm-env/bin/python "$WHEEL_URL"; \
     else \
-      WHEEL_ARCH="manylinux2014_aarch64"; \
-    fi \
- && WHEEL_URL="https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}%2B${VLLM_CUDA_VERSION}-${VLLM_PYTHON_TAG}-${WHEEL_ARCH}.whl" \
- && ~/.local/bin/uv pip install --python /opt/vllm-env/bin/python "$WHEEL_URL"
+      ~/.local/bin/uv pip install --python /opt/vllm-env/bin/python "vllm==${VLLM_VERSION}"; \
+    fi
 
 RUN /opt/vllm-env/bin/python -c "import vllm; print(vllm.__version__)" > /opt/vllm-env/version
 


### PR DESCRIPTION
The ARM64 wheel 0.11.0 is not available at the GitHub URL.