### PR TITLE
run: don't color code blocks by default

### DIFF
--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -744,7 +744,7 @@ func newRunCmd() *cobra.Command {
 
 	c.Flags().BoolVar(&debug, "debug", false, "Enable debug logging")
 	c.Flags().BoolVar(&ignoreRuntimeMemoryCheck, "ignore-runtime-memory-check", false, "Do not block pull if estimated runtime memory for model exceeds system resources.")
-	c.Flags().StringVar(&colorMode, "color", "auto", "Use colored output (auto|yes|no)")
+	c.Flags().StringVar(&colorMode, "color", "no", "Use colored output (auto|yes|no)")
 	c.Flags().BoolVarP(&detach, "detach", "d", false, "Load the model in the background without interaction")
 
 	return c

--- a/cmd/cli/docs/reference/docker_model_run.yaml
+++ b/cmd/cli/docs/reference/docker_model_run.yaml
@@ -12,7 +12,7 @@ plink: docker_model.yaml
 options:
     - option: color
       value_type: string
-      default_value: auto
+      default_value: "no"
       description: Use colored output (auto|yes|no)
       deprecated: false
       hidden: false

--- a/cmd/cli/docs/reference/model_run.md
+++ b/cmd/cli/docs/reference/model_run.md
@@ -7,7 +7,7 @@ Run a model and interact with it using a submitted prompt or chat mode
 
 | Name                            | Type     | Default | Description                                                                       |
 |:--------------------------------|:---------|:--------|:----------------------------------------------------------------------------------|
-| `--color`                       | `string` | `auto`  | Use colored output (auto\|yes\|no)                                                |
+| `--color`                       | `string` | `no`    | Use colored output (auto\|yes\|no)                                                |
 | `--debug`                       | `bool`   |         | Enable debug logging                                                              |
 | `-d`, `--detach`                | `bool`   |         | Load the model in the background without interaction                              |
 | `--ignore-runtime-memory-check` | `bool`   |         | Do not block pull if estimated runtime memory for model exceeds system resources. |


### PR DESCRIPTION
Do not color code blocks by default.

Before:
<img width="826" height="190" alt="Screenshot 2025-11-11 at 14 03 09" src="https://github.com/user-attachments/assets/acbb4f02-fe2b-47bc-a4a2-7bb4046cd71b" />


Now:
<img width="879" height="344" alt="Screenshot 2025-11-11 at 14 02 23" src="https://github.com/user-attachments/assets/8aeb4c3b-9462-47dc-9999-1699180eccc6" />

Attempt to solve https://github.com/docker/model-runner/issues/376.