### PR TITLE
fix: increase installation wait tries from 20 to 60

### DIFF
--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -21,7 +21,7 @@ import (
 const (
 	// installWaitTries controls how many times the automatic installation will
 	// try to reach the model runner while waiting for it to be ready.
-	installWaitTries = 20
+	installWaitTries = 60
 	// installWaitRetryInterval controls the interval at which automatic
 	// installation will try to reach the model runner while waiting for it to
 	// be ready.
@@ -138,7 +138,7 @@ func ensureStandaloneRunnerAvailable(ctx context.Context, printer standalone.Sta
 		port = standalone.DefaultControllerPortCloud
 		environment = "cloud"
 	}
-if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, "", modelStorageVolume, printer, engineKind, debug); err != nil {
+	if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, "", modelStorageVolume, printer, engineKind, debug); err != nil {
 		return nil, fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 


### PR DESCRIPTION
With current tries I usually get: 
```
Status: Downloaded newer image for docker/model-runner:latest-vllm-cuda
Successfully pulled docker/model-runner:latest-vllm-cuda
Creating model storage volume docker-model-runner-models...
Starting model runner container docker-model-runner...
standalone model runner took too long to initialize
```
This PR increases the timeout to 30 seconds to give it more chances to successfully start