### PR TITLE
feat: support vLLM on Docker Desktop w/ WSL2

### DIFF
--- a/cmd/cli/commands/uninstall-runner.go
+++ b/cmd/cli/commands/uninstall-runner.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/docker/model-runner/cmd/cli/pkg/types"
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -20,12 +20,16 @@ type cleanupOptions struct {
 func runUninstallOrStop(cmd *cobra.Command, opts cleanupOptions) error {
 	// Ensure that we're running in a supported model runner context.
 	if kind := modelRunner.EngineKind(); kind == types.ModelRunnerEngineKindDesktop {
-		// TODO: We may eventually want to auto-forward this to
-		// docker desktop disable model-runner, but we should first
-		// make install-runner forward in the same way.
-		cmd.Println("Standalone uninstallation not supported with Docker Desktop")
-		cmd.Println("Use `docker desktop disable model-runner` instead")
-		return nil
+		if desktop.IsDesktopWSLContext(cmd.Context(), dockerCLI) {
+			kind = types.ModelRunnerEngineKindMoby
+		} else {
+			// TODO: We may eventually want to auto-forward this to
+			// docker desktop disable model-runner, but we should first
+			// make install-runner forward in the same way.
+			cmd.Println("Standalone uninstallation not supported with Docker Desktop")
+			cmd.Println("Use `docker desktop disable model-runner` instead")
+			return nil
+		}
 	} else if kind == types.ModelRunnerEngineKindMobyManual {
 		cmd.Println("Standalone uninstallation not supported with MODEL_RUNNER_HOST set")
 		return nil


### PR DESCRIPTION
In order to test this you need to have Docker Model Runner running inside Docker Desktop for Windows w/ WSL2 backend and w/ an NVIDIA GPU.

Build:
```
make -C cmd/cli/ build
```

Install:
```
./cmd/cli/model-cli install-runner --backend vllm --gpu cuda
```

Check:
```
$ ./cmd/cli/model-cli status
Docker Model Runner is running

Status:
llama.cpp: running llama.cpp version: c22473b
vllm: running vllm version: 0.11.0
```

Run:
```
./cmd/cli/model-cli run ai/smollm2-vllm hi
```

Profit:
```
$ ./cmd/cli/model-cli run ai/smollm2-vllm hi
Hello! I'm sure everything goes smoothly here. How can I assist you today?
$ ./cmd/cli/model-cli run ai/smollm2-vllm "Capital of Romania?"
The capital of Romania is Bucharest.
```


This is the initial version of supporting containerized Docker Model Runner with vLLM support. This includes llama.cpp as well.
You must enable it using `install-runner --backend vllm --gpu cuda`, otherwise the host Docker Model Runner embedded in Docker Desktop will be used.

---

Troubleshooting:
If you hit `ValueError: Free memory on device (6.96/8.0 GiB) on startup is less than desired GPU memory utilization (0.9, 7.2 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes."`, you can use:
```
./cmd/cli/model-cli configure ai/smollm2-vllm -- --gpu-memory-utilization 0.5
```