### PR TITLE
Warn on platforms that vLLM is not implemented on yet

### DIFF
--- a/cmd/cli/desktop/progress.go
+++ b/cmd/cli/desktop/progress.go
@@ -69,6 +69,10 @@ func DisplayProgress(body io.Reader, printer standalone.StatusPrinter) (string, 
 			// Don't write the success message here - let the caller print it
 			// to avoid duplicate output
 
+		case "warning":
+			// Print warning to stderr
+			printer.PrintErrf("Warning: %s\n", progressMsg.Message)
+
 		case "error":
 			pw.Close()
 			return "", false, fmt.Errorf("%s", progressMsg.Message)
@@ -127,6 +131,10 @@ func displayProgressSimple(body io.Reader, printer standalone.StatusPrinter) (st
 
 		case "success":
 			finalMessage = progressMsg.Message
+
+		case "warning":
+			// Print warning to stderr
+			printer.PrintErrf("Warning: %s\n", progressMsg.Message)
 
 		case "error":
 			return "", false, fmt.Errorf("%s", progressMsg.Message)

--- a/pkg/distribution/distribution/errors.go
+++ b/pkg/distribution/distribution/errors.go
@@ -16,6 +16,6 @@ var (
 		"client supports only models of type %q and older - try upgrading",
 		types.MediaTypeModelConfigV01,
 	))
-	ErrUnsupportedFormat = errors.New("safetensors models are not currently supported - this runner only supports GGUF format models")
+	ErrUnsupportedFormat = errors.New("vLLM backend currently only implemented for x86_64 Nvidia platforms")
 	ErrConflict          = errors.New("resource conflict")
 )

--- a/pkg/distribution/internal/progress/reporter.go
+++ b/pkg/distribution/internal/progress/reporter.go
@@ -24,7 +24,7 @@ type Layer struct {
 
 // Message represents a structured message for progress reporting
 type Message struct {
-	Type    string `json:"type"`    // "progress", "success", or "error"
+	Type    string `json:"type"`    // "progress", "success", "warning", or "error"
 	Message string `json:"message"` // Deprecated: the message should be defined by clients based on Message.Total and Message.Layer
 	Total   uint64 `json:"total"`
 	Pulled  uint64 `json:"pulled"` // Deprecated: use Layer.Current
@@ -151,6 +151,14 @@ func WriteSuccess(w io.Writer, message string) error {
 func WriteError(w io.Writer, message string) error {
 	return write(w, Message{
 		Type:    "error",
+		Message: message,
+	})
+}
+
+// WriteWarning writes a warning message
+func WriteWarning(w io.Writer, message string) error {
+	return write(w, Message{
+		Type:    "warning",
 		Message: message,
 	})
 }

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -241,11 +241,8 @@ func (m *Manager) handleCreateModel(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Model not found", http.StatusNotFound)
 			return
 		}
-		if errors.Is(err, distribution.ErrUnsupportedFormat) {
-			m.log.Warnf("Unsupported model format for %q: %v", request.From, err)
-			http.Error(w, distribution.ErrUnsupportedFormat.Error(), http.StatusUnsupportedMediaType)
-			return
-		}
+		// Note: ErrUnsupportedFormat is no longer treated as an error - it's a warning
+		// that's sent to the client via the progress stream
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Instead of blocking. This will help users distribute vLLM models and implement vLLM for alternate platforms.