### PR TITLE
refactor: add optional maxLength parameter to SanitizeForLog

### DIFF
--- a/pkg/inference/backends/runner.go
+++ b/pkg/inference/backends/runner.go
@@ -60,7 +60,7 @@ func RunBackend(ctx context.Context, config RunnerConfig) error {
 	// Sanitize args for safe logging
 	sanitizedArgs := make([]string, len(config.Args))
 	for i, arg := range config.Args {
-		sanitizedArgs[i] = utils.SanitizeForLog(arg)
+		sanitizedArgs[i] = utils.SanitizeForLog(arg, 0)
 	}
 	config.Logger.Infof("%s args: %v", config.BackendName, sanitizedArgs)
 

--- a/pkg/internal/utils/log.go
+++ b/pkg/internal/utils/log.go
@@ -7,9 +7,11 @@ import (
 
 // SanitizeForLog sanitizes a string for safe logging by removing or escaping
 // control characters that could cause log injection attacks.
+// The optional maxLength parameter controls truncation (default: 100).
+// Pass 0 or negative to disable truncation.
 // TODO: Consider migrating to structured logging which
 // handles sanitization automatically through field encoding.
-func SanitizeForLog(s string) string {
+func SanitizeForLog(s string, maxLength ...int) string {
 	if s == "" {
 		return ""
 	}
@@ -42,9 +44,15 @@ func SanitizeForLog(s string) string {
 		}
 	}
 
-	const maxLength = 100
-	if result.Len() > maxLength {
-		return result.String()[:maxLength] + "...[truncated]"
+	// Default maxLength is 100, or use provided value.
+	// Pass 0 or negative to disable truncation.
+	maxLen := 100
+	if len(maxLength) > 0 {
+		maxLen = maxLength[0]
+	}
+
+	if maxLen > 0 && result.Len() > maxLen {
+		return result.String()[:maxLen] + "...[truncated]"
 	}
 
 	return result.String()


### PR DESCRIPTION
Defaults to 100 characters. Pass 0 to disable truncation.

Before:
```
llama.cpp args: [-ngl 999 --metrics --no-mmap --threads 5 --model /Users/doringeman/.docker/models/bundles/sha256/a15c3117eeeb36d0ae3cc5653dce80218ba971355ee51fa9abd3...[truncated] --host inference-runner-0.sock --ctx-size 4096 --jinja]
...
vLLM args: [serve /models/bundles/sha256/9749a463b5ad73fad92f25bdaa4d5bf36de45edb780020f62de8eee4e6241f9f/model --uds inference-runner-0.sock --hf_overrides {\"architectures\": [\"Qwen3ForSequenceClassification\"],\"classifier_from_token\": [\"no\", \"yes\"],\"is_orig...[truncated] --served-model-name sha256:9749a463b5ad73fad92f25bdaa4d5bf36de45edb780020f62de8eee4e6241f9f aistaging/qwen3-reranker-vllm:0.6B]
```

Now:
```
llama.cpp args: [-ngl 999 --metrics --no-mmap --threads 5 --model /Users/doringeman/.docker/models/bundles/sha256/a15c3117eeeb36d0ae3cc5653dce80218ba971355ee51fa9abd318d55c027405/model/model.gguf --host inference-runner-0.sock --ctx-size 4096 --jinja]
...
vLLM args: [serve /models/bundles/sha256/9749a463b5ad73fad92f25bdaa4d5bf36de45edb780020f62de8eee4e6241f9f/model --uds inference-runner-0.sock --hf_overrides {\"architectures\": [\"Qwen3ForSequenceClassification\"],\"classifier_from_token\": [\"no\", \"yes\"],\"is_original_qwen3_reranker\": true} --served-model-name sha256:9749a463b5ad73fad92f25bdaa4d5bf36de45edb780020f62de8eee4e6241f9f aistaging/qwen3-reranker-vllm:0.6B]
```