### PR TITLE
feat: add Docker CE installation test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LICENSE ?=
 BUILD_DMR ?= 1
 
 # Main targets
-.PHONY: build run clean test integration-tests docker-build docker-build-multiplatform docker-run docker-build-vllm docker-run-vllm docker-run-impl help validate model-distribution-tool
+.PHONY: build run clean test integration-tests test-docker-ce-installation docker-build docker-build-multiplatform docker-run docker-build-vllm docker-run-vllm docker-run-impl help validate model-distribution-tool
 # Default target
 .DEFAULT_GOAL := build
 
@@ -75,6 +75,11 @@ integration-tests:
 	fi
 	@BUILD_DMR=$(BUILD_DMR) go test -v -race -count=1 -tags=integration -run "^TestIntegration" -timeout=5m ./cmd/cli/commands
 	@echo "Integration tests completed!"
+
+test-docker-ce-installation:
+	@echo "Testing Docker CE installation..."
+	@echo "Note: This requires Docker to be running"
+	BASE_IMAGE=$(BASE_IMAGE) scripts/test-docker-ce-installation.sh
 
 validate:
 	find . -type f -name "*.sh" | grep -v pkg/go-containerregistry | xargs shellcheck
@@ -156,6 +161,8 @@ help:
 	@echo "  run				- Run the application locally"
 	@echo "  clean				- Clean build artifacts"
 	@echo "  test				- Run tests"
+	@echo "  integration-tests		- Run integration tests"
+	@echo "  test-docker-ce-installation	- Test Docker CE installation with CLI plugin"
 	@echo "  docker-build			- Build Docker image for current platform"
 	@echo "  docker-build-multiplatform	- Build Docker image for multiple platforms"
 	@echo "  docker-run			- Run in Docker container with TCP port access and mounted model storage"

--- a/scripts/test-docker-ce-in-container.sh
+++ b/scripts/test-docker-ce-in-container.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+echo "Installing curl..."
+apt-get update -qq 1>/dev/null
+apt-get install -y curl 1>/dev/null
+
+echo "Installing Docker CE..."
+curl -fsSL https://get.docker.com -o get-docker.sh
+sh get-docker.sh 1>/dev/null
+
+echo "Testing docker model version..."
+version_output=$(docker model version 2>&1 || true)
+echo "Output: $version_output"
+
+if echo "$version_output" | grep -q "version $EXPECTED_VERSION"; then
+  echo "✓ Success: Found expected version $EXPECTED_VERSION"
+  exit 0
+else
+  echo "✗ Error: Expected version $EXPECTED_VERSION not found in output"
+  exit 1
+fi

--- a/scripts/test-docker-ce-installation.sh
+++ b/scripts/test-docker-ce-installation.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+main() {
+  # Find the remote that points to docker/model-runner.
+  local remote
+  remote=$(git remote -v | awk '/docker\/model-runner/ && /\(fetch\)/ {print $1; exit}')
+
+  if [ -n "$remote" ]; then
+    echo "Fetching tags from $remote (docker/model-runner)..."
+    git fetch "$remote" --tags >/dev/null 2>&1 || echo "Warning: Failed to fetch tags from $remote. Continuing with local tags." >&2
+  else
+    echo "Warning: No remote found for docker/model-runner, using local tags only" >&2
+  fi
+
+  local cli_version
+  cli_version=$(git tag -l --sort=-version:refname "cmd/cli/v*" | head -1 | sed 's|^cmd/cli/||')
+
+  if [ -z "$cli_version" ]; then
+    echo "Error: Could not determine CLI version from git tags" >&2
+    exit 1
+  fi
+
+  echo "Testing Docker CE installation with expected CLI version: $cli_version"
+
+  if [ -z "${BASE_IMAGE:-}" ]; then
+    echo "Error: BASE_IMAGE is not set" >&2
+    exit 1
+  fi
+
+  echo "Using base image: $BASE_IMAGE"
+
+  echo "Starting container and installing Docker CE..."
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  docker run --rm \
+    -e "EXPECTED_VERSION=$cli_version" \
+    -v "$script_dir/test-docker-ce-in-container.sh:/test.sh:ro" \
+    "$BASE_IMAGE" \
+    /test.sh
+
+  echo "✓ Docker CE installation test passed!"
+}
+
+main "$@"


### PR DESCRIPTION
Add script and Makefile target to verify docker-model CLI plugin is bundled with Docker CE:
- Fetches tags from docker/model-runner remote
- Installs Docker CE in container using get.docker.com
- Verifies 'docker model version' matches latest CLI tag

```
$ make test-docker-ce-installation
Testing Docker CE installation...
Note: This requires Docker to be running
BASE_IMAGE=ubuntu:24.04 scripts/test-docker-ce-installation.sh
Fetching tags from origin (docker/model-runner)...
Testing Docker CE installation with expected CLI version: v1.0.1
Using base image: ubuntu:24.04
Starting container and installing Docker CE...
Installing curl...
debconf: delaying package configuration, since apt-utils is not installed
Installing Docker CE...
+ sh -c apt-get -qq update >/dev/null
+ sh -c DEBIAN_FRONTEND=noninteractive apt-get -y -qq install ca-certificates curl >/dev/null
+ sh -c install -m 0755 -d /etc/apt/keyrings
+ sh -c curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" -o /etc/apt/keyrings/docker.asc
+ sh -c chmod a+r /etc/apt/keyrings/docker.asc
+ sh -c echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" > /etc/apt/sources.list.d/docker.list
+ sh -c apt-get -qq update >/dev/null
+ sh -c DEBIAN_FRONTEND=noninteractive apt-get -y -qq install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras docker-buildx-plugin docker-model-plugin >/dev/null
debconf: delaying package configuration, since apt-utils is not installed
Testing docker model version...
Output: Docker Model Runner version v1.0.1
Docker Engine Kind: Docker Engine
✓ Success: Found expected version v1.0.1
✓ Docker CE installation test passed!
```