### PR TITLE
Fix go-containerregistry module path to resolve import issues

### DIFF
--- a/pkg/go-containerregistry/go.mod
+++ b/pkg/go-containerregistry/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-containerregistry
+module github.com/docker/model-runner/pkg/go-containerregistry
 
 go 1.24
 


### PR DESCRIPTION
For projects that use this as a library