### PR TITLE
feat: wake up idle Docker Cloud contexts automatically

### DIFF
--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -66,7 +66,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 
 			// Detect the model runner context and create a client for it.
 			var err error
-			modelRunner, err = desktop.DetectContext(cmd.Context(), dockerCLI)
+			modelRunner, err = desktop.DetectContext(cmd.Context(), dockerCLI, asPrinter(cmd))
 			if err != nil {
 				return fmt.Errorf("unable to detect model runner context: %w", err)
 			}


### PR DESCRIPTION
Detect and wake up idle Docker Cloud contexts during context detection.

---

```
make -C cmd/cli install
```

Before:
```
$ docker model ls
latest: Pulling from docker/model-runner
```

Now:
```
$ docker model ls
latest-cuda: Pulling from docker/model-runner
```