### PR TITLE
Use the latest vulkan packages from Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ARG LLAMA_SERVER_VERSION=latest
 ARG LLAMA_SERVER_VARIANT=cpu
 ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.${LLAMA_SERVER_VARIANT}.${TARGETARCH}
 
-# only 25.10 for cpu variant for max hardware support with vulkan
+# only 26.04 for cpu variant for max hardware support with vulkan
 # use 22.04 for gpu variants to match ROCm/CUDA base images
-ARG BASE_IMAGE=ubuntu:25.10
+ARG BASE_IMAGE=ubuntu:26.04
 
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS builder
 

--- a/llamacpp/native/generic.Dockerfile
+++ b/llamacpp/native/generic.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=ubuntu:25.10
+ARG BASE_IMAGE=ubuntu:26.04
 
 FROM ${BASE_IMAGE} AS builder
 


### PR DESCRIPTION
Users have noticed some AI-related optimizations from 25.10, as an exception, build on 26.04 for the Vulkan variant of our image.