### PR TITLE
feat: add configure flag to disable loader memory checks

### DIFF
--- a/cmd/cli/commands/configure.go
+++ b/cmd/cli/commands/configure.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/pkg/inference"
-
 	"github.com/docker/model-runner/pkg/inference/scheduling"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +16,15 @@ func newConfigureCmd() *cobra.Command {
 	var minAcceptanceRate float64
 
 	c := &cobra.Command{
-		Use:    "configure [--context-size=<n>] [--speculative-draft-model=<model>] MODEL [-- <runtime-flags...>]",
-		Short:  "Configure runtime options for a model",
+		Use:    "configure [--disable-loader-memory-check] [MODEL [--context-size=<n>] [--speculative-draft-model=<model>] [-- <runtime-flags...>]]",
+		Short:  "Configure runtime options globally or for a specific model",
 		Hidden: true,
 		Args: func(cmd *cobra.Command, args []string) error {
+			// If only setting global flags (like --disable-loader-memory-check), allow 0 args.
+			if opts.DisableLoaderMemoryCheck && len(args) == 0 {
+				return nil
+			}
+
 			argsBeforeDash := cmd.ArgsLenAtDash()
 			if argsBeforeDash == -1 {
 				// No "--" used, so we need exactly 1 total argument.
@@ -54,12 +58,13 @@ func newConfigureCmd() *cobra.Command {
 			}
 			return desktopClient.ConfigureBackend(opts)
 		},
-		ValidArgsFunction: completion.ModelNames(getDesktopClient, -1),
+		ValidArgsFunction: completion.ModelNames(getDesktopClient, 1),
 	}
 
 	c.Flags().Int64Var(&opts.ContextSize, "context-size", -1, "context size (in tokens)")
 	c.Flags().StringVar(&draftModel, "speculative-draft-model", "", "draft model for speculative decoding")
 	c.Flags().IntVar(&numTokens, "speculative-num-tokens", 0, "number of tokens to predict speculatively")
 	c.Flags().Float64Var(&minAcceptanceRate, "speculative-min-acceptance-rate", 0, "minimum acceptance rate for speculative decoding")
+	c.Flags().BoolVar(&opts.DisableLoaderMemoryCheck, "disable-loader-memory-check", false, "disable memory checks in the model loader")
 	return c
 }

--- a/cmd/cli/docs/reference/docker_model_configure.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure.yaml
@@ -1,7 +1,7 @@
 command: docker model configure
-short: Configure runtime options for a model
-long: Configure runtime options for a model
-usage: docker model configure [--context-size=<n>] [--speculative-draft-model=<model>] MODEL [-- <runtime-flags...>]
+short: Configure runtime options globally or for a specific model
+long: Configure runtime options globally or for a specific model
+usage: docker model configure [--disable-loader-memory-check] [MODEL [--context-size=<n>] [--speculative-draft-model=<model>] [-- <runtime-flags...>]]
 pname: docker model
 plink: docker_model.yaml
 options:
@@ -9,6 +9,16 @@ options:
       value_type: int64
       default_value: "-1"
       description: context size (in tokens)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: disable-loader-memory-check
+      value_type: bool
+      default_value: "false"
+      description: disable memory checks in the model loader
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/inference/memory/settings.go
+++ b/pkg/inference/memory/settings.go
@@ -1,18 +1,28 @@
 package memory
 
-import "sync"
+import "sync/atomic"
 
-var runtimeMemoryCheck bool
-var runtimeMemoryCheckLock sync.Mutex
+var runtimeMemoryCheck atomic.Bool
 
 func SetRuntimeMemoryCheck(enabled bool) {
-	runtimeMemoryCheckLock.Lock()
-	defer runtimeMemoryCheckLock.Unlock()
-	runtimeMemoryCheck = enabled
+	runtimeMemoryCheck.Store(enabled)
 }
 
 func RuntimeMemoryCheckEnabled() bool {
-	runtimeMemoryCheckLock.Lock()
-	defer runtimeMemoryCheckLock.Unlock()
-	return runtimeMemoryCheck
+	return runtimeMemoryCheck.Load()
+}
+
+var runtimeLoaderMemoryCheck atomic.Bool
+
+func init() {
+	// Loader memory checks are enabled by default to prevent OOM errors.
+	runtimeLoaderMemoryCheck.Store(true)
+}
+
+func SetRuntimeLoaderMemoryCheck(enabled bool) {
+	runtimeLoaderMemoryCheck.Store(enabled)
+}
+
+func RuntimeLoaderMemoryCheckEnabled() bool {
+	return runtimeLoaderMemoryCheck.Load()
 }

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -93,9 +93,10 @@ type UnloadResponse struct {
 
 // ConfigureRequest specifies per-model runtime configuration options.
 type ConfigureRequest struct {
-	Model           string                               `json:"model"`
-	ContextSize     int64                                `json:"context-size,omitempty"`
-	RuntimeFlags    []string                             `json:"runtime-flags,omitempty"`
-	RawRuntimeFlags string                               `json:"raw-runtime-flags,omitempty"`
-	Speculative     *inference.SpeculativeDecodingConfig `json:"speculative,omitempty"`
+	Model                    string                               `json:"model"`
+	ContextSize              int64                                `json:"context-size,omitempty"`
+	RuntimeFlags             []string                             `json:"runtime-flags,omitempty"`
+	RawRuntimeFlags          string                               `json:"raw-runtime-flags,omitempty"`
+	Speculative              *inference.SpeculativeDecodingConfig `json:"speculative,omitempty"`
+	DisableLoaderMemoryCheck bool                                 `json:"disable-loader-memory-check,omitempty"`
 }

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -435,6 +435,18 @@ func (s *Scheduler) Configure(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
+
+	// Handle loader memory check configuration (global setting)
+	if configureRequest.DisableLoaderMemoryCheck {
+		s.log.Infoln("Disabling loader memory checks")
+		memory.SetRuntimeLoaderMemoryCheck(false)
+		// If this is a global-only request (no model specified), return early
+		if configureRequest.Model == "" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+	}
+
 	var runtimeFlags []string
 	if len(configureRequest.RuntimeFlags) > 0 {
 		runtimeFlags = configureRequest.RuntimeFlags


### PR DESCRIPTION
Addresses https://github.com/docker/model-runner/issues/453.

Add `--disable-loader-memory-check` flag to `docker model configure` to allow bypassing memory validation in the model loader. This is useful for development and testing scenarios where memory constraints should be ignored.

The flag can be used standalone:
docker model configure --disable-loader-memory-check

Or combined with model-specific configuration:
docker model configure MODEL --context-size=8192 --disable-loader-memory-check