### PR TITLE
fix(context): pass an empty config to avoid panic

### DIFF
--- a/cmd/cli/desktop/context.go
+++ b/cmd/cli/desktop/context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/docker/api/types/container"
 	clientpkg "github.com/docker/docker/client"
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
 	"github.com/docker/model-runner/cmd/cli/pkg/types"
@@ -163,7 +164,7 @@ func wakeUpCloudIfIdle(ctx context.Context, cli *command.DockerCli) error {
 	// The call is expected to fail with a client error due to nil arguments, but it triggers
 	// Docker Cloud to wake up from idle. Only return unexpected failures (network issues,
 	// server errors) so they're logged as warnings.
-	_, err = dockerClient.ContainerCreate(ctx, nil, nil, nil, nil, "")
+	_, err = dockerClient.ContainerCreate(ctx, &container.Config{}, nil, nil, nil, "")
 	if err != nil && !errdefs.IsInvalidArgument(err) {
 		return fmt.Errorf("failed to wake up Docker Cloud: %w", err)
 	}


### PR DESCRIPTION
Fixes
```
$ docker model ls
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xd8 pc=0x102b4c540]

goroutine 1 [running]:
github.com/docker/docker/client.(*Client).ContainerCreate(0x140003ec000, {0x10375c7f8, 0x140004d8150}, 0x0, 0x0, 0x0, 0x0, {0x0, 0x0})
	/Users/doringeman/go/pkg/mod/github.com/docker/docker@v28.3.3+incompatible/client/container_create.go:78 +0x480
github.com/docker/model-runner/cmd/cli/desktop.wakeUpCloudIfIdle({0x10375c788?, 0x140004079f0?}, 0x14000354500)
	/Users/doringeman/workspace/model-runner/cmd/cli/desktop/context.go:166 +0x224
github.com/docker/model-runner/cmd/cli/desktop.DetectContext({0x10375c788, 0x140004079f0}, 0x14000354500, {0x10375f000, 0x14000196598})
	/Users/doringeman/workspace/model-runner/cmd/cli/desktop/context.go:207 +0xd8
github.com/docker/model-runner/cmd/cli/commands.NewRootCmd.func1(0x14000414008, {0x103feb7a0, 0x0, 0x0})
	/Users/doringeman/workspace/model-runner/cmd/cli/commands/root.go:63 +0x1d4
github.com/spf13/cobra.(*Command).execute(0x14000414008, {0x140004d4130, 0x0, 0x0})
	/Users/doringeman/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:986 +0x6c8
github.com/spf13/cobra.(*Command).ExecuteC(0x1400055a308)
	/Users/doringeman/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/doringeman/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
github.com/docker/cli/cli-plugins/plugin.RunPlugin(0x14000354500, 0x14000316c08, {{0x103108004, 0x5}, {0x103114d09, 0xb}, {0x10349d5c0, 0x13}, {0x0, 0x0}, ...})
	/Users/doringeman/go/pkg/mod/github.com/docker/cli@v28.3.0+incompatible/cli-plugins/plugin/plugin.go:80 +0xfc
main.run()
	/Users/doringeman/workspace/model-runner/cmd/cli/main.go:33 +0x130
main.main()
	/Users/doringeman/workspace/model-runner/cmd/cli/main.go:15 +0x1c
```