### PR TITLE
refactor(inference): add ParseBackendMode with reranking support

### DIFF
--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -40,6 +40,22 @@ func (m BackendMode) String() string {
 	}
 }
 
+// ParseBackendMode converts a string mode to BackendMode.
+// It returns the parsed mode and a boolean indicating if the mode was known.
+// For unknown modes, it returns BackendModeCompletion and false.
+func ParseBackendMode(mode string) (BackendMode, bool) {
+	switch mode {
+	case "completion":
+		return BackendModeCompletion, true
+	case "embedding":
+		return BackendModeEmbedding, true
+	case "reranking":
+		return BackendModeReranking, true
+	default:
+		return BackendModeCompletion, false
+	}
+}
+
 type SpeculativeDecodingConfig struct {
 	DraftModel        string  `json:"draft_model,omitempty"`
 	NumTokens         int     `json:"num_tokens,omitempty"`


### PR DESCRIPTION
Move parseBackendMode from scheduler.go to inference package as a public function. Adds missing support for parsing "reranking" mode string, ensuring all BackendMode values can be parsed.