### PR TITLE
feat(cli): add kind and endpointHost to docker model status --json

### DIFF
--- a/cmd/cli/commands/integration_test.go
+++ b/cmd/cli/commands/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
 	"github.com/docker/model-runner/pkg/distribution/builder"
 	"github.com/docker/model-runner/pkg/distribution/registry"
 	"github.com/stretchr/testify/require"
@@ -117,7 +118,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	registryURL := ociRegistry(t, ctx, net)
 	dmrURL := dockerModelRunner(t, ctx, net)
 
-	modelRunnerCtx, err := desktop.NewContextForTest(dmrURL, nil)
+	modelRunnerCtx, err := desktop.NewContextForTest(dmrURL, nil, types.ModelRunnerEngineKindMoby)
 	require.NoError(t, err, "Failed to create model runner context")
 
 	client := desktop.New(modelRunnerCtx)

--- a/cmd/cli/desktop/context.go
+++ b/cmd/cli/desktop/context.go
@@ -113,10 +113,10 @@ func NewContextForMock(client DockerHttpClient) *ModelRunnerContext {
 	}
 }
 
-// NewContextForTest creates a ModelRunnerContext for integration testing
-// with a custom URL endpoint. This is intended for use in integration tests
+// NewContextForTest creates a ModelRunnerContext for integration and mock testing
+// with a custom URL endpoint and engine kind. This is intended for use in tests
 // where the Model Runner endpoint is dynamically created (e.g., testcontainers).
-func NewContextForTest(endpoint string, client DockerHttpClient) (*ModelRunnerContext, error) {
+func NewContextForTest(endpoint string, client DockerHttpClient, kind types.ModelRunnerEngineKind) (*ModelRunnerContext, error) {
 	urlPrefix, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint URL: %w", err)
@@ -127,7 +127,7 @@ func NewContextForTest(endpoint string, client DockerHttpClient) (*ModelRunnerCo
 	}
 
 	return &ModelRunnerContext{
-		kind:      types.ModelRunnerEngineKindMoby,
+		kind:      kind,
 		urlPrefix: urlPrefix,
 		client:    client,
 	}, nil


### PR DESCRIPTION
- kind: deployment type (Docker Desktop, Docker Engine, Docker Cloud, Docker Engine (Manual Install))
- endpointHost: endpoint URL for host-to-model-runner communication
- endpoint: existing field, for container-to-model-runner communication

Addresses https://github.com/docker/model-runner/issues/446.

Note: The `"endpointHost`" in the Docker Desktop case is for the Docker UNIX socket (i.e., `/var/run/docker.sock`).