### PR TITLE
build(cli): filter git tags by cmd/cli prefix for version

### DIFF
--- a/cmd/cli/Makefile
+++ b/cmd/cli/Makefile
@@ -14,7 +14,7 @@ all: build
 
 build:
 	@echo "Building $(BINARY_NAME)..."
-	go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=$(shell git describe --tags --always --dirty)" -o $(BINARY_NAME) .
+	go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=$(shell git describe --tags --always --dirty --match "cmd/cli*" | sed 's|^cmd/cli/||')" -o $(BINARY_NAME) .
 
 link:
 	@if [ ! -f $(BINARY_NAME) ]; then \


### PR DESCRIPTION
Update build to match only cmd/cli/* tags and strip the prefix, allowing CLI-specific versioning.

Before:
```
$ make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=v1.0.9" -o model-cli .
...
```

Now:
```
$ make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=v1.0.4-2-gf12b17b-dirty" -o model-cli .
...
```