### PR TITLE
fix(inference): share single Manager instance between HTTPHandler and backends

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,13 +89,13 @@ func main() {
 		Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
 		Transport:     baseTransport,
 	}
+	modelManager := models.NewManager(log.WithFields(logrus.Fields{"component": "model-manager"}), clientConfig)
 	modelHandler := models.NewHTTPHandler(
 		log,
-		clientConfig,
+		modelManager,
 		nil,
 		memEstimator,
 	)
-	modelManager := models.NewManager(log.WithFields(logrus.Fields{"component": "model-manager"}), clientConfig)
 	log.Infof("LLAMA_SERVER_PATH: %s", llamaServerPath)
 
 	// Create llama.cpp configuration from environment variables

--- a/pkg/inference/models/http_handler.go
+++ b/pkg/inference/models/http_handler.go
@@ -56,13 +56,12 @@ type ClientConfig struct {
 }
 
 // NewHTTPHandler creates a new model's handler.
-func NewHTTPHandler(log logging.Logger, c ClientConfig, allowedOrigins []string, memoryEstimator memory.MemoryEstimator) *HTTPHandler {
-	// Create the manager.
+func NewHTTPHandler(log logging.Logger, manager *Manager, allowedOrigins []string, memoryEstimator memory.MemoryEstimator) *HTTPHandler {
 	m := &HTTPHandler{
 		log:             log,
 		router:          http.NewServeMux(),
 		memoryEstimator: memoryEstimator,
-		manager:         NewManager(log.WithFields(logrus.Fields{"component": "service"}), c),
+		manager:         manager,
 	}
 
 	// Register routes.


### PR DESCRIPTION
Previously, NewHTTPHandler created its own Manager internally, resulting in two separate store instances - one for HTTP requests and one for backends. This caused issues where purge operations would fail because the HTTPHandler's store was never properly initialized.

Now NewHTTPHandler accepts a Manager as a parameter, ensuring all components share the same store instance.