### PR TITLE
feat(cli): add --proxy-cert flag for proxy SSL inspection support

### DIFF
--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -138,7 +138,7 @@ func ensureStandaloneRunnerAvailable(ctx context.Context, printer standalone.Sta
 		port = standalone.DefaultControllerPortCloud
 		environment = "cloud"
 	}
-	if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, "", modelStorageVolume, printer, engineKind, debug, false); err != nil {
+	if err := standalone.CreateControllerContainer(ctx, dockerClient, port, host, environment, false, gpu, "", modelStorageVolume, printer, engineKind, debug, false, ""); err != nil {
 		return nil, fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 
@@ -172,6 +172,7 @@ type runnerOptions struct {
 	doNotTrack      bool
 	pullImage       bool
 	pruneContainers bool
+	proxyCert       string
 }
 
 // runInstallOrStart is shared logic for install-runner and start-runner commands
@@ -285,7 +286,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 		return fmt.Errorf("unable to initialize standalone model storage: %w", err)
 	}
 	// Create the model runner container.
-	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.backend, modelStorageVolume, asPrinter(cmd), engineKind, debug, vllmOnWSL); err != nil {
+	if err := standalone.CreateControllerContainer(cmd.Context(), dockerClient, port, opts.host, environment, opts.doNotTrack, gpu, opts.backend, modelStorageVolume, asPrinter(cmd), engineKind, debug, vllmOnWSL, opts.proxyCert); err != nil {
 		return fmt.Errorf("unable to initialize standalone model runner container: %w", err)
 	}
 
@@ -300,6 +301,7 @@ func newInstallRunner() *cobra.Command {
 	var backend string
 	var doNotTrack bool
 	var debug bool
+	var proxyCert string
 	c := &cobra.Command{
 		Use:   "install-runner",
 		Short: "Install Docker Model Runner (Docker Engine only)",
@@ -312,6 +314,7 @@ func newInstallRunner() *cobra.Command {
 				doNotTrack:      doNotTrack,
 				pullImage:       true,
 				pruneContainers: false,
+				proxyCert:       proxyCert,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
@@ -323,6 +326,7 @@ func newInstallRunner() *cobra.Command {
 		Backend:    &backend,
 		DoNotTrack: &doNotTrack,
 		Debug:      &debug,
+		ProxyCert:  &proxyCert,
 	})
 	return c
 }

--- a/cmd/cli/commands/reinstall-runner.go
+++ b/cmd/cli/commands/reinstall-runner.go
@@ -12,6 +12,7 @@ func newReinstallRunner() *cobra.Command {
 	var backend string
 	var doNotTrack bool
 	var debug bool
+	var proxyCert string
 	c := &cobra.Command{
 		Use:   "reinstall-runner",
 		Short: "Reinstall Docker Model Runner (Docker Engine only)",
@@ -24,6 +25,7 @@ func newReinstallRunner() *cobra.Command {
 				doNotTrack:      doNotTrack,
 				pullImage:       true,
 				pruneContainers: true,
+				proxyCert:       proxyCert,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
@@ -35,6 +37,7 @@ func newReinstallRunner() *cobra.Command {
 		Backend:    &backend,
 		DoNotTrack: &doNotTrack,
 		Debug:      &debug,
+		ProxyCert:  &proxyCert,
 	})
 	return c
 }

--- a/cmd/cli/commands/restart-runner.go
+++ b/cmd/cli/commands/restart-runner.go
@@ -11,6 +11,7 @@ func newRestartRunner() *cobra.Command {
 	var gpuMode string
 	var doNotTrack bool
 	var debug bool
+	var proxyCert string
 	c := &cobra.Command{
 		Use:   "restart-runner",
 		Short: "Restart Docker Model Runner (Docker Engine only)",
@@ -30,6 +31,7 @@ func newRestartRunner() *cobra.Command {
 				gpuMode:    gpuMode,
 				doNotTrack: doNotTrack,
 				pullImage:  false,
+				proxyCert:  proxyCert,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
@@ -40,6 +42,7 @@ func newRestartRunner() *cobra.Command {
 		GpuMode:    &gpuMode,
 		DoNotTrack: &doNotTrack,
 		Debug:      &debug,
+		ProxyCert:  &proxyCert,
 	})
 	return c
 }

--- a/cmd/cli/commands/start-runner.go
+++ b/cmd/cli/commands/start-runner.go
@@ -11,6 +11,7 @@ func newStartRunner() *cobra.Command {
 	var backend string
 	var doNotTrack bool
 	var debug bool
+	var proxyCert string
 	c := &cobra.Command{
 		Use:   "start-runner",
 		Short: "Start Docker Model Runner (Docker Engine only)",
@@ -21,6 +22,7 @@ func newStartRunner() *cobra.Command {
 				backend:    backend,
 				doNotTrack: doNotTrack,
 				pullImage:  false,
+				proxyCert:  proxyCert,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
@@ -31,6 +33,7 @@ func newStartRunner() *cobra.Command {
 		Backend:    &backend,
 		DoNotTrack: &doNotTrack,
 		Debug:      &debug,
+		ProxyCert:  &proxyCert,
 	})
 	return c
 }

--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -182,7 +182,7 @@ func requireMinArgs(n int, cmdName string, usageArgs string) cobra.PositionalArg
 	}
 }
 
-// runnerOptions holds common runner configuration options
+// runnerFlagOptions holds common runner configuration options
 type runnerFlagOptions struct {
 	Port       *uint16
 	Host       *string
@@ -190,6 +190,7 @@ type runnerFlagOptions struct {
 	Backend    *string
 	DoNotTrack *bool
 	Debug      *bool
+	ProxyCert  *string
 }
 
 // addRunnerFlags adds common runner flags to a command
@@ -212,5 +213,8 @@ func addRunnerFlags(cmd *cobra.Command, opts runnerFlagOptions) {
 	}
 	if opts.Debug != nil {
 		cmd.Flags().BoolVar(opts.Debug, "debug", false, "Enable debug logging")
+	}
+	if opts.ProxyCert != nil {
+		cmd.Flags().StringVar(opts.ProxyCert, "proxy-cert", "", "Path to a CA certificate file for proxy SSL inspection")
 	}
 }

--- a/cmd/cli/docs/reference/docker_model_install-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_install-runner.yaml
@@ -66,6 +66,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: proxy-cert
+      value_type: string
+      description: Path to a CA certificate file for proxy SSL inspection
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
@@ -66,6 +66,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: proxy-cert
+      value_type: string
+      description: Path to a CA certificate file for proxy SSL inspection
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/docker_model_restart-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_restart-runner.yaml
@@ -59,6 +59,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: proxy-cert
+      value_type: string
+      description: Path to a CA certificate file for proxy SSL inspection
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/docker_model_start-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_start-runner.yaml
@@ -58,6 +58,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: proxy-cert
+      value_type: string
+      description: Path to a CA certificate file for proxy SSL inspection
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/model_install-runner.md
+++ b/cmd/cli/docs/reference/model_install-runner.md
@@ -13,6 +13,7 @@ Install Docker Model Runner (Docker Engine only)
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
 | `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
 | `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
+| `--proxy-cert`   | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                 |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_reinstall-runner.md
+++ b/cmd/cli/docs/reference/model_reinstall-runner.md
@@ -13,6 +13,7 @@ Reinstall Docker Model Runner (Docker Engine only)
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
 | `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
 | `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
+| `--proxy-cert`   | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                 |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_restart-runner.md
+++ b/cmd/cli/docs/reference/model_restart-runner.md
@@ -12,6 +12,7 @@ Restart Docker Model Runner (Docker Engine only)
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
 | `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
 | `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
+| `--proxy-cert`   | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                 |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_start-runner.md
+++ b/cmd/cli/docs/reference/model_start-runner.md
@@ -12,6 +12,7 @@ Start Docker Model Runner (Docker Engine only)
 | `--do-not-track` | `bool`   |         | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`  | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
 | `--port`         | `uint16` | `0`     | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
+| `--proxy-cert`   | `string` |         | Path to a CA certificate file for proxy SSL inspection                                                 |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
Fixes https://github.com/docker/model-runner/issues/500.

Add support for corporate proxies that perform SSL interception allowing users to provide a CA certificate file.

The flag is available on install-runner, reinstall-runner, start-runner and restart-runner commands.                                                                                                                                                                             

When provided, the certificate is:                                                                                                                                                                       
- Mounted into the container
- Appended to the system CA bundle
- Container is restarted to apply the new CA certificates

### Test

- Run the proxy:
```
docker run --rm -it --name mitmproxy -p 0.0.0.0:8080:8080 mitmproxy/mitmproxy mitmdump
```

- Set `HTTP_PROXY` and `HTTPS_PROXY`:
E.g.,
```
export HTTP_PROXY=http://172.0.0.1:8080
export HTTPS_PROXY=http://172.0.0.1:8080
```

- Get the certificate:
```
docker cp mitmproxy:/home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem ./mitmproxy-ca.crt
```

- Install the new CLI of this PR:
```
make -C cmd/cli install
```

- Uninstall DMR:
```
docker model uninstall-runner
```

- Install DMR and provide the path to your proxy certificate:
```
docker model install-runner --proxy-cert $(pwd)/mitmproxy-ca.crt
```

<img width="1727" height="447" alt="Screenshot 2025-12-12 at 17 12 54" src="https://github.com/user-attachments/assets/3feea616-7c76-436d-ae6d-b953d931ff61" />