### PR TITLE
fix(cli): correct bench command usage to show MODEL as required

### DIFF
--- a/cmd/cli/commands/bench.go
+++ b/cmd/cli/commands/bench.go
@@ -57,7 +57,7 @@ func newBenchCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "bench [MODEL]",
+		Use:   "bench MODEL",
 		Short: "Benchmark a model's performance at different concurrency levels",
 		Long: `Benchmark a model's performance showing tokens per second at different concurrency levels.
 

--- a/cmd/cli/docs/reference/docker_model_bench.yaml
+++ b/cmd/cli/docs/reference/docker_model_bench.yaml
@@ -5,7 +5,7 @@ long: |-
 
     This command runs a series of benchmarks with 1, 2, 4, and 8 concurrent requests by default,
     measuring the tokens per second (TPS) that the model can generate.
-usage: docker model bench [MODEL]
+usage: docker model bench MODEL
 pname: docker model
 plink: docker_model.yaml
 options:


### PR DESCRIPTION
Correct `bench` command usage to show `MODEL` as required