### PR TITLE
chore(lint): enable gci formatter for import grouping

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,12 @@ formatters:
   enable:
     - gofmt
     - goimports
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard # stdlib
+        - default  # everything else
 
 linters:
   enable:

--- a/cmd/cli/commands/compose.go
+++ b/cmd/cli/commands/compose.go
@@ -9,15 +9,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/model-runner/cmd/cli/pkg/types"
-	"github.com/spf13/pflag"
-
 	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/inference/backends/llamacpp"
 	dmrm "github.com/docker/model-runner/pkg/inference/models"
 	"github.com/docker/model-runner/pkg/inference/scheduling"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func newComposeCmd() *cobra.Command {

--- a/cmd/cli/commands/inspect.go
+++ b/cmd/cli/commands/inspect.go
@@ -6,7 +6,6 @@ import (
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/commands/formatter"
 	"github.com/docker/model-runner/cmd/cli/desktop"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/commands/package.go
+++ b/cmd/cli/commands/package.go
@@ -10,18 +10,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/model-runner/cmd/cli/commands/completion"
+	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/pkg/distribution/builder"
 	"github.com/docker/model-runner/pkg/distribution/distribution"
 	"github.com/docker/model-runner/pkg/distribution/packaging"
 	"github.com/docker/model-runner/pkg/distribution/registry"
 	"github.com/docker/model-runner/pkg/distribution/tarball"
 	"github.com/docker/model-runner/pkg/distribution/types"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
-
-	"github.com/docker/model-runner/cmd/cli/commands/completion"
-	"github.com/docker/model-runner/cmd/cli/desktop"
 )
 
 // validateAbsolutePath validates that a path is absolute and returns the cleaned path

--- a/cmd/cli/commands/pull.go
+++ b/cmd/cli/commands/pull.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/commands/push.go
+++ b/cmd/cli/commands/push.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/commands/rm.go
+++ b/cmd/cli/commands/rm.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -15,9 +15,8 @@ import (
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/cmd/cli/readline"
-	"github.com/muesli/termenv"
-
 	"github.com/fatih/color"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )

--- a/cmd/cli/commands/unload.go
+++ b/cmd/cli/commands/unload.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/desktop/progress.go
+++ b/cmd/cli/desktop/progress.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-units"
-
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
 )
 

--- a/pkg/distribution/builder/builder.go
+++ b/pkg/distribution/builder/builder.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/gguf"
 	"github.com/docker/model-runner/pkg/distribution/internal/mutate"
 	"github.com/docker/model-runner/pkg/distribution/internal/partial"
 	"github.com/docker/model-runner/pkg/distribution/internal/safetensors"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 // Builder builds a model artifact

--- a/pkg/distribution/distribution/client.go
+++ b/pkg/distribution/distribution/client.go
@@ -9,9 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/docker/model-runner/pkg/internal/utils"
-	"github.com/sirupsen/logrus"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/progress"
 	"github.com/docker/model-runner/pkg/distribution/internal/store"
 	"github.com/docker/model-runner/pkg/distribution/registry"
@@ -20,6 +17,8 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/inference/platform"
+	"github.com/docker/model-runner/pkg/internal/utils"
+	"github.com/sirupsen/logrus"
 )
 
 // Client provides model distribution functionality

--- a/pkg/distribution/distribution/client_test.go
+++ b/pkg/distribution/distribution/client_test.go
@@ -16,17 +16,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
-	"github.com/sirupsen/logrus"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/gguf"
 	"github.com/docker/model-runner/pkg/distribution/internal/mutate"
 	"github.com/docker/model-runner/pkg/distribution/internal/progress"
 	"github.com/docker/model-runner/pkg/distribution/internal/safetensors"
 	mdregistry "github.com/docker/model-runner/pkg/distribution/registry"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/inference/platform"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/distribution/internal/gguf/create.go
+++ b/pkg/distribution/internal/gguf/create.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-	parser "github.com/gpustack/gguf-parser-go"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/partial"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
+	parser "github.com/gpustack/gguf-parser-go"
 )
 
 func NewModel(path string) (*Model, error) {

--- a/pkg/distribution/internal/mutate/model.go
+++ b/pkg/distribution/internal/mutate/model.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/docker/model-runner/pkg/distribution/internal/partial"
+	"github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	ggcrpartial "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
 	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	"github.com/docker/model-runner/pkg/distribution/internal/partial"
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 type model struct {

--- a/pkg/distribution/internal/mutate/mutate.go
+++ b/pkg/distribution/internal/mutate/mutate.go
@@ -1,10 +1,9 @@
 package mutate
 
 import (
+	"github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 func AppendLayers(mdl types.ModelArtifact, layers ...v1.Layer) types.ModelArtifact {

--- a/pkg/distribution/internal/mutate/mutate_test.go
+++ b/pkg/distribution/internal/mutate/mutate_test.go
@@ -5,12 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/static"
-	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/gguf"
 	"github.com/docker/model-runner/pkg/distribution/internal/mutate"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/static"
+	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 )
 
 func TestAppendLayer(t *testing.T) {

--- a/pkg/distribution/internal/partial/model.go
+++ b/pkg/distribution/internal/partial/model.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
 	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 // BaseModel provides a common implementation for model types.

--- a/pkg/distribution/internal/partial/partial.go
+++ b/pkg/distribution/internal/partial/partial.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
 	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 type WithRawConfigFile interface {

--- a/pkg/distribution/internal/progress/reporter_test.go
+++ b/pkg/distribution/internal/progress/reporter_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	v1types "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 // mockLayer implements v1.Layer for testing

--- a/pkg/distribution/internal/safetensors/create.go
+++ b/pkg/distribution/internal/safetensors/create.go
@@ -8,10 +8,9 @@ import (
 	"strconv"
 	"time"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/partial"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 var (

--- a/pkg/distribution/internal/store/blobs.go
+++ b/pkg/distribution/internal/store/blobs.go
@@ -12,7 +12,6 @@ import (
 	"unicode"
 
 	"github.com/docker/model-runner/pkg/distribution/internal/progress"
-
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 

--- a/pkg/distribution/internal/store/bundles.go
+++ b/pkg/distribution/internal/store/bundles.go
@@ -5,10 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/bundle"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 const (

--- a/pkg/distribution/internal/store/index.go
+++ b/pkg/distribution/internal/store/index.go
@@ -8,9 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
-
 	"github.com/docker/model-runner/pkg/distribution/registry"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 )
 
 // Index represents the index of all models in the store

--- a/pkg/distribution/internal/store/model.go
+++ b/pkg/distribution/internal/store/model.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"os"
 
+	mdpartial "github.com/docker/model-runner/pkg/distribution/internal/partial"
+	mdtypes "github.com/docker/model-runner/pkg/distribution/types"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
-
-	mdpartial "github.com/docker/model-runner/pkg/distribution/internal/partial"
-	mdtypes "github.com/docker/model-runner/pkg/distribution/types"
 )
 
 var _ v1.Image = &Model{}

--- a/pkg/distribution/internal/store/store.go
+++ b/pkg/distribution/internal/store/store.go
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"time"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/progress"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 const (

--- a/pkg/distribution/registry/client.go
+++ b/pkg/distribution/registry/client.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/model-runner/pkg/distribution/internal/progress"
+	"github.com/docker/model-runner/pkg/distribution/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote/transport"
-
-	"github.com/docker/model-runner/pkg/distribution/internal/progress"
-	"github.com/docker/model-runner/pkg/distribution/types"
 )
 
 const (

--- a/pkg/distribution/tarball/target.go
+++ b/pkg/distribution/tarball/target.go
@@ -7,10 +7,9 @@ import (
 	"io"
 	"path/filepath"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/progress"
 	"github.com/docker/model-runner/pkg/distribution/types"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 // Target stores an artifact as a TAR archive

--- a/pkg/distribution/tarball/target_test.go
+++ b/pkg/distribution/tarball/target_test.go
@@ -8,10 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
-
 	"github.com/docker/model-runner/pkg/distribution/internal/gguf"
 	"github.com/docker/model-runner/pkg/distribution/tarball"
+	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
 func TestTarget(t *testing.T) {

--- a/pkg/inference/backends/llamacpp/llamacpp_config_test.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/docker/model-runner/pkg/distribution/types"
-
 	"github.com/docker/model-runner/pkg/inference"
 )
 

--- a/pkg/inference/config/config.go
+++ b/pkg/inference/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/docker/model-runner/pkg/distribution/types"
-
 	"github.com/docker/model-runner/pkg/inference"
 )
 

--- a/pkg/inference/models/handler_test.go
+++ b/pkg/inference/models/handler_test.go
@@ -12,12 +12,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
-
 	"github.com/docker/model-runner/pkg/distribution/builder"
 	reg "github.com/docker/model-runner/pkg/distribution/registry"
+	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
 	"github.com/docker/model-runner/pkg/inference"
-
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Configure gci formatter in golangci-lint to enforce consistent import ordering with two groups: stdlib imports first, then all other imports.