### PR TITLE
Add openaiurl flag to list and run commands

### DIFF
--- a/cmd/cli/desktop/desktop.go
+++ b/cmd/cli/desktop/desktop.go
@@ -276,7 +276,7 @@ func (c *Client) List() ([]dmrm.Model, error) {
 }
 
 func (c *Client) ListOpenAI() (dmrm.OpenAIModelList, error) {
-	modelsRoute := inference.InferencePrefix + "/v1/models"
+	modelsRoute := c.modelRunner.OpenAIPathPrefix() + "/models"
 	body, err := c.listRaw(modelsRoute, "")
 	if err != nil {
 		return dmrm.OpenAIModelList{}, err
@@ -304,7 +304,7 @@ func (c *Client) Inspect(model string, remote bool) (dmrm.Model, error) {
 }
 
 func (c *Client) InspectOpenAI(model string) (dmrm.OpenAIModel, error) {
-	modelsRoute := inference.InferencePrefix + "/v1/models"
+	modelsRoute := c.modelRunner.OpenAIPathPrefix() + "/models"
 	rawResponse, err := c.listRaw(fmt.Sprintf("%s/%s", modelsRoute, model), model)
 	if err != nil {
 		return dmrm.OpenAIModel{}, err
@@ -398,7 +398,7 @@ func (c *Client) ChatWithContext(ctx context.Context, model, prompt string, imag
 		return fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	completionsPath := inference.InferencePrefix + "/v1/chat/completions"
+	completionsPath := c.modelRunner.OpenAIPathPrefix() + "/chat/completions"
 
 	resp, err := c.doRequestWithAuthContext(
 		ctx,

--- a/cmd/cli/docs/reference/docker_model_list.yaml
+++ b/cmd/cli/docs/reference/docker_model_list.yaml
@@ -26,6 +26,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: openaiurl
+      value_type: string
+      description: OpenAI-compatible API endpoint URL to list models from
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       shorthand: q
       value_type: bool

--- a/cmd/cli/docs/reference/docker_model_run.yaml
+++ b/cmd/cli/docs/reference/docker_model_run.yaml
@@ -41,6 +41,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: openaiurl
+      value_type: string
+      description: OpenAI-compatible API endpoint URL to chat with
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 examples: |-
     ### One-time prompt
 

--- a/cmd/cli/docs/reference/model_list.md
+++ b/cmd/cli/docs/reference/model_list.md
@@ -9,11 +9,12 @@ List the models pulled to your local environment
 
 ### Options
 
-| Name            | Type   | Default | Description                     |
-|:----------------|:-------|:--------|:--------------------------------|
-| `--json`        | `bool` |         | List models in a JSON format    |
-| `--openai`      | `bool` |         | List models in an OpenAI format |
-| `-q`, `--quiet` | `bool` |         | Only show model IDs             |
+| Name            | Type     | Default | Description                                            |
+|:----------------|:---------|:--------|:-------------------------------------------------------|
+| `--json`        | `bool`   |         | List models in a JSON format                           |
+| `--openai`      | `bool`   |         | List models in an OpenAI format                        |
+| `--openaiurl`   | `string` |         | OpenAI-compatible API endpoint URL to list models from |
+| `-q`, `--quiet` | `bool`   |         | Only show model IDs                                    |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_run.md
+++ b/cmd/cli/docs/reference/model_run.md
@@ -10,6 +10,7 @@ Run a model and interact with it using a submitted prompt or chat mode
 | `--color`        | `string` | `no`    | Use colored output (auto\|yes\|no)                   |
 | `--debug`        | `bool`   |         | Enable debug logging                                 |
 | `-d`, `--detach` | `bool`   |         | Load the model in the background without interaction |
+| `--openaiurl`    | `string` |         | OpenAI-compatible API endpoint URL to chat with      |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
The openaiurl flag enables users to connect to external
OpenAI-compatible API endpoints for both listing models and running chat
interactions. When this flag is specified, the commands will bypass the
local model runner and communicate directly with the provided endpoint.
The list command now supports filtering models from external endpoints,
and the run command supports both single prompt mode and interactive
mode with external endpoints.