### PR TITLE
Add conversation history support to chat modes

### DIFF
--- a/cmd/cli/readline/term.go
+++ b/cmd/cli/readline/term.go
@@ -29,9 +29,3 @@ func UnsetRawMode(fd uintptr, termios any) error {
 	t := termios.(*Termios)
 	return setTermios(fd, t)
 }
-
-// IsTerminal returns true if the given file descriptor is a terminal.
-func IsTerminal(fd uintptr) bool {
-	_, err := getTermios(fd)
-	return err == nil
-}

--- a/cmd/cli/readline/term_windows.go
+++ b/cmd/cli/readline/term_windows.go
@@ -8,13 +8,6 @@ type State struct {
 	mode uint32
 }
 
-// IsTerminal checks if the given file descriptor is associated with a terminal
-func IsTerminal(fd uintptr) bool {
-	var st uint32
-	err := windows.GetConsoleMode(windows.Handle(fd), &st)
-	return err == nil
-}
-
 func SetRawMode(fd uintptr) (*State, error) {
 	var st uint32
 	if err := windows.GetConsoleMode(windows.Handle(fd), &st); err != nil {


### PR DESCRIPTION
The interactive mode now maintains conversation context across chat
exchanges. The readline-based interactive mode was enhanced to track
conversation history and pass it to the model on each request. A new
ChatWithMessagesContext method was added to support conversation history
while maintaining backward compatibility through the existing
ChatWithContext method. The conversation history uses the processed user
messages after file inclusions and image processing to ensure accuracy.
Additionally, the code now properly handles context cancellation by
returning the assistant response when cancelled. The basic interactive
mode fallback was removed since readline initialization is now required.