### PR TITLE
Add ability to pull vllm-compatible hf models

### DIFF
--- a/pkg/distribution/huggingface/client.go
+++ b/pkg/distribution/huggingface/client.go
@@ -1,0 +1,192 @@
+package huggingface
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultBaseURL   = "https://huggingface.co"
+	defaultUserAgent = "model-distribution"
+)
+
+// Client handles HuggingFace Hub API interactions
+type Client struct {
+	httpClient *http.Client
+	userAgent  string
+	token      string
+	baseURL    string
+}
+
+// ClientOption configures a Client
+type ClientOption func(*Client)
+
+// WithToken sets the HuggingFace API token for authentication
+func WithToken(token string) ClientOption {
+	return func(c *Client) {
+		if token != "" {
+			c.token = token
+		}
+	}
+}
+
+// WithTransport sets the HTTP transport for the client
+func WithTransport(transport http.RoundTripper) ClientOption {
+	return func(c *Client) {
+		if transport != nil {
+			c.httpClient.Transport = transport
+		}
+	}
+}
+
+// WithUserAgent sets the User-Agent header for requests
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) {
+		if userAgent != "" {
+			c.userAgent = userAgent
+		}
+	}
+}
+
+// WithBaseURL sets a custom base URL (useful for testing)
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) {
+		if baseURL != "" {
+			c.baseURL = strings.TrimSuffix(baseURL, "/")
+		}
+	}
+}
+
+// NewClient creates a new HuggingFace Hub API client
+func NewClient(opts ...ClientOption) *Client {
+	c := &Client{
+		httpClient: &http.Client{},
+		userAgent:  defaultUserAgent,
+		baseURL:    defaultBaseURL,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ListFiles returns all files in a repository at a given revision
+func (c *Client) ListFiles(ctx context.Context, repo, revision string) ([]RepoFile, error) {
+	if revision == "" {
+		revision = "main"
+	}
+
+	// HuggingFace API endpoint for listing files
+	url := fmt.Sprintf("%s/api/models/%s/tree/%s", c.baseURL, repo, revision)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list files: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := c.checkResponse(resp, repo); err != nil {
+		return nil, err
+	}
+
+	var files []RepoFile
+	if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return files, nil
+}
+
+// DownloadFile streams a file from the repository
+// Returns the reader, content length (-1 if unknown), and any error
+func (c *Client) DownloadFile(ctx context.Context, repo, revision, filename string) (io.ReadCloser, int64, error) {
+	if revision == "" {
+		revision = "main"
+	}
+
+	// HuggingFace file download endpoint (handles LFS redirects automatically)
+	url := fmt.Sprintf("%s/%s/resolve/%s/%s", c.baseURL, repo, revision, filename)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("download file: %w", err)
+	}
+
+	if err := c.checkResponse(resp, repo); err != nil {
+		resp.Body.Close()
+		return nil, 0, err
+	}
+
+	return resp.Body, resp.ContentLength, nil
+}
+
+// setHeaders sets common headers for HuggingFace API requests
+func (c *Client) setHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", c.userAgent)
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}
+
+// checkResponse checks the HTTP response for errors
+func (c *Client) checkResponse(resp *http.Response, repo string) error {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return &AuthError{Repo: repo, StatusCode: resp.StatusCode}
+	case http.StatusNotFound:
+		return &NotFoundError{Repo: repo}
+	case http.StatusTooManyRequests:
+		return &RateLimitError{Repo: repo}
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// AuthError indicates authentication failure
+type AuthError struct {
+	Repo       string
+	StatusCode int
+}
+
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("authentication required for repository %q (status %d)", e.Repo, e.StatusCode)
+}
+
+// NotFoundError indicates the repository or file was not found
+type NotFoundError struct {
+	Repo string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("repository %q not found", e.Repo)
+}
+
+// RateLimitError indicates rate limiting
+type RateLimitError struct {
+	Repo string
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("rate limited while accessing repository %q", e.Repo)
+}

--- a/pkg/distribution/huggingface/client_test.go
+++ b/pkg/distribution/huggingface/client_test.go
@@ -1,0 +1,157 @@
+package huggingface
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClientListFiles(t *testing.T) {
+	// Mock HuggingFace API response
+	mockFiles := []RepoFile{
+		{Type: "file", Path: "model.safetensors", Size: 1000},
+		{Type: "file", Path: "config.json", Size: 100},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/test-org/test-model/tree/main" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(mockFiles)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	files, err := client.ListFiles(context.Background(), "test-org/test-model", "main")
+	if err != nil {
+		t.Fatalf("ListFiles failed: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("Expected 2 files, got %d", len(files))
+	}
+}
+
+func TestClientListFilesDefaultRevision(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the default revision is "main"
+		if !strings.Contains(r.URL.Path, "/tree/main") {
+			t.Errorf("Expected /tree/main in path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]RepoFile{})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	_, err := client.ListFiles(context.Background(), "test/model", "")
+	if err != nil {
+		t.Fatalf("ListFiles failed: %v", err)
+	}
+}
+
+func TestClientDownloadFile(t *testing.T) {
+	expectedContent := "test file content"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/test-org/test-model/resolve/main/test.txt" {
+			w.Header().Set("Content-Length", "17")
+			w.Write([]byte(expectedContent))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	reader, size, err := client.DownloadFile(context.Background(), "test-org/test-model", "main", "test.txt")
+	if err != nil {
+		t.Fatalf("DownloadFile failed: %v", err)
+	}
+	defer reader.Close()
+
+	if size != 17 {
+		t.Errorf("Expected size 17, got %d", size)
+	}
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if string(content) != expectedContent {
+		t.Errorf("Expected content %q, got %q", expectedContent, string(content))
+	}
+}
+
+func TestClientAuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	_, err := client.ListFiles(context.Background(), "private/model", "main")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Errorf("Expected AuthError, got %T", err)
+	}
+}
+
+func TestClientNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	_, err := client.ListFiles(context.Background(), "nonexistent/model", "main")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var notFoundErr *NotFoundError
+	if !errors.As(err, &notFoundErr) {
+		t.Errorf("Expected NotFoundError, got %T", err)
+	}
+}
+
+func TestClientWithToken(t *testing.T) {
+	var receivedToken string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedToken = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]RepoFile{})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithToken("test-token"),
+	)
+
+	_, err := client.ListFiles(context.Background(), "test/model", "main")
+	if err != nil {
+		t.Fatalf("ListFiles failed: %v", err)
+	}
+
+	if receivedToken != "Bearer test-token" {
+		t.Errorf("Expected 'Bearer test-token', got %q", receivedToken)
+	}
+}

--- a/pkg/distribution/huggingface/downloader.go
+++ b/pkg/distribution/huggingface/downloader.go
@@ -1,0 +1,221 @@
+package huggingface
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/docker/model-runner/pkg/distribution/internal/progress"
+)
+
+// Downloader manages file downloads from HuggingFace repositories
+type Downloader struct {
+	client   *Client
+	repo     string
+	revision string
+	tempDir  string
+}
+
+// NewDownloader creates a new downloader for a HuggingFace repository
+func NewDownloader(client *Client, repo, revision, tempDir string) *Downloader {
+	if revision == "" {
+		revision = "main"
+	}
+	return &Downloader{
+		client:   client,
+		repo:     repo,
+		revision: revision,
+		tempDir:  tempDir,
+	}
+}
+
+// DownloadResult contains the result of downloading files
+type DownloadResult struct {
+	// LocalPaths maps original repo paths to local file paths
+	LocalPaths map[string]string
+	// TotalBytes is the total number of bytes downloaded
+	TotalBytes int64
+}
+
+// syncWriter wraps an io.Writer with a mutex for thread-safe concurrent writes
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (sw *syncWriter) Write(p []byte) (n int, err error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.w.Write(p)
+}
+
+// fileIDFromPath generates a unique ID for a file based on its path
+// Returns a sha256: prefixed hash to match layer ID format
+func fileIDFromPath(path string) string {
+	hash := sha256.Sum256([]byte(path))
+	return "sha256:" + hex.EncodeToString(hash[:])
+}
+
+// DownloadAll downloads all specified files with progress reporting
+// Files are downloaded in parallel with per-file progress updates written to progressWriter
+func (d *Downloader) DownloadAll(ctx context.Context, files []RepoFile, progressWriter io.Writer) (*DownloadResult, error) {
+	if len(files) == 0 {
+		return &DownloadResult{LocalPaths: make(map[string]string)}, nil
+	}
+
+	totalSize := TotalSize(files)
+
+	// Create result map (thread-safe access)
+	var mu sync.Mutex
+	localPaths := make(map[string]string, len(files))
+
+	// Create thread-safe writer for concurrent progress reporting
+	var safeWriter io.Writer
+	if progressWriter != nil {
+		safeWriter = &syncWriter{w: progressWriter}
+	}
+
+	// Download files in parallel (limit concurrency to avoid overwhelming)
+	const maxConcurrent = 4
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(files))
+
+	for _, file := range files {
+		wg.Add(1)
+		go func(f RepoFile) {
+			defer wg.Done()
+
+			// Acquire semaphore
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			}
+			defer func() { <-sem }()
+
+			localPath, err := d.downloadFileWithProgress(ctx, f, uint64(totalSize), safeWriter)
+			if err != nil {
+				errChan <- fmt.Errorf("download %s: %w", f.Path, err)
+				return
+			}
+
+			mu.Lock()
+			localPaths[f.Path] = localPath
+			mu.Unlock()
+		}(file)
+	}
+
+	// Wait for all downloads to complete
+	wg.Wait()
+	close(errChan)
+
+	// Collect any errors
+	var errs []error
+	for err := range errChan {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("download errors: %v", errs)
+	}
+
+	// Calculate total downloaded
+	var totalDownloaded int64
+	for _, f := range files {
+		totalDownloaded += f.ActualSize()
+	}
+
+	return &DownloadResult{
+		LocalPaths: localPaths,
+		TotalBytes: totalDownloaded,
+	}, nil
+}
+
+// downloadFileWithProgress downloads a single file with progress reporting
+func (d *Downloader) downloadFileWithProgress(ctx context.Context, file RepoFile, totalImageSize uint64, progressWriter io.Writer) (string, error) {
+	// Create local file path (preserve directory structure)
+	localPath := filepath.Join(d.tempDir, file.Path)
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return "", fmt.Errorf("create directory: %w", err)
+	}
+
+	// Download from HuggingFace
+	reader, _, err := d.client.DownloadFile(ctx, d.repo, d.revision, file.Path)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	// Create local file
+	f, err := os.Create(localPath)
+	if err != nil {
+		return "", fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	// Generate unique ID for this file (for progress tracking)
+	fileID := fileIDFromPath(file.Path)
+	fileSize := uint64(file.ActualSize())
+
+	// Copy with progress tracking
+	pr := &progressReader{
+		reader:         reader,
+		progressWriter: progressWriter,
+		totalImageSize: totalImageSize,
+		fileSize:       fileSize,
+		fileID:         fileID,
+	}
+
+	if _, err := io.Copy(f, pr); err != nil {
+		os.Remove(localPath) // Clean up on error
+		return "", fmt.Errorf("write file: %w", err)
+	}
+
+	// Write final progress for this file (100% complete)
+	if progressWriter != nil {
+		_ = progress.WriteProgress(progressWriter, "", totalImageSize, fileSize, fileSize, fileID)
+	}
+
+	return localPath, nil
+}
+
+// progressReader wraps a reader and reports per-file progress
+type progressReader struct {
+	reader         io.Reader
+	progressWriter io.Writer
+	totalImageSize uint64
+	fileSize       uint64
+	fileID         string
+	bytesRead      uint64
+	lastReported   uint64
+}
+
+func (pr *progressReader) Read(p []byte) (n int, err error) {
+	n, err = pr.reader.Read(p)
+	if n > 0 {
+		pr.bytesRead += uint64(n)
+
+		// Report progress periodically (every 1MB or when complete)
+		if pr.progressWriter != nil && (pr.bytesRead-pr.lastReported >= progress.MinBytesForUpdate || pr.bytesRead == pr.fileSize) {
+			_ = progress.WriteProgress(pr.progressWriter, "", pr.totalImageSize, pr.fileSize, pr.bytesRead, pr.fileID)
+			pr.lastReported = pr.bytesRead
+		}
+	}
+	return n, err
+}
+
+// DownloadSingleFile downloads a single file and returns its local path
+func (d *Downloader) DownloadSingleFile(ctx context.Context, file RepoFile) (string, error) {
+	return d.downloadFileWithProgress(ctx, file, uint64(file.ActualSize()), nil)
+}

--- a/pkg/distribution/huggingface/model.go
+++ b/pkg/distribution/huggingface/model.go
@@ -1,0 +1,161 @@
+package huggingface
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/docker/model-runner/pkg/distribution/builder"
+	"github.com/docker/model-runner/pkg/distribution/internal/progress"
+	"github.com/docker/model-runner/pkg/distribution/packaging"
+	"github.com/docker/model-runner/pkg/distribution/types"
+)
+
+// BuildModel downloads files from a HuggingFace repository and constructs an OCI model artifact
+// This is the main entry point for pulling native HuggingFace models
+func BuildModel(ctx context.Context, client *Client, repo, revision string, tempDir string, progressWriter io.Writer) (types.ModelArtifact, error) {
+	// Step 1: List files in the repository
+	if progressWriter != nil {
+		_ = progress.WriteProgress(progressWriter, "Fetching file list...", 0, 0, 0, "")
+	}
+
+	files, err := client.ListFiles(ctx, repo, revision)
+	if err != nil {
+		return nil, fmt.Errorf("list files: %w", err)
+	}
+
+	// Step 2: Filter to model files (safetensors + configs)
+	safetensorsFiles, configFiles := FilterModelFiles(files)
+
+	if len(safetensorsFiles) == 0 {
+		return nil, fmt.Errorf("no safetensors files found in repository %s", repo)
+	}
+
+	// Combine all files to download
+	allFiles := append(safetensorsFiles, configFiles...)
+
+	if progressWriter != nil {
+		totalSize := TotalSize(allFiles)
+		msg := fmt.Sprintf("Found %d files (%.2f MB total)",
+			len(allFiles), float64(totalSize)/1024/1024)
+		_ = progress.WriteProgress(progressWriter, msg, uint64(totalSize), 0, 0, "")
+	}
+
+	// Step 3: Download all files
+	downloader := NewDownloader(client, repo, revision, tempDir)
+	result, err := downloader.DownloadAll(ctx, allFiles, progressWriter)
+	if err != nil {
+		return nil, fmt.Errorf("download files: %w", err)
+	}
+
+	// Step 4: Build the model artifact
+	if progressWriter != nil {
+		_ = progress.WriteProgress(progressWriter, "Building model artifact...", 0, 0, 0, "")
+	}
+
+	model, err := buildModelFromFiles(result.LocalPaths, safetensorsFiles, configFiles, tempDir)
+	if err != nil {
+		return nil, fmt.Errorf("build model: %w", err)
+	}
+
+	return model, nil
+}
+
+// buildModelFromFiles constructs an OCI model artifact from downloaded files
+func buildModelFromFiles(localPaths map[string]string, safetensorsFiles, configFiles []RepoFile, tempDir string) (types.ModelArtifact, error) {
+	// Collect safetensors paths (sorted for reproducibility)
+	var safetensorsPaths []string
+	for _, f := range safetensorsFiles {
+		localPath, ok := localPaths[f.Path]
+		if !ok {
+			return nil, fmt.Errorf("missing local path for %s", f.Path)
+		}
+		safetensorsPaths = append(safetensorsPaths, localPath)
+	}
+	sort.Strings(safetensorsPaths)
+
+	// Create builder from safetensors files
+	b, err := builder.FromSafetensors(safetensorsPaths)
+	if err != nil {
+		return nil, fmt.Errorf("create builder: %w", err)
+	}
+
+	// Create config archive if we have config files
+	if len(configFiles) > 0 {
+		configArchive, err := createConfigArchive(localPaths, configFiles, tempDir)
+		if err != nil {
+			return nil, fmt.Errorf("create config archive: %w", err)
+		}
+		// Note: configArchive is created inside tempDir and will be cleaned up when
+		// the caller removes tempDir. The file must exist until after store.Write()
+		// completes since the model artifact references it lazily.
+
+		if configArchive != "" {
+			b, err = b.WithConfigArchive(configArchive)
+			if err != nil {
+				return nil, fmt.Errorf("add config archive: %w", err)
+			}
+		}
+	}
+
+	// Check for chat template and add it
+	for _, f := range configFiles {
+		if isChatTemplate(f.Path) {
+			localPath := localPaths[f.Path]
+			b, err = b.WithChatTemplateFile(localPath)
+			if err != nil {
+				// Non-fatal: log warning but continue to try other potential templates
+				log.Printf("Warning: failed to add chat template from %s: %v", f.Path, err)
+				continue
+			}
+			break // Only add one chat template
+		}
+	}
+
+	return b.Model(), nil
+}
+
+// createConfigArchive creates a tar archive of config files in the specified tempDir
+func createConfigArchive(localPaths map[string]string, configFiles []RepoFile, tempDir string) (string, error) {
+	// Collect config file paths (excluding chat templates which are added separately)
+	var configPaths []string
+	for _, f := range configFiles {
+		if isChatTemplate(f.Path) {
+			continue // Chat templates are added as separate layers
+		}
+		localPath, ok := localPaths[f.Path]
+		if !ok {
+			return "", fmt.Errorf("internal error: missing local path for downloaded config file %s", f.Path)
+		}
+		configPaths = append(configPaths, localPath)
+	}
+
+	if len(configPaths) == 0 {
+		// No config files to archive
+		return "", nil
+	}
+
+	// Sort for reproducibility
+	sort.Strings(configPaths)
+
+	// Create the archive in our tempDir so it gets cleaned up with everything else
+	archivePath, err := packaging.CreateConfigArchiveInDir(configPaths, tempDir)
+	if err != nil {
+		return "", fmt.Errorf("create config archive: %w", err)
+	}
+
+	return archivePath, nil
+}
+
+// isChatTemplate checks if a file is a chat template
+func isChatTemplate(path string) bool {
+	filename := filepath.Base(path)
+	lower := strings.ToLower(filename)
+	return strings.HasSuffix(lower, ".jinja") ||
+		strings.Contains(lower, "chat_template") ||
+		filename == "tokenizer_config.json" // Often contains chat_template
+}

--- a/pkg/distribution/huggingface/repository.go
+++ b/pkg/distribution/huggingface/repository.go
@@ -1,0 +1,114 @@
+package huggingface
+
+import (
+	"path"
+	"strings"
+
+	"github.com/docker/model-runner/pkg/distribution/packaging"
+)
+
+// RepoFile represents a file in a HuggingFace repository
+type RepoFile struct {
+	Type string   `json:"type"` // "file" or "directory"
+	Path string   `json:"path"` // Relative path in repo
+	Size int64    `json:"size"` // File size in bytes (0 for directories)
+	OID  string   `json:"oid"`  // Git blob ID
+	LFS  *LFSInfo `json:"lfs"`  // Present if LFS file
+}
+
+// LFSInfo contains LFS-specific file information
+type LFSInfo struct {
+	OID         string `json:"oid"`          // LFS object ID (sha256)
+	Size        int64  `json:"size"`         // Actual file size
+	PointerSize int64  `json:"pointer_size"` // Size of pointer file
+}
+
+// ActualSize returns the actual file size, accounting for LFS
+func (f *RepoFile) ActualSize() int64 {
+	if f.LFS != nil {
+		return f.LFS.Size
+	}
+	return f.Size
+}
+
+// Filename returns the base filename without directory path
+func (f *RepoFile) Filename() string {
+	return path.Base(f.Path)
+}
+
+// fileType represents the type of file for model packaging
+type fileType int
+
+const (
+	// fileTypeUnknown is an unrecognized file type
+	fileTypeUnknown fileType = iota
+	// fileTypeSafetensors is a safetensors model weight file
+	fileTypeSafetensors
+	// fileTypeConfig is a configuration file (json, txt, etc.)
+	fileTypeConfig
+)
+
+// classifyFile determines the file type based on filename
+func classifyFile(filename string) fileType {
+	lower := strings.ToLower(filename)
+
+	// Check for safetensors files
+	if strings.HasSuffix(lower, ".safetensors") {
+		return fileTypeSafetensors
+	}
+
+	// Check for config file extensions
+	for _, ext := range packaging.ConfigExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return fileTypeConfig
+		}
+	}
+
+	// Check for special config files
+	for _, special := range packaging.SpecialConfigFiles {
+		if strings.EqualFold(filename, special) {
+			return fileTypeConfig
+		}
+	}
+
+	return fileTypeUnknown
+}
+
+// FilterModelFiles filters repository files to only include files needed for model-runner
+// Returns safetensors files and config files separately
+func FilterModelFiles(files []RepoFile) (safetensors []RepoFile, configs []RepoFile) {
+	for _, f := range files {
+		if f.Type != "file" {
+			continue
+		}
+
+		switch classifyFile(f.Filename()) {
+		case fileTypeSafetensors:
+			safetensors = append(safetensors, f)
+		case fileTypeConfig:
+			configs = append(configs, f)
+		case fileTypeUnknown:
+			// Skip unknown file types
+		}
+	}
+	return safetensors, configs
+}
+
+// TotalSize calculates the total size of files
+func TotalSize(files []RepoFile) int64 {
+	var total int64
+	for _, f := range files {
+		total += f.ActualSize()
+	}
+	return total
+}
+
+// isSafetensorsModel checks if the files contain at least one safetensors file
+func isSafetensorsModel(files []RepoFile) bool {
+	for _, f := range files {
+		if f.Type == "file" && classifyFile(f.Filename()) == fileTypeSafetensors {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/distribution/huggingface/repository_test.go
+++ b/pkg/distribution/huggingface/repository_test.go
@@ -1,0 +1,138 @@
+package huggingface
+
+import (
+	"testing"
+)
+
+func TestClassifyFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     fileType
+	}{
+		{"safetensors file", "model.safetensors", fileTypeSafetensors},
+		{"safetensors uppercase", "model.SAFETENSORS", fileTypeSafetensors},
+		{"safetensors mixed case", "Model.SafeTensors", fileTypeSafetensors},
+		{"sharded safetensors", "model-00001-of-00003.safetensors", fileTypeSafetensors},
+
+		{"json config", "config.json", fileTypeConfig},
+		{"tokenizer json", "tokenizer.json", fileTypeConfig},
+		{"tokenizer config", "tokenizer_config.json", fileTypeConfig},
+		{"txt file", "README.txt", fileTypeConfig},
+		{"markdown file", "README.md", fileTypeConfig},
+		{"vocab file", "vocab.vocab", fileTypeConfig},
+		{"jinja template", "chat_template.jinja", fileTypeConfig},
+		{"tokenizer model", "tokenizer.model", fileTypeConfig},
+
+		{"unknown extension", "model.bin", fileTypeUnknown},
+		{"python file", "model.py", fileTypeUnknown},
+		{"pytorch model", "pytorch_model.bin", fileTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyFile(tt.filename); got != tt.want {
+				t.Errorf("classifyFile(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterModelFiles(t *testing.T) {
+	files := []RepoFile{
+		{Type: "file", Path: "model.safetensors", Size: 1000},
+		{Type: "file", Path: "config.json", Size: 100},
+		{Type: "file", Path: "tokenizer.json", Size: 200},
+		{Type: "file", Path: "README.md", Size: 50},
+		{Type: "file", Path: "model.py", Size: 500},
+		{Type: "directory", Path: "subdir", Size: 0},
+		{Type: "file", Path: "model-00001-of-00002.safetensors", Size: 2000},
+		{Type: "file", Path: "model-00002-of-00002.safetensors", Size: 2000},
+	}
+
+	safetensors, configs := FilterModelFiles(files)
+
+	if len(safetensors) != 3 {
+		t.Errorf("Expected 3 safetensors files, got %d", len(safetensors))
+	}
+	if len(configs) != 3 {
+		t.Errorf("Expected 3 config files, got %d", len(configs))
+	}
+}
+
+func TestTotalSize(t *testing.T) {
+	files := []RepoFile{
+		{Type: "file", Path: "a.safetensors", Size: 1000},
+		{Type: "file", Path: "b.safetensors", Size: 2000, LFS: &LFSInfo{Size: 5000}},
+	}
+
+	total := TotalSize(files)
+	if total != 6000 { // 1000 + 5000 (LFS size takes precedence)
+		t.Errorf("TotalSize() = %d, want 6000", total)
+	}
+}
+
+func TestRepoFileActualSize(t *testing.T) {
+	tests := []struct {
+		name string
+		file RepoFile
+		want int64
+	}{
+		{
+			name: "regular file",
+			file: RepoFile{Size: 1000},
+			want: 1000,
+		},
+		{
+			name: "LFS file",
+			file: RepoFile{Size: 100, LFS: &LFSInfo{Size: 5000}},
+			want: 5000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.file.ActualSize(); got != tt.want {
+				t.Errorf("ActualSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSafetensorsModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []RepoFile
+		want  bool
+	}{
+		{
+			name: "has safetensors",
+			files: []RepoFile{
+				{Type: "file", Path: "model.safetensors"},
+				{Type: "file", Path: "config.json"},
+			},
+			want: true,
+		},
+		{
+			name: "no safetensors",
+			files: []RepoFile{
+				{Type: "file", Path: "config.json"},
+				{Type: "file", Path: "README.md"},
+			},
+			want: false,
+		},
+		{
+			name:  "empty",
+			files: []RepoFile{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSafetensorsModel(tt.files); got != tt.want {
+				t.Errorf("isSafetensorsModel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces native HuggingFace model support by adding a new HuggingFace client implementation that can download safetensors files directly from HuggingFace Hub repositories. The changes include:

A new HuggingFace client with authentication, file listing, and download capabilities. The client handles LFS files, error responses, and rate limiting appropriately.

A downloader component that manages parallel file downloads with progress reporting and temporary file storage. It includes progress tracking and concurrent download limiting.

Model building functionality that downloads files from HuggingFace repositories and constructs OCI model artifacts using the existing builder framework.

Repository utilities for file classification, filtering, and size calculations to identify safetensors and config files needed for model construction.

Integration with the existing pull mechanism to detect HuggingFace references and attempt native pulling when no OCI manifest is found. This preserves existing OCI functionality while adding fallback support for raw HuggingFace repositories.