### PR TITLE
Fix/model json unmarshaling

### DIFF
--- a/pkg/inference/models/api.go
+++ b/pkg/inference/models/api.go
@@ -134,6 +134,7 @@ func (m *Model) UnmarshalJSON(data []byte) error {
 	}
 
 	if len(aux.Config) == 0 || bytes.Equal(aux.Config, []byte("null")) {
+		m.Config = nil
 		return nil
 	}
 


### PR DESCRIPTION
Go's standard `json.Unmarshal` cannot deserialize JSON directly into an interface type (`types.ModelConfig`). This caused issues when deserializing `Model` objects received over HTTP (e.g., from the scheduler API).
```
docker model ls
Failed to list models: failed to unmarshal response body: json: cannot unmarshal object into Go struct field Model.config of type types.ModelConfig
```

This PR adds a custom `UnmarshalJSON` on `Model` using the alias pattern and `json.RawMessage` to decode the `config` field into the supported concrete config type.
```
docker model ls
MODEL NAME                              PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       CONTEXT  SIZE       
example                                 162.97M     MOSTLY_Q8_0     llama         4b9cbb0015eb  46 hours ago  8192     165.24MiB  
gpt-oss                                 20.91 B     MOSTLY_Q4_K_M   gpt-oss       9398339cb0d3  2 months ago           11.04 GiB  
huggingface.co/unsloth/qwen3-0.6b-gguf  596M                        qwen3         fde891dc5f5a  8 months ago           397M       
qwen3:0.6B-F16                          751.63 M    F16             qwen3         8cd0c2b3ebf0  8 months ago           1.40 GiB   
qwen3-coder                             30.53 B     IQ2_XXS/Q4_K_M  qwen3moe      6cd9fcd122e1  3 months ago           16.45 GiB  
```