### PR TITLE
Add diffusers backend support for image generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,44 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ~/.local/bin/uv pip install --python /opt/sglang-env/bin/python "sglang==${SGLANG_VERSION}"
 
 RUN /opt/sglang-env/bin/python -c "import sglang; print(sglang.__version__)" > /opt/sglang-env/version
+
+# --- Diffusers variant ---
+FROM llamacpp AS diffusers
+
+ARG DIFFUSERS_VERSION=0.31.0
+ARG TORCH_VERSION=2.5.1
+
+USER root
+
+RUN apt update && apt install -y \
+    python3 python3-venv python3-dev \
+    curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/diffusers-env && chown -R modelrunner:modelrunner /opt/diffusers-env
+
+USER modelrunner
+
+# Install uv and diffusers as modelrunner user
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && ~/.local/bin/uv venv --python /usr/bin/python3 /opt/diffusers-env \
+    && ~/.local/bin/uv pip install --python /opt/diffusers-env/bin/python \
+        "diffusers==${DIFFUSERS_VERSION}" \
+        "torch==${TORCH_VERSION}" \
+        "transformers" \
+        "accelerate" \
+        "safetensors" \
+        "fastapi" \
+        "uvicorn[standard]" \
+        "pillow"
+
+# Determine the Python site-packages directory dynamically and copy the Python server code
+RUN PYTHON_SITE_PACKAGES=$(/opt/diffusers-env/bin/python -c "import site; print(site.getsitepackages()[0])") && \
+    mkdir -p "$(dirname "$PYTHON_SITE_PACKAGES")" && \
+    cp -r python/diffusers_server "$PYTHON_SITE_PACKAGES/"
+
+RUN /opt/diffusers-env/bin/python -c "import diffusers; print(diffusers.__version__)" > /opt/diffusers-env/version
+
 FROM llamacpp AS final-llamacpp
 # Copy the built binary from builder
 COPY --from=builder /app/model-runner /app/model-runner
@@ -158,3 +196,7 @@ COPY --from=builder /app/model-runner /app/model-runner
 FROM sglang AS final-sglang
 # Copy the built binary from builder-sglang (without vLLM)
 COPY --from=builder-sglang /app/model-runner /app/model-runner
+
+FROM diffusers AS final-diffusers
+# Copy the built binary from builder
+COPY --from=builder /app/model-runner /app/model-runner

--- a/backends_vllm_stub.go
+++ b/backends_vllm_stub.go
@@ -9,7 +9,7 @@ import (
 )
 
 func initVLLMBackend(log *logrus.Logger, modelManager *models.Manager) (inference.Backend, error) {
-	return nil, nil
+	return nil, nil // VLLM backend is disabled
 }
 
 func registerVLLMBackend(backends map[string]inference.Backend, backend inference.Backend) {

--- a/main_test.go
+++ b/main_test.go
@@ -30,8 +30,18 @@ func TestCreateLlamaCppConfigFromEnv(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "disallowed model arg with equals",
+			llamaArgs: "--model=test.gguf",
+			wantErr:   true,
+		},
+		{
 			name:      "disallowed host arg",
 			llamaArgs: "--host localhost:8080",
+			wantErr:   true,
+		},
+		{
+			name:      "disallowed host arg with equals",
+			llamaArgs: "--host=localhost:8080",
 			wantErr:   true,
 		},
 		{
@@ -42,6 +52,11 @@ func TestCreateLlamaCppConfigFromEnv(t *testing.T) {
 		{
 			name:      "disallowed mmproj arg",
 			llamaArgs: "--mmproj test.mmproj",
+			wantErr:   true,
+		},
+		{
+			name:      "disallowed mmproj arg with equals",
+			llamaArgs: "--mmproj=test.mmproj",
 			wantErr:   true,
 		},
 		{
@@ -78,14 +93,18 @@ func TestCreateLlamaCppConfigFromEnv(t *testing.T) {
 
 			config := createLlamaCppConfigFromEnv()
 
+			// With the new error handling, we don't exit on error, just log it
+			// So we expect exitCode to always be 0 (no fatal exit)
+			if exitCode != 0 {
+				t.Errorf("Expected exit code 0, got %d", exitCode)
+			}
+
 			if tt.wantErr {
-				if exitCode != 1 {
-					t.Errorf("Expected exit code 1, got %d", exitCode)
+				// For error cases, we now return nil config instead of exiting
+				if config != nil {
+					t.Error("Expected nil config for error cases")
 				}
 			} else {
-				if exitCode != 0 {
-					t.Errorf("Expected exit code 0, got %d", exitCode)
-				}
 				if tt.llamaArgs == "" {
 					if config != nil {
 						t.Error("Expected nil config for empty args")

--- a/pkg/diskusage/diskusage.go
+++ b/pkg/diskusage/diskusage.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 )
 
+// Size calculates the total size of files in the given directory path.
 func Size(path string) (int64, error) {
 	var size int64
 	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {

--- a/pkg/distribution/huggingface/client.go
+++ b/pkg/distribution/huggingface/client.go
@@ -81,7 +81,8 @@ func (c *Client) ListFiles(ctx context.Context, repo, revision string) ([]RepoFi
 	}
 
 	// HuggingFace API endpoint for listing files
-	url := fmt.Sprintf("%s/api/models/%s/tree/%s", c.baseURL, repo, revision)
+	// Use recursive=true to get files from subdirectories (needed for diffusers models)
+	url := fmt.Sprintf("%s/api/models/%s/tree/%s?recursive=true", c.baseURL, repo, revision)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
@@ -94,7 +95,9 @@ func (c *Client) ListFiles(ctx context.Context, repo, revision string) ([]RepoFi
 	if err != nil {
 		return nil, fmt.Errorf("list files: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if err := c.checkResponse(resp, repo); err != nil {
 		return nil, err
@@ -131,7 +134,7 @@ func (c *Client) DownloadFile(ctx context.Context, repo, revision, filename stri
 	}
 
 	if err := c.checkResponse(resp, repo); err != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, 0, err
 	}
 

--- a/pkg/distribution/huggingface/downloader.go
+++ b/pkg/distribution/huggingface/downloader.go
@@ -155,7 +155,9 @@ func (d *Downloader) downloadFileWithProgress(ctx context.Context, file RepoFile
 	if err != nil {
 		return "", err
 	}
-	defer reader.Close()
+	defer func() {
+		_ = reader.Close()
+	}()
 
 	// Create local file
 	f, err := os.Create(localPath)

--- a/pkg/distribution/internal/partial/layer.go
+++ b/pkg/distribution/internal/partial/layer.go
@@ -13,11 +13,13 @@ import (
 
 var _ v1.Layer = &Layer{}
 
+// Layer represents a layer in a model distribution.
 type Layer struct {
 	Path string
 	v1.Descriptor
 }
 
+// NewLayer creates a new layer from a file path and media type.
 func NewLayer(path string, mt ggcrtypes.MediaType) (*Layer, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -70,26 +72,32 @@ func NewLayer(path string, mt ggcrtypes.MediaType) (*Layer, error) {
 	}, err
 }
 
+// Digest returns the layer's digest.
 func (l Layer) Digest() (v1.Hash, error) {
 	return l.DiffID()
 }
 
+// DiffID returns the layer's diff ID.
 func (l Layer) DiffID() (v1.Hash, error) {
 	return l.Descriptor.Digest, nil
 }
 
+// Compressed returns a reader for the compressed layer contents.
 func (l Layer) Compressed() (io.ReadCloser, error) {
 	return l.Uncompressed()
 }
 
+// Uncompressed returns a reader for the uncompressed layer contents.
 func (l Layer) Uncompressed() (io.ReadCloser, error) {
 	return os.Open(l.Path)
 }
 
+// Size returns the size of the layer.
 func (l Layer) Size() (int64, error) {
 	return l.Descriptor.Size, nil
 }
 
+// MediaType returns the media type of the layer.
 func (l Layer) MediaType() (ggcrtypes.MediaType, error) {
 	return l.Descriptor.MediaType, nil
 }

--- a/pkg/distribution/internal/partial/model.go
+++ b/pkg/distribution/internal/partial/model.go
@@ -19,30 +19,37 @@ type BaseModel struct {
 
 var _ types.ModelArtifact = &BaseModel{}
 
+// Layers returns the layers of the model.
 func (m *BaseModel) Layers() ([]v1.Layer, error) {
 	return m.LayerList, nil
 }
 
+// Size returns the total size of the model.
 func (m *BaseModel) Size() (int64, error) {
 	return partial.Size(m)
 }
 
+// ConfigName returns the hash of the model's config file.
 func (m *BaseModel) ConfigName() (v1.Hash, error) {
 	return partial.ConfigName(m)
 }
 
+// ConfigFile returns the model's config file.
 func (m *BaseModel) ConfigFile() (*v1.ConfigFile, error) {
 	return nil, fmt.Errorf("invalid for model")
 }
 
+// Digest returns the digest of the model.
 func (m *BaseModel) Digest() (v1.Hash, error) {
 	return partial.Digest(m)
 }
 
+// Manifest returns the manifest of the model.
 func (m *BaseModel) Manifest() (*v1.Manifest, error) {
 	return ManifestForLayers(m)
 }
 
+// LayerByDigest returns the layer with the given digest.
 func (m *BaseModel) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
 	for _, l := range m.LayerList {
 		d, err := l.Digest()
@@ -56,6 +63,7 @@ func (m *BaseModel) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
 	return nil, fmt.Errorf("layer not found")
 }
 
+// LayerByDiffID returns the layer with the given diff ID.
 func (m *BaseModel) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	for _, l := range m.LayerList {
 		d, err := l.DiffID()
@@ -69,14 +77,17 @@ func (m *BaseModel) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	return nil, fmt.Errorf("layer not found")
 }
 
+// RawManifest returns the raw manifest of the model.
 func (m *BaseModel) RawManifest() ([]byte, error) {
 	return partial.RawManifest(m)
 }
 
+// RawConfigFile returns the raw config file of the model.
 func (m *BaseModel) RawConfigFile() ([]byte, error) {
 	return json.Marshal(m.ModelConfigFile)
 }
 
+// MediaType returns the media type of the model.
 func (m *BaseModel) MediaType() (ggcr.MediaType, error) {
 	manifest, err := m.Manifest()
 	if err != nil {
@@ -85,14 +96,17 @@ func (m *BaseModel) MediaType() (ggcr.MediaType, error) {
 	return manifest.MediaType, nil
 }
 
+// ID returns the ID of the model.
 func (m *BaseModel) ID() (string, error) {
 	return ID(m)
 }
 
+// Config returns the configuration of the model.
 func (m *BaseModel) Config() (types.ModelConfig, error) {
 	return Config(m)
 }
 
+// Descriptor returns the descriptor of the model.
 func (m *BaseModel) Descriptor() (types.Descriptor, error) {
 	return Descriptor(m)
 }

--- a/pkg/distribution/internal/partial/partial.go
+++ b/pkg/distribution/internal/partial/partial.go
@@ -11,6 +11,7 @@ import (
 	ggcr "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 )
 
+// WithRawConfigFile is an interface for getting raw config file data.
 type WithRawConfigFile interface {
 	// RawConfigFile returns the serialized bytes of this model's config file.
 	RawConfigFile() ([]byte, error)
@@ -70,6 +71,7 @@ type WithRawManifest interface {
 	RawManifest() ([]byte, error)
 }
 
+// ID returns the ID of the model.
 func ID(i WithRawManifest) (string, error) {
 	digest, err := partial.Digest(i)
 	if err != nil {
@@ -78,15 +80,18 @@ func ID(i WithRawManifest) (string, error) {
 	return digest.String(), nil
 }
 
+// WithLayers is an interface for accessing model layers.
 type WithLayers interface {
 	WithRawConfigFile
 	Layers() ([]v1.Layer, error)
 }
 
+// GGUFPaths returns the paths of GGUF layers in the model.
 func GGUFPaths(i WithLayers) ([]string, error) {
 	return layerPathsByMediaType(i, types.MediaTypeGGUF)
 }
 
+// MMPROJPath returns the path of the multimodal projector layer in the model.
 func MMPROJPath(i WithLayers) (string, error) {
 	paths, err := layerPathsByMediaType(i, types.MediaTypeMultimodalProjector)
 	if err != nil {
@@ -102,6 +107,7 @@ func MMPROJPath(i WithLayers) (string, error) {
 	return paths[0], err
 }
 
+// ChatTemplatePath returns the path of the chat template layer in the model.
 func ChatTemplatePath(i WithLayers) (string, error) {
 	paths, err := layerPathsByMediaType(i, types.MediaTypeChatTemplate)
 	if err != nil {
@@ -117,10 +123,12 @@ func ChatTemplatePath(i WithLayers) (string, error) {
 	return paths[0], err
 }
 
+// SafetensorsPaths returns the paths of safetensors layers in the model.
 func SafetensorsPaths(i WithLayers) ([]string, error) {
 	return layerPathsByMediaType(i, types.MediaTypeSafetensors)
 }
 
+// ConfigArchivePath returns the path of the VLLM config archive layer in the model.
 func ConfigArchivePath(i WithLayers) (string, error) {
 	paths, err := layerPathsByMediaType(i, types.MediaTypeVLLMConfigArchive)
 	if err != nil {
@@ -184,6 +192,7 @@ func matchesMediaType(layerMT, targetMT ggcr.MediaType) bool {
 	}
 }
 
+// ManifestForLayers creates a manifest for the given layers.
 func ManifestForLayers(i WithLayers) (*v1.Manifest, error) {
 	cfgLayer, err := partial.ConfigLayer(i)
 	if err != nil {

--- a/pkg/distribution/internal/progress/reporter.go
+++ b/pkg/distribution/internal/progress/reporter.go
@@ -16,6 +16,7 @@ const UpdateInterval = 100 * time.Millisecond
 // before sending a progress update
 const MinBytesForUpdate = 1024 * 1024 // 1MB
 
+// Layer represents progress information for a single layer.
 type Layer struct {
 	ID      string // Layer ID
 	Size    uint64 // Layer size
@@ -31,6 +32,7 @@ type Message struct {
 	Layer   Layer  `json:"layer"`  // Current layer information
 }
 
+// Reporter tracks and reports progress for image operations.
 type Reporter struct {
 	progress  chan v1.Update
 	done      chan struct{}
@@ -43,14 +45,17 @@ type Reporter struct {
 
 type progressF func(update v1.Update) string
 
+// PullMsg formats a message for pull operations.
 func PullMsg(update v1.Update) string {
 	return fmt.Sprintf("Downloaded: %.2f MB", float64(update.Complete)/1024/1024)
 }
 
+// PushMsg formats a message for push operations.
 func PushMsg(update v1.Update) string {
 	return fmt.Sprintf("Uploaded: %.2f MB", float64(update.Complete)/1024/1024)
 }
 
+// NewProgressReporter creates a new progress reporter.
 func NewProgressReporter(w io.Writer, msgF progressF, imageSize int64, layer v1.Layer) *Reporter {
 	return &Reporter{
 		out:       w,

--- a/pkg/distribution/internal/store/manifests.go
+++ b/pkg/distribution/internal/store/manifests.go
@@ -92,12 +92,12 @@ func writeFile(path string, data []byte) error {
 	}
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		cleanup()
 		return fmt.Errorf("write temporary file %q: %w", tmpName, err)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		cleanup()
 		return fmt.Errorf("sync temporary file %q: %w", tmpName, err)
 	}

--- a/pkg/distribution/internal/utils/utils.go
+++ b/pkg/distribution/internal/utils/utils.go
@@ -1,3 +1,4 @@
+// Package utils provides utility functions for the distribution package.
 package utils
 
 import (

--- a/pkg/distribution/packaging/dirtar.go
+++ b/pkg/distribution/packaging/dirtar.go
@@ -34,7 +34,7 @@ func CreateDirectoryTarArchive(dirPath string) (string, error) {
 	shouldKeepTempFile := false
 	defer func() {
 		if !shouldKeepTempFile {
-			os.Remove(tmpPath)
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
@@ -96,14 +96,14 @@ func CreateDirectoryTarArchive(dirPath string) (string, error) {
 	})
 
 	if err != nil {
-		tw.Close()
-		tmpFile.Close()
+		_ = tw.Close()
+		_ = tmpFile.Close()
 		return "", fmt.Errorf("walk directory: %w", err)
 	}
 
 	// Close tar writer
 	if err := tw.Close(); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		return "", fmt.Errorf("close tar writer: %w", err)
 	}
 
@@ -147,7 +147,7 @@ func (p *DirTarProcessor) Process() ([]string, func(), error) {
 	// Return cleanup function
 	cleanup := func() {
 		for _, tempFile := range p.tempFiles {
-			os.Remove(tempFile)
+			_ = os.Remove(tempFile)
 		}
 	}
 

--- a/pkg/distribution/registry/client.go
+++ b/pkg/distribution/registry/client.go
@@ -168,8 +168,8 @@ func (c *Client) BlobURL(reference string, digest v1.Hash) (string, error) {
 	}
 
 	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
-		ref.Context().Registry.Scheme(),
-		ref.Context().Registry.RegistryStr(),
+		ref.Context().Scheme(),
+		ref.Context().RegistryStr(),
 		ref.Context().RepositoryStr(),
 		digest.String()), nil
 }

--- a/pkg/distribution/registry/client_test.go
+++ b/pkg/distribution/registry/client_test.go
@@ -35,8 +35,8 @@ func TestGetDefaultRegistryOptions_NoEnvVars(t *testing.T) {
 	}
 
 	// Verify it uses HTTPS (secure by default)
-	if ref.Context().Registry.Scheme() != "https" {
-		t.Errorf("Expected scheme to be 'https', got '%s'", ref.Context().Registry.Scheme())
+	if ref.Context().Scheme() != "https" {
+		t.Errorf("Expected scheme to be 'https', got '%s'", ref.Context().Scheme())
 	}
 }
 
@@ -64,8 +64,8 @@ func TestGetDefaultRegistryOptions_OnlyDefaultRegistry(t *testing.T) {
 	}
 
 	// Verify it's not insecure (should use https)
-	if ref.Context().Registry.Scheme() != "https" {
-		t.Errorf("Expected scheme to be 'https', got '%s'", ref.Context().Registry.Scheme())
+	if ref.Context().Scheme() != "https" {
+		t.Errorf("Expected scheme to be 'https', got '%s'", ref.Context().Scheme())
 	}
 }
 
@@ -89,8 +89,8 @@ func TestGetDefaultRegistryOptions_OnlyInsecureRegistry(t *testing.T) {
 	}
 
 	// Insecure registries should use http
-	if ref.Context().Registry.Scheme() != "http" {
-		t.Errorf("Expected scheme to be 'http', got '%s'", ref.Context().Registry.Scheme())
+	if ref.Context().Scheme() != "http" {
+		t.Errorf("Expected scheme to be 'http', got '%s'", ref.Context().Scheme())
 	}
 }
 
@@ -119,8 +119,8 @@ func TestGetDefaultRegistryOptions_BothEnvVars(t *testing.T) {
 	}
 
 	// Check insecure is applied (http scheme)
-	if ref.Context().Registry.Scheme() != "http" {
-		t.Errorf("Expected scheme to be 'http', got '%s'", ref.Context().Registry.Scheme())
+	if ref.Context().Scheme() != "http" {
+		t.Errorf("Expected scheme to be 'http', got '%s'", ref.Context().Scheme())
 	}
 }
 

--- a/pkg/distribution/tarball/file.go
+++ b/pkg/distribution/tarball/file.go
@@ -27,7 +27,9 @@ func (t *FileTarget) Write(ctx context.Context, mdl types.ModelArtifact, pw io.W
 	if err != nil {
 		return fmt.Errorf("create file for archive: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	target, err := NewTarget(f)
 	if err != nil {
 		return fmt.Errorf("create target: %w", err)

--- a/pkg/distribution/tarball/reader.go
+++ b/pkg/distribution/tarball/reader.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 )
 
+// Reader reads a tarball containing model artifacts.
 type Reader struct {
 	tr          *tar.Reader
 	rawManifest []byte
@@ -19,15 +20,18 @@ type Reader struct {
 	done        bool
 }
 
+// Blob represents a blob in a tarball.
 type Blob struct {
 	diffID v1.Hash
 	rc     io.ReadCloser
 }
 
+// DiffID returns the diff ID of the blob.
 func (b Blob) DiffID() (v1.Hash, error) {
 	return b.diffID, nil
 }
 
+// Uncompressed returns an uncompressed reader for the blob.
 func (b Blob) Uncompressed() (io.ReadCloser, error) {
 	return b.rc, nil
 }
@@ -81,6 +85,7 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 	return r.tr.Read(p)
 }
 
+// Manifest returns the manifest from the tarball.
 func (r *Reader) Manifest() ([]byte, v1.Hash, error) {
 	if !r.done {
 		return nil, v1.Hash{}, errors.New("must read all blobs first before getting manifest")
@@ -91,6 +96,7 @@ func (r *Reader) Manifest() ([]byte, v1.Hash, error) {
 	return r.rawManifest, r.digest, nil
 }
 
+// NewReader creates a new tarball reader.
 func NewReader(r io.Reader) *Reader {
 	return &Reader{
 		tr: tar.NewReader(r),

--- a/pkg/distribution/tarball/target.go
+++ b/pkg/distribution/tarball/target.go
@@ -26,7 +26,7 @@ func NewTarget(w io.Writer) (*Target, error) {
 	}, nil
 }
 
-// Write writes the artifact in archive format to the configured io.Writer
+// Write writes the artifact in archive format to the configured io.Writer.
 func (t *Target) Write(ctx context.Context, mdl types.ModelArtifact, progressWriter io.Writer) error {
 	tw := tar.NewWriter(t.writer)
 	defer tw.Close()

--- a/pkg/distribution/types/config.go
+++ b/pkg/distribution/types/config.go
@@ -32,7 +32,9 @@ const (
 	// MediaTypeChatTemplate indicates a Jinja chat template
 	MediaTypeChatTemplate = types.MediaType("application/vnd.docker.ai.chat.template.jinja")
 
-	FormatGGUF        = Format("gguf")
+	// FormatGGUF represents the GGUF format.
+	FormatGGUF = Format("gguf")
+	// FormatSafetensors represents the Safetensors format.
 	FormatSafetensors = Format("safetensors")
 
 	// OCI Annotation keys for model layers
@@ -50,6 +52,7 @@ const (
 	AnnotationMediaTypeUntested = "org.cncf.model.file.mediatype.untested"
 )
 
+// Format represents the format of a model.
 type Format string
 
 // ModelConfig provides a unified interface for accessing model configuration.
@@ -65,6 +68,7 @@ type ModelConfig interface {
 	GetQuantization() string
 }
 
+// ConfigFile represents a model configuration file.
 type ConfigFile struct {
 	Config     Config     `json:"config"`
 	Descriptor Descriptor `json:"descriptor"`

--- a/pkg/go-containerregistry/cmd/crane/cmd/serve.go
+++ b/pkg/go-containerregistry/cmd/crane/cmd/serve.go
@@ -23,9 +23,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/spf13/cobra"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
+	"github.com/spf13/cobra"
 )
 
 func NewCmdRegistry() *cobra.Command {

--- a/pkg/go-containerregistry/pkg/authn/kubernetes/keychain_test.go
+++ b/pkg/go-containerregistry/pkg/authn/kubernetes/keychain_test.go
@@ -23,9 +23,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/go-containerregistry/pkg/gcrane/copy_test.go
+++ b/pkg/go-containerregistry/pkg/gcrane/copy_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/internal/retry"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/logs"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
@@ -40,6 +39,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 type fakeXCR struct {

--- a/pkg/go-containerregistry/pkg/v1/daemon/image.go
+++ b/pkg/go-containerregistry/pkg/v1/daemon/image.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	api "github.com/docker/docker/api/types/image"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/tarball"

--- a/pkg/go-containerregistry/pkg/v1/daemon/image_test.go
+++ b/pkg/go-containerregistry/pkg/v1/daemon/image_test.go
@@ -26,12 +26,11 @@ import (
 	api "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
 	"github.com/docker/docker/client"
-	specs "github.com/moby/docker-image-spec/specs-go/v1"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/compare"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/tarball"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	specs "github.com/moby/docker-image-spec/specs-go/v1"
 )
 
 var imagePath = "../tarball/testdata/test_image_1.tar"

--- a/pkg/go-containerregistry/pkg/v1/daemon/write_test.go
+++ b/pkg/go-containerregistry/pkg/v1/daemon/write_test.go
@@ -24,7 +24,6 @@ import (
 
 	api "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/empty"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/tarball"

--- a/pkg/go-containerregistry/pkg/v1/google/list_test.go
+++ b/pkg/go-containerregistry/pkg/v1/google/list_test.go
@@ -26,10 +26,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/logs"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
+	"github.com/google/go-cmp/cmp"
 )
 
 func mustParseDuration(t *testing.T, d string) time.Duration {

--- a/pkg/go-containerregistry/pkg/v1/layout/write_test.go
+++ b/pkg/go-containerregistry/pkg/v1/layout/write_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/empty"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/match"
@@ -32,6 +31,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/stream"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWrite(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/mutate/index_test.go
+++ b/pkg/go-containerregistry/pkg/v1/mutate/index_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/empty"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/mutate"
@@ -27,6 +26,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAppendIndex(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/mutate/mutate_test.go
+++ b/pkg/go-containerregistry/pkg/v1/mutate/mutate_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/empty"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/match"
@@ -38,6 +36,8 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/tarball"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestExtractWhiteout(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/partial/compressed_test.go
+++ b/pkg/go-containerregistry/pkg/v1/partial/compressed_test.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
 )
 
 // Remote leverages a lot of compressed partials.

--- a/pkg/go-containerregistry/pkg/v1/partial/with_test.go
+++ b/pkg/go-containerregistry/pkg/v1/partial/with_test.go
@@ -17,11 +17,11 @@ package partial_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRawConfigFile(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/platform_test.go
+++ b/pkg/go-containerregistry/pkg/v1/platform_test.go
@@ -17,8 +17,8 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPlatformString(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/remote/catalog_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/catalog_test.go
@@ -23,8 +23,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCatalogPage(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/remote/descriptor_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/descriptor_test.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 var fakeDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"

--- a/pkg/go-containerregistry/pkg/v1/remote/image_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/image_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/logs"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
@@ -38,6 +37,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
 )
 
 const bogusDigest = "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"

--- a/pkg/go-containerregistry/pkg/v1/remote/index_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/index_test.go
@@ -23,10 +23,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func randomIndex(t *testing.T) v1.ImageIndex {

--- a/pkg/go-containerregistry/pkg/v1/remote/list_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/list_test.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestList(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/remote/progress_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/progress_test.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/mutate"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWriteLayer_Progress(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/remote/referrers_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/referrers_test.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
@@ -28,6 +27,7 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/random"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/remote"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestReferrers(t *testing.T) {

--- a/pkg/go-containerregistry/pkg/v1/remote/transport/bearer.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/transport/bearer.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	authchallenge "github.com/docker/distribution/registry/client/auth/challenge"
-
 	"github.com/docker/model-runner/pkg/go-containerregistry/internal/redact"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/authn"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/logs"

--- a/pkg/go-containerregistry/pkg/v1/remote/write_test.go
+++ b/pkg/go-containerregistry/pkg/v1/remote/write_test.go
@@ -30,8 +30,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/name"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/registry"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
@@ -44,6 +42,8 @@ import (
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/tarball"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/validate"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func mustNewTag(t *testing.T, s string) name.Tag {

--- a/pkg/go-containerregistry/pkg/v1/validate/image.go
+++ b/pkg/go-containerregistry/pkg/v1/validate/image.go
@@ -21,9 +21,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-cmp/cmp"
 )
 
 // Image validates that img does not violate any invariants of the image format.

--- a/pkg/go-containerregistry/pkg/v1/validate/index.go
+++ b/pkg/go-containerregistry/pkg/v1/validate/index.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/logs"
 	v1 "github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1"
 	"github.com/docker/model-runner/pkg/go-containerregistry/pkg/v1/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 // Index validates that idx does not violate any invariants of the index format.

--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -18,6 +18,9 @@ const (
 	// mode.
 	BackendModeEmbedding
 	BackendModeReranking
+	// BackendModeImageGeneration indicates that the backend should run in
+	// image generation mode.
+	BackendModeImageGeneration
 )
 
 type ErrGGUFParse struct {
@@ -37,6 +40,8 @@ func (m BackendMode) String() string {
 		return "embedding"
 	case BackendModeReranking:
 		return "reranking"
+	case BackendModeImageGeneration:
+		return "image_generation"
 	default:
 		return "unknown"
 	}
@@ -72,6 +77,8 @@ func ParseBackendMode(mode string) (BackendMode, bool) {
 		return BackendModeEmbedding, true
 	case "reranking":
 		return BackendModeReranking, true
+	case "image_generation":
+		return BackendModeImageGeneration, true
 	default:
 		return BackendModeCompletion, false
 	}
@@ -101,6 +108,16 @@ type LlamaCppConfig struct {
 	ReasoningBudget *int32 `json:"reasoning-budget,omitempty"`
 }
 
+// DiffusersConfig contains diffusers-specific configuration options.
+type DiffusersConfig struct {
+	// Device specifies the compute device (cpu, cuda, mps).
+	Device string `json:"device,omitempty"`
+	// Precision specifies the compute precision (fp16, bf16, fp32).
+	Precision string `json:"precision,omitempty"`
+	// EnableAttentionSlicing enables attention slicing for memory efficiency.
+	EnableAttentionSlicing bool `json:"enable-attention-slicing,omitempty"`
+}
+
 type BackendConfiguration struct {
 	// Shared configuration across all backends
 	ContextSize  *int32                     `json:"context-size,omitempty"`
@@ -108,8 +125,9 @@ type BackendConfiguration struct {
 	Speculative  *SpeculativeDecodingConfig `json:"speculative,omitempty"`
 
 	// Backend-specific configuration
-	VLLM     *VLLMConfig     `json:"vllm,omitempty"`
-	LlamaCpp *LlamaCppConfig `json:"llamacpp,omitempty"`
+	VLLM      *VLLMConfig      `json:"vllm,omitempty"`
+	LlamaCpp  *LlamaCppConfig  `json:"llamacpp,omitempty"`
+	Diffusers *DiffusersConfig `json:"diffusers,omitempty"`
 }
 
 type RequiredMemory struct {

--- a/pkg/inference/backends/diffusers/diffusers.go
+++ b/pkg/inference/backends/diffusers/diffusers.go
@@ -1,0 +1,178 @@
+package diffusers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/docker/model-runner/pkg/diskusage"
+	"github.com/docker/model-runner/pkg/inference"
+	"github.com/docker/model-runner/pkg/inference/backends"
+	"github.com/docker/model-runner/pkg/inference/models"
+	"github.com/docker/model-runner/pkg/inference/platform"
+	"github.com/docker/model-runner/pkg/logging"
+)
+
+const (
+	// Name is the backend name.
+	Name = "diffusers"
+	// diffusersDir is the default installation directory in Docker containers.
+	diffusersDir = "/opt/diffusers-env"
+)
+
+// ErrorNotFound indicates that the diffusers Python environment was not found.
+var ErrorNotFound = errors.New("diffusers Python environment not found")
+
+// diffusersBackend is the diffusers-based backend implementation for image generation.
+type diffusersBackend struct {
+	// log is the associated logger.
+	log logging.Logger
+	// modelManager is the shared model manager.
+	modelManager *models.Manager
+	// serverLog is the logger to use for the diffusers server process.
+	serverLog logging.Logger
+	// config is the configuration for the diffusers backend.
+	config *Config
+	// status is the state in which the diffusers backend is in.
+	status string
+	// pythonPath is the path to the Python interpreter to use.
+	pythonPath string
+}
+
+// New creates a new diffusers-based backend for image generation.
+func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config) (inference.Backend, error) {
+	if conf == nil {
+		conf = NewDefaultConfig()
+	}
+
+	return &diffusersBackend{
+		log:          log,
+		modelManager: modelManager,
+		serverLog:    serverLog,
+		config:       conf,
+		status:       "not installed",
+	}, nil
+}
+
+// Name implements inference.Backend.Name.
+func (d *diffusersBackend) Name() string {
+	return Name
+}
+
+// UsesExternalModelManagement implements inference.Backend.UsesExternalModelManagement.
+func (d *diffusersBackend) UsesExternalModelManagement() bool {
+	return false
+}
+
+// UsesTCP implements inference.Backend.UsesTCP.
+func (d *diffusersBackend) UsesTCP() bool {
+	return false
+}
+
+// Install implements inference.Backend.Install.
+func (d *diffusersBackend) Install(_ context.Context, _ *http.Client) error {
+	if !platform.SupportsDiffusers() {
+		d.status = "not supported on this platform"
+		return errors.New("diffusers is not supported on this platform")
+	}
+
+	// Try container path first
+	containerPython := filepath.Join(diffusersDir, "bin", "python3")
+	if _, err := os.Stat(containerPython); err == nil {
+		d.pythonPath = containerPython
+		return nil
+	}
+
+	// Try system Python with diffusers installed
+	systemPython, err := d.findSystemPython()
+	if err != nil {
+		d.status = ErrorNotFound.Error()
+		return ErrorNotFound
+	}
+
+	d.pythonPath = systemPython
+	return nil
+}
+
+// findSystemPython looks for a Python installation with diffusers available.
+func (d *diffusersBackend) findSystemPython() (string, error) {
+	pythonCandidates := []string{"python3", "python"}
+
+	// On macOS, also check common homebrew paths
+	if runtime.GOOS == "darwin" {
+		pythonCandidates = append([]string{
+			"/opt/homebrew/bin/python3",
+			"/usr/local/bin/python3",
+		}, pythonCandidates...)
+	}
+
+	for _, python := range pythonCandidates {
+		pythonPath, err := exec.LookPath(python)
+		if err != nil {
+			continue
+		}
+
+		return pythonPath, nil
+	}
+
+	return "", ErrorNotFound
+}
+
+// Run implements inference.Backend.Run.
+func (d *diffusersBackend) Run(ctx context.Context, socket, model string, modelRef string, mode inference.BackendMode, backendConfig *inference.BackendConfiguration) error {
+	if d.pythonPath == "" {
+		return ErrorNotFound
+	}
+
+	if mode != inference.BackendModeImageGeneration {
+		return fmt.Errorf("diffusers backend only supports image generation mode, got %s", mode.String())
+	}
+
+	bundle, err := d.modelManager.GetBundle(model)
+	if err != nil {
+		return fmt.Errorf("failed to get model: %w", err)
+	}
+
+	args, err := d.config.GetArgs(bundle, socket, mode, backendConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get diffusers arguments: %w", err)
+	}
+
+	// Add model name arguments
+	args = append(args, "--served-model-name", model, modelRef)
+
+	return backends.RunBackend(ctx, backends.RunnerConfig{
+		BackendName:     "diffusers",
+		Socket:          socket,
+		BinaryPath:      d.pythonPath,
+		SandboxPath:     filepath.Dir(d.pythonPath),
+		SandboxConfig:   "",
+		Args:            args,
+		Logger:          d.log,
+		ServerLogWriter: d.serverLog.Writer(),
+	})
+}
+
+// Status implements inference.Backend.Status.
+func (d *diffusersBackend) Status() string {
+	return d.status
+}
+
+// GetDiskUsage implements inference.Backend.GetDiskUsage.
+func (d *diffusersBackend) GetDiskUsage() (int64, error) {
+	// Check if we're using the container installation
+	if _, err := os.Stat(diffusersDir); err == nil {
+		size, err := diskusage.Size(diffusersDir)
+		if err != nil {
+			return 0, fmt.Errorf("error while getting store size: %w", err)
+		}
+		return size, nil
+	}
+	// For system Python, report 0 since it's not managed by us
+	return 0, nil
+}

--- a/pkg/inference/backends/diffusers/diffusers_config.go
+++ b/pkg/inference/backends/diffusers/diffusers_config.go
@@ -1,0 +1,76 @@
+package diffusers
+
+import (
+	"fmt"
+
+	"github.com/docker/model-runner/pkg/distribution/types"
+	"github.com/docker/model-runner/pkg/inference"
+)
+
+// Config is the configuration for the diffusers backend.
+type Config struct {
+	// Args are the base arguments that are always included.
+	Args []string
+}
+
+// NewDefaultConfig creates a new Config with default values.
+func NewDefaultConfig() *Config {
+	return &Config{
+		Args: []string{},
+	}
+}
+
+// GetArgs implements config.BackendConfig.GetArgs.
+func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
+	if mode != inference.BackendModeImageGeneration {
+		return nil, fmt.Errorf("diffusers backend only supports image generation mode")
+	}
+
+	// Start with base arguments
+	args := append([]string{}, c.Args...)
+
+	// Python module entry point
+	args = append(args, "-m", "diffusers_server")
+
+	// Get model path
+	modelPath, err := getModelPath(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model path: %w", err)
+	}
+
+	// Add model path argument
+	args = append(args, "--model-path", modelPath)
+
+	// Add socket argument
+	args = append(args, "--socket", socket)
+
+	// Add runtime flags from backend config
+	if config != nil {
+		args = append(args, config.RuntimeFlags...)
+	}
+
+	// Add diffusers-specific arguments from backend config
+	if config != nil && config.Diffusers != nil {
+		if config.Diffusers.Device != "" {
+			args = append(args, "--device", config.Diffusers.Device)
+		}
+		if config.Diffusers.Precision != "" {
+			args = append(args, "--precision", config.Diffusers.Precision)
+		}
+		if config.Diffusers.EnableAttentionSlicing {
+			args = append(args, "--enable-attention-slicing")
+		}
+	}
+
+	return args, nil
+}
+
+// getModelPath extracts the model path from the bundle.
+func getModelPath(bundle types.ModelBundle) (string, error) {
+	rootDir := bundle.RootDir()
+	if rootDir != "" {
+		return rootDir, nil
+	}
+
+	return "", fmt.Errorf("no model path found in bundle")
+}

--- a/pkg/inference/backends/llamacpp/llamacpp_config.go
+++ b/pkg/inference/backends/llamacpp/llamacpp_config.go
@@ -65,6 +65,8 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 		args = append(args, "--embeddings")
 	case inference.BackendModeReranking:
 		args = append(args, "--embeddings", "--reranking")
+	case inference.BackendModeImageGeneration:
+		return nil, fmt.Errorf("image generation mode not supported by llama.cpp backend")
 	default:
 		return nil, fmt.Errorf("unsupported backend mode %q", mode)
 	}

--- a/pkg/inference/backends/mlx/mlx.go
+++ b/pkg/inference/backends/mlx/mlx.go
@@ -20,7 +20,7 @@ const (
 	Name = "mlx"
 )
 
-var ErrStatusNotFound = errors.New("Python or mlx-lm not found")
+var ErrStatusNotFound = errors.New("python or mlx-lm not found")
 
 // mlx is the MLX-based backend implementation.
 type mlx struct {

--- a/pkg/inference/backends/mlx/mlx_config.go
+++ b/pkg/inference/backends/mlx/mlx_config.go
@@ -49,6 +49,8 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	case inference.BackendModeReranking:
 		// MLX may not support reranking mode
 		return nil, fmt.Errorf("reranking mode not supported by MLX backend")
+	case inference.BackendModeImageGeneration:
+		return nil, fmt.Errorf("image generation mode not supported by MLX backend")
 	default:
 		return nil, fmt.Errorf("unsupported backend mode %q", mode)
 	}

--- a/pkg/inference/backends/runner.go
+++ b/pkg/inference/backends/runner.go
@@ -89,13 +89,15 @@ func RunBackend(ctx context.Context, config RunnerConfig) error {
 	if err != nil {
 		return fmt.Errorf("unable to start %s: %w", config.BackendName, err)
 	}
-	defer backendSandbox.Close()
+	defer func() {
+		_ = backendSandbox.Close()
+	}()
 
 	// Handle backend process errors
 	backendErrors := make(chan error, 1)
 	go func() {
 		backendErr := backendSandbox.Command().Wait()
-		config.ServerLogWriter.Close()
+		_ = config.ServerLogWriter.Close()
 
 		errOutput := new(strings.Builder)
 		if _, err := io.Copy(errOutput, tailBuf); err != nil {

--- a/pkg/inference/backends/sglang/sglang_config.go
+++ b/pkg/inference/backends/sglang/sglang_config.go
@@ -50,6 +50,8 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	case inference.BackendModeEmbedding:
 		args = append(args, "--is-embedding")
 	case inference.BackendModeReranking:
+	case inference.BackendModeImageGeneration:
+		return nil, fmt.Errorf("image generation mode not supported by SGLang backend")
 	default:
 		return nil, fmt.Errorf("unsupported backend mode %q", mode)
 	}

--- a/pkg/inference/backends/vllm/vllm_config.go
+++ b/pkg/inference/backends/vllm/vllm_config.go
@@ -48,6 +48,8 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	// vLLM doesn't have a specific embedding flag like llama.cpp
 	// Embedding models are detected automatically
 	case inference.BackendModeReranking:
+	case inference.BackendModeImageGeneration:
+		return nil, fmt.Errorf("image generation mode not supported by vLLM backend")
 	default:
 		return nil, fmt.Errorf("unsupported backend mode %q", mode)
 	}

--- a/pkg/inference/platform/platform.go
+++ b/pkg/inference/platform/platform.go
@@ -1,3 +1,4 @@
+// Package platform provides platform-specific checks for backend support.
 package platform
 
 import "runtime"
@@ -16,4 +17,10 @@ func SupportsMLX() bool {
 // SupportsSGLang returns true if SGLang is supported on the current platform.
 func SupportsSGLang() bool {
 	return runtime.GOOS == "linux"
+}
+
+// SupportsDiffusers returns true if diffusers is supported on the current platform.
+// Diffusers is supported on Linux (Docker/GPU) and macOS (MPS/CPU).
+func SupportsDiffusers() bool {
+	return runtime.GOOS == "linux" || runtime.GOOS == "darwin"
 }

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -41,6 +41,8 @@ func backendModeForRequest(path string) (inference.BackendMode, bool) {
 	} else if strings.HasSuffix(path, "/v1/messages") || strings.HasSuffix(path, "/v1/messages/count_tokens") {
 		// Anthropic Messages API - treated as completion mode
 		return inference.BackendModeCompletion, true
+	} else if strings.HasSuffix(path, "/v1/images/generations") {
+		return inference.BackendModeImageGeneration, true
 	}
 	return inference.BackendMode(0), false
 }

--- a/pkg/inference/scheduling/http_handler.go
+++ b/pkg/inference/scheduling/http_handler.go
@@ -76,8 +76,14 @@ func (h *HTTPHandler) routeHandlers() map[string]http.HandlerFunc {
 		"POST " + inference.InferencePrefix + "/v1/messages/count_tokens",
 	}
 
+	// OpenAI Images API routes
+	imageRoutes := []string{
+		"POST " + inference.InferencePrefix + "/{backend}/v1/images/generations",
+		"POST " + inference.InferencePrefix + "/v1/images/generations",
+	}
+
 	m := make(map[string]http.HandlerFunc)
-	for _, route := range append(openAIRoutes, anthropicRoutes...) {
+	for _, route := range append(append(openAIRoutes, anthropicRoutes...), imageRoutes...) {
 		m[route] = h.handleOpenAIInference
 	}
 

--- a/pkg/inference/scheduling/images_api.go
+++ b/pkg/inference/scheduling/images_api.go
@@ -1,0 +1,38 @@
+package scheduling
+
+// ImageGenerationRequest represents an OpenAI-compatible image generation request.
+// See https://platform.openai.com/docs/api-reference/images/create
+type ImageGenerationRequest struct {
+	// Model is the model to use for image generation.
+	Model string `json:"model"`
+	// Prompt is the text description of the desired image(s).
+	Prompt string `json:"prompt"`
+	// N is the number of images to generate. Defaults to 1.
+	N int `json:"n,omitempty"`
+	// Size is the size of the generated images. Defaults to "1024x1024".
+	Size string `json:"size,omitempty"`
+	// Quality is the quality of the image. "standard" or "hd". Defaults to "standard".
+	Quality string `json:"quality,omitempty"`
+	// ResponseFormat is the format of the generated images. "url" or "b64_json". Defaults to "url".
+	ResponseFormat string `json:"response_format,omitempty"`
+	// Style is the style of the generated images. "vivid" or "natural". Defaults to "vivid".
+	Style string `json:"style,omitempty"`
+}
+
+// ImageGenerationResponse represents an OpenAI-compatible image generation response.
+type ImageGenerationResponse struct {
+	// Created is the Unix timestamp of when the images were created.
+	Created int64 `json:"created"`
+	// Data is the list of generated images.
+	Data []ImageData `json:"data"`
+}
+
+// ImageData represents a single generated image.
+type ImageData struct {
+	// URL is the URL of the generated image. Present when response_format is "url".
+	URL string `json:"url,omitempty"`
+	// B64JSON is the base64-encoded JSON of the generated image. Present when response_format is "b64_json".
+	B64JSON string `json:"b64_json,omitempty"`
+	// RevisedPrompt is the prompt that was used if it was revised.
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}

--- a/pkg/internal/jsonutil/jsonutil.go
+++ b/pkg/internal/jsonutil/jsonutil.go
@@ -12,7 +12,9 @@ func ReadFile[T any](path string, result T) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	dec := json.NewDecoder(f)
 	if err := dec.Decode(&result); err != nil {
 		return fmt.Errorf("parsing JSON: %w", err)

--- a/pkg/internal/utils/log.go
+++ b/pkg/internal/utils/log.go
@@ -1,3 +1,4 @@
+// Package utils provides utility functions for internal use.
 package utils
 
 import (

--- a/pkg/responses/streaming.go
+++ b/pkg/responses/streaming.go
@@ -486,8 +486,8 @@ func (s *StreamingResponseWriter) sendEvent(eventType string, event *StreamEvent
 		return
 	}
 
-	fmt.Fprintf(s.w, "event: %s\n", eventType)
-	fmt.Fprintf(s.w, "data: %s\n\n", data)
+	_, _ = fmt.Fprintf(s.w, "event: %s\n", eventType)
+	_, _ = fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	if s.flusher != nil {
 		s.flusher.Flush()

--- a/python/diffusers_server/__init__.py
+++ b/python/diffusers_server/__init__.py
@@ -1,0 +1,7 @@
+"""Diffusers server for Docker Model Runner.
+
+This package provides an OpenAI-compatible image generation API
+backed by the Hugging Face diffusers library.
+"""
+
+__version__ = "0.1.0"

--- a/python/diffusers_server/__main__.py
+++ b/python/diffusers_server/__main__.py
@@ -1,0 +1,71 @@
+"""Entry point for running the diffusers server as a module.
+
+Usage:
+    python -m diffusers_server --model-path /path/to/model --socket /path/to/socket
+"""
+
+import argparse
+import sys
+
+from .server import run_server
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Diffusers server for Docker Model Runner"
+    )
+    parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Path to the diffusers model directory",
+    )
+    parser.add_argument(
+        "--socket",
+        required=True,
+        help="Unix socket path to listen on",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=["auto", "cpu", "cuda", "mps"],
+        help="Device to run inference on (default: auto)",
+    )
+    parser.add_argument(
+        "--precision",
+        default="auto",
+        choices=["auto", "fp16", "bf16", "fp32"],
+        help="Precision for inference (default: auto)",
+    )
+    parser.add_argument(
+        "--enable-attention-slicing",
+        action="store_true",
+        help="Enable attention slicing for memory efficiency",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        nargs="*",
+        default=[],
+        help="Model names to serve (for OpenAI API compatibility)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        run_server(
+            model_path=args.model_path,
+            socket_path=args.socket,
+            device=args.device,
+            precision=args.precision,
+            enable_attention_slicing=args.enable_attention_slicing,
+            served_model_names=args.served_model_name,
+        )
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/diffusers_server/pipeline.py
+++ b/python/diffusers_server/pipeline.py
@@ -1,0 +1,181 @@
+"""Diffusers pipeline wrapper for image generation."""
+
+import logging
+import os
+from typing import List, Optional
+
+import torch
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+class DiffusersPipeline:
+    """Wrapper for diffusers pipelines supporting various image generation models."""
+
+    def __init__(
+        self,
+        model_path: str,
+        device: str = "auto",
+        precision: str = "auto",
+        enable_attention_slicing: bool = False,
+    ):
+        """Initialize the diffusers pipeline.
+
+        Args:
+            model_path: Path to the model directory
+            device: Device to use (auto, cpu, cuda, mps)
+            precision: Precision to use (auto, fp16, bf16, fp32)
+            enable_attention_slicing: Enable attention slicing for memory efficiency
+        """
+        self.model_path = model_path
+        self.device = self._resolve_device(device)
+        self.dtype = self._resolve_dtype(precision)
+        self.enable_attention_slicing = enable_attention_slicing
+
+        logger.info(f"Using device: {self.device}, dtype: {self.dtype}")
+
+        self.pipeline = self._load_pipeline()
+
+    def _resolve_device(self, device: str) -> str:
+        """Resolve the device to use."""
+        if device != "auto":
+            return device
+
+        if torch.cuda.is_available():
+            return "cuda"
+        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return "mps"
+        else:
+            return "cpu"
+
+    def _resolve_dtype(self, precision: str) -> torch.dtype:
+        """Resolve the dtype to use."""
+        if precision == "fp16":
+            return torch.float16
+        elif precision == "bf16":
+            return torch.bfloat16
+        elif precision == "fp32":
+            return torch.float32
+        elif precision == "auto":
+            # Use fp16 on GPU, fp32 on CPU
+            if self.device in ("cuda", "mps"):
+                return torch.float16
+            else:
+                return torch.float32
+        else:
+            return torch.float32
+
+    def _load_pipeline(self):
+        """Load the appropriate diffusers pipeline based on model type."""
+        from diffusers import (
+            DiffusionPipeline,
+            StableDiffusionPipeline,
+            StableDiffusionXLPipeline,
+        )
+
+        # Check for model_index.json to determine pipeline type
+        model_index_path = os.path.join(self.model_path, "model_index.json")
+
+        try:
+            if os.path.exists(model_index_path):
+                # Use auto-detection via DiffusionPipeline
+                logger.info("Loading pipeline using DiffusionPipeline.from_pretrained")
+                pipeline = DiffusionPipeline.from_pretrained(
+                    self.model_path,
+                    torch_dtype=self.dtype,
+                    local_files_only=True,
+                )
+            else:
+                # Try StableDiffusion as fallback
+                logger.info("No model_index.json found, trying StableDiffusionPipeline")
+                try:
+                    pipeline = StableDiffusionXLPipeline.from_pretrained(
+                        self.model_path,
+                        torch_dtype=self.dtype,
+                        local_files_only=True,
+                    )
+                except Exception:
+                    pipeline = StableDiffusionPipeline.from_pretrained(
+                        self.model_path,
+                        torch_dtype=self.dtype,
+                        local_files_only=True,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to load pipeline: {e}")
+            raise RuntimeError(f"Failed to load diffusers model from {self.model_path}: {e}")
+
+        # Move to device
+        pipeline = pipeline.to(self.device)
+
+        # Apply optimizations
+        if self.enable_attention_slicing:
+            logger.info("Enabling attention slicing")
+            pipeline.enable_attention_slicing()
+
+        # Enable memory efficient attention if available
+        if self.device == "cuda":
+            try:
+                pipeline.enable_xformers_memory_efficient_attention()
+                logger.info("Enabled xformers memory efficient attention")
+            except Exception:
+                logger.info("xformers not available, using default attention")
+
+        return pipeline
+
+    def generate(
+        self,
+        prompt: str,
+        num_images: int = 1,
+        width: int = 1024,
+        height: int = 1024,
+        num_inference_steps: int = 30,
+        guidance_scale: float = 7.5,
+        negative_prompt: Optional[str] = None,
+        seed: Optional[int] = None,
+    ) -> List[Image.Image]:
+        """Generate images from a text prompt.
+
+        Args:
+            prompt: The text prompt to generate images from
+            num_images: Number of images to generate
+            width: Image width
+            height: Image height
+            num_inference_steps: Number of denoising steps
+            guidance_scale: Guidance scale for classifier-free guidance
+            negative_prompt: Negative prompt for guidance
+            seed: Random seed for reproducibility
+
+        Returns:
+            List of PIL Images
+        """
+        generator = None
+        if seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(seed)
+
+        logger.info(
+            f"Generating {num_images} image(s): {width}x{height}, "
+            f"steps={num_inference_steps}, guidance={guidance_scale}"
+        )
+
+        # Build kwargs based on pipeline capabilities
+        kwargs = {
+            "prompt": prompt,
+            "num_images_per_prompt": num_images,
+            "width": width,
+            "height": height,
+            "num_inference_steps": num_inference_steps,
+            "guidance_scale": guidance_scale,
+        }
+
+        if generator is not None:
+            kwargs["generator"] = generator
+
+        if negative_prompt is not None:
+            kwargs["negative_prompt"] = negative_prompt
+
+        # Run inference
+        with torch.inference_mode():
+            result = self.pipeline(**kwargs)
+
+        return result.images

--- a/python/diffusers_server/server.py
+++ b/python/diffusers_server/server.py
@@ -1,0 +1,215 @@
+"""FastAPI server implementing OpenAI-compatible image generation API."""
+
+import base64
+import io
+import logging
+import os
+import socket
+import time
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+import uvicorn
+
+from .pipeline import DiffusersPipeline
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Diffusers Server", version="0.1.0")
+
+# Global pipeline instance
+_pipeline: Optional[DiffusersPipeline] = None
+_served_model_names: List[str] = []
+
+
+class ImageGenerationRequest(BaseModel):
+    """OpenAI-compatible image generation request."""
+
+    model: str
+    prompt: str
+    n: int = Field(default=1, ge=1, le=10)
+    size: str = Field(default="1024x1024")
+    quality: str = Field(default="standard")
+    response_format: str = Field(default="b64_json")
+    style: str = Field(default="vivid")
+
+
+class ImageData(BaseModel):
+    """Single generated image data."""
+
+    url: Optional[str] = None
+    b64_json: Optional[str] = None
+    revised_prompt: Optional[str] = None
+
+
+class ImageGenerationResponse(BaseModel):
+    """OpenAI-compatible image generation response."""
+
+    created: int
+    data: List[ImageData]
+
+
+class ErrorDetail(BaseModel):
+    """Error detail for OpenAI-compatible error response."""
+
+    message: str
+    type: str
+    param: Optional[str] = None
+    code: Optional[str] = None
+
+
+class ErrorResponse(BaseModel):
+    """OpenAI-compatible error response."""
+
+    error: ErrorDetail
+
+
+def parse_size(size: str) -> tuple[int, int]:
+    """Parse size string like '1024x1024' into (width, height)."""
+    try:
+        parts = size.lower().split("x")
+        if len(parts) != 2:
+            raise ValueError(f"Invalid size format: {size}")
+        width, height = int(parts[0]), int(parts[1])
+        return width, height
+    except (ValueError, IndexError) as e:
+        raise ValueError(f"Invalid size format: {size}") from e
+
+
+@app.post("/v1/images/generations", response_model=ImageGenerationResponse)
+async def generate_images(request: ImageGenerationRequest) -> ImageGenerationResponse:
+    """Generate images from a text prompt."""
+    global _pipeline, _served_model_names
+
+    if _pipeline is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    # Validate model name if served_model_names is configured
+    if _served_model_names and request.model not in _served_model_names:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{request.model}' not found. Available: {_served_model_names}",
+        )
+
+    try:
+        width, height = parse_size(request.size)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Map quality to inference steps
+    num_inference_steps = 50 if request.quality == "hd" else 30
+
+    try:
+        images = _pipeline.generate(
+            prompt=request.prompt,
+            num_images=request.n,
+            width=width,
+            height=height,
+            num_inference_steps=num_inference_steps,
+        )
+    except Exception as e:
+        logger.exception("Error generating images")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Convert images to response format
+    data = []
+    for img in images:
+        if request.response_format == "b64_json":
+            # Convert PIL Image to base64
+            buffer = io.BytesIO()
+            img.save(buffer, format="PNG")
+            b64_data = base64.b64encode(buffer.getvalue()).decode("utf-8")
+            data.append(ImageData(b64_json=b64_data))
+        else:
+            # URL format not supported without file storage
+            raise HTTPException(
+                status_code=400,
+                detail="response_format 'url' not supported, use 'b64_json'",
+            )
+
+    return ImageGenerationResponse(
+        created=int(time.time()),
+        data=data,
+    )
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "ok", "model_loaded": _pipeline is not None}
+
+
+@app.get("/v1/models")
+async def list_models():
+    """List available models (OpenAI-compatible)."""
+    models = []
+    for name in _served_model_names:
+        models.append(
+            {
+                "id": name,
+                "object": "model",
+                "created": int(time.time()),
+                "owned_by": "diffusers",
+            }
+        )
+    return {"object": "list", "data": models}
+
+
+def run_server(
+    model_path: str,
+    socket_path: str,
+    device: str = "auto",
+    precision: str = "auto",
+    enable_attention_slicing: bool = False,
+    served_model_names: Optional[List[str]] = None,
+):
+    """Run the diffusers server on a Unix domain socket."""
+    global _pipeline, _served_model_names
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    logger.info(f"Loading model from {model_path}")
+    logger.info(f"Device: {device}, Precision: {precision}")
+
+    # Load the pipeline
+    _pipeline = DiffusersPipeline(
+        model_path=model_path,
+        device=device,
+        precision=precision,
+        enable_attention_slicing=enable_attention_slicing,
+    )
+
+    _served_model_names = served_model_names or []
+    logger.info(f"Serving model names: {_served_model_names}")
+
+    # Remove existing socket if present
+    if os.path.exists(socket_path):
+        os.unlink(socket_path)
+
+    logger.info(f"Starting server on unix://{socket_path}")
+
+    # Create and bind the socket manually for Unix domain sockets
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(socket_path)
+    os.chmod(socket_path, 0o666)
+
+    config = uvicorn.Config(
+        app,
+        log_level="info",
+    )
+    server = uvicorn.Server(config)
+
+    # Override the socket
+    server.config.fd = sock.fileno()
+
+    try:
+        server.run(sockets=[sock])
+    finally:
+        sock.close()
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)


### PR DESCRIPTION
This commit introduces a new diffusers backend that enables image
generation capabilities in the model runner. The backend integrates with
Hugging Face diffusers library to provide OpenAI-compatible image
generation API endpoints.

The implementation includes a new Python server component that runs as a
subprocess and handles image generation requests through a Unix socket
interface. The backend supports various diffusers models and provides
configuration options for device selection, precision, and memory
optimization features.

Additionally, the Dockerfile now includes a diffusers variant with the
necessary Python dependencies pre-installed. The model distribution
logic has been updated to properly handle diffusers model formats with
their directory structure preserved in the model bundles.

Signed-off-by: Eric Curtin <eric.curtin@docker.com>
