### PR TITLE
Add environment variable for custom backend paths

### DIFF
--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -40,21 +40,25 @@ type vLLM struct {
 	config *Config
 	// status is the state in which the vLLM backend is in.
 	status string
+	// customBinaryPath is an optional custom path to the vllm binary.
+	customBinaryPath string
 }
 
 // New creates a new vLLM-based backend.
-func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config) (inference.Backend, error) {
+// customBinaryPath is an optional path to a custom vllm binary; if empty, the default path is used.
+func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config, customBinaryPath string) (inference.Backend, error) {
 	// If no config is provided, use the default configuration
 	if conf == nil {
 		conf = NewDefaultVLLMConfig()
 	}
 
 	return &vLLM{
-		log:          log,
-		modelManager: modelManager,
-		serverLog:    serverLog,
-		config:       conf,
-		status:       "not installed",
+		log:              log,
+		modelManager:     modelManager,
+		serverLog:        serverLog,
+		config:           conf,
+		status:           "not installed",
+		customBinaryPath: customBinaryPath,
 	}, nil
 }
 
@@ -171,5 +175,8 @@ func (v *vLLM) GetDiskUsage() (int64, error) {
 }
 
 func (v *vLLM) binaryPath() string {
+	if v.customBinaryPath != "" {
+		return v.customBinaryPath
+	}
 	return filepath.Join(vllmDir, "vllm")
 }

--- a/vllm_backend.go
+++ b/vllm_backend.go
@@ -9,12 +9,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func initVLLMBackend(log *logrus.Logger, modelManager *models.Manager) (inference.Backend, error) {
+func initVLLMBackend(log *logrus.Logger, modelManager *models.Manager, customBinaryPath string) (inference.Backend, error) {
 	return vllm.New(
 		log,
 		modelManager,
 		log.WithFields(logrus.Fields{"component": vllm.Name}),
 		nil,
+		customBinaryPath,
 	)
 }
 

--- a/vllm_backend_stub.go
+++ b/vllm_backend_stub.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func initVLLMBackend(log *logrus.Logger, modelManager *models.Manager) (inference.Backend, error) {
+func initVLLMBackend(log *logrus.Logger, modelManager *models.Manager, customBinaryPath string) (inference.Backend, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Support custom paths for vLLM, SGLang, and MLX backends via environment
variables. This allows users to specify custom binary and Python paths
for each backend. Log the custom paths when set. Update backend
initialization functions to accept custom paths.

Signed-off-by: Eric Curtin <eric.curtin@docker.com>
