### PR TITLE
fix(models): deduplicate "Pushing model" log message

### DIFF
--- a/pkg/distribution/distribution/client.go
+++ b/pkg/distribution/distribution/client.go
@@ -592,7 +592,7 @@ func (c *Client) PushModel(ctx context.Context, tag string, progressWriter io.Wr
 	}
 
 	// Push the model
-	c.log.Infoln("Pushing model:", tag)
+	c.log.Infoln("Pushing model:", utils.SanitizeForLog(tag, -1))
 	if err := target.Write(ctx, mdl, progressWriter); err != nil {
 		c.log.Errorln("Failed to push image:", err, "reference:", tag)
 		if writeErr := progress.WriteError(progressWriter, fmt.Sprintf("Error: %s", err.Error())); writeErr != nil {

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -400,8 +400,6 @@ func (m *Manager) Push(model string, r *http.Request, w http.ResponseWriter) err
 		isJSON:  isJSON,
 	}
 
-	// Pull the model using the Docker model distribution client
-	m.log.Infoln("Pushing model:", utils.SanitizeForLog(model, -1))
 	err := m.distributionClient.PushModel(r.Context(), model, progressWriter)
 	if err != nil {
 		return fmt.Errorf("error while pushing model: %w", err)


### PR DESCRIPTION
The log was appearing twice - once in manager.Push and once in client.PushModel. Keep only the client-level log.

Before:
```
time="2026-01-12T13:03:16Z" level=info msg="Pushing model: doringeman657/smollm2" component=model-manager
time="2026-01-12T13:03:16Z" level=info msg="Pushing model: doringeman657/smollm2" component=model-manager
time="2026-01-12T13:03:16Z" level=warning msg="reference for unknown type: application/vnd.docker.ai.gguf.v3"
time="2026-01-12T13:03:17Z" level=warning msg="reference for unknown type: application/vnd.docker.ai.license"
time="2026-01-12T13:03:17Z" level=info msg="Successfully pushed model: doringeman657/smollm2" component=model-manager
```