### PR TITLE
chore(ci): show "and latest" in run-name when pushLatest is true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release model-runner images for CE
-run-name: Release model-runner images for CE, version ${{ inputs.releaseTag }}
+run-name: Release model-runner images for CE, version ${{ inputs.releaseTag }}${{ inputs.pushLatest && ' and latest' || '' }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Show "and latest" in the workflow run name when `pushLatest` is true.

Test: https://github.com/docker/model-runner/actions/runs/20958745020.