### PR TITLE
chore(ci): improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,8 @@ on:
         default: false
       releaseTag:
         description: "Release tag"
-        required: false
+        required: true
         type: string
-        default: "test"
       llamaServerVersion:
         description: "llama-server version"
         required: false


### PR DESCRIPTION
- Add job summary table showing all release parameters at a glance
- Simplify tag formatting logic using a reusable bash function (42 → 18 lines)
- Make releaseTag a required input to prevent accidental pushes to default "test" tag

Test: https://github.com/docker/model-runner/actions/runs/20959387670.

<img width="373" height="394" alt="Screenshot 2026-01-13 at 15 59 16" src="https://github.com/user-attachments/assets/8da31ab1-5057-4abc-8190-8d764f10afc7" />
