### PR TITLE
feat(authn): support DOCKER_USERNAME/DOCKER_PASSWORD env vars

### DIFF
--- a/pkg/distribution/oci/authn/authn.go
+++ b/pkg/distribution/oci/authn/authn.go
@@ -92,12 +92,17 @@ func (k *defaultKeychain) Resolve(r Resource) (Authenticator, error) {
 	registry := r.RegistryStr()
 
 	// Try environment variables first
-	if username := os.Getenv("DOCKER_HUB_USER"); username != "" {
-		if password := os.Getenv("DOCKER_HUB_PASSWORD"); password != "" {
-			return &Basic{
-				Username: username,
-				Password: password,
-			}, nil
+	for _, envPair := range []struct{ user, pass string }{
+		{"DOCKER_USERNAME", "DOCKER_PASSWORD"},
+		{"DOCKER_HUB_USER", "DOCKER_HUB_PASSWORD"},
+	} {
+		if username := os.Getenv(envPair.user); username != "" {
+			if password := os.Getenv(envPair.pass); password != "" {
+				return &Basic{
+					Username: username,
+					Password: password,
+				}, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Add support for both DOCKER_USERNAME/DOCKER_PASSWORD and the existing DOCKER_HUB_USER/DOCKER_HUB_PASSWORD environment variables in DefaultKeychain.

This change is part of an effort to remove mdltool, which had its own env var handling for DOCKER_USERNAME/DOCKER_PASSWORD. By moving this support into DefaultKeychain, registry clients automatically pick up credentials without requiring explicit configuration.

Previous PR part of the initiative of removing `mdltool`: https://github.com/docker/model-runner/pull/567.
It helps https://github.com/docker/model-publisher/pull/77.