### PR TITLE
fix: update vLLM installation message to reflect correct command usage

### DIFF
--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -28,7 +28,7 @@ const (
 const (
 	enableViaCLI = "Enable Docker Model Runner via the CLI → docker desktop enable model-runner"
 	enableViaGUI = "Enable Docker Model Runner via the GUI → Go to Settings->AI->Enable Docker Model Runner"
-	enableVLLM   = "It looks like you're trying to use a model for vLLM → docker model install-runner --vllm"
+	enableVLLM   = "It looks like you're trying to use a model for vLLM → docker model reinstall-runner --backend vllm --gpu cuda"
 )
 
 // getDefaultRegistry returns the default registry, checking for environment override


### PR DESCRIPTION
```
docker model status
latest: Pulling from docker/model-runner
551b54d111b6: Pulling fs layer 
b9b9c5dd5c4b: Pulling fs layer 
1ff8feaee46b: Pulling fs layer 
Digest: sha256:0b4641277ed9d95f698c832533868cc6d19774bce34a1b9327cb9026cae1fc76
Status: Downloaded newer image for docker/model-runner:latest
Successfully pulled docker/model-runner:latest
Creating model storage volume docker-model-runner-models...
Starting model runner container docker-model-runner...
Docker Model Runner is running

Status:
mlx: not installed
sglang: python3 not found in PATH
vllm: vLLM binary not found
llama.cpp: running llama.cpp version: 34ce48d
docker model install-runner --backend vllm --gpu cuda
Model Runner container docker-model-runner (f59422d6973f) is already running
```
As you can see if I try to install the new runner using `install-runner` after pulling the new image it will not start the new container as it detects DMR already running.
By using `reinstall-runner` we purge running containers