### PR TITLE
feat: add Anthropic streaming response recording support

### DIFF
--- a/pkg/inference/scheduling/http_handler.go
+++ b/pkg/inference/scheduling/http_handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/docker/model-runner/pkg/distribution/distribution"
@@ -140,6 +141,12 @@ func (h *HTTPHandler) handleOpenAIInference(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		http.Error(w, "unknown request path", http.StatusInternalServerError)
 		return
+	}
+
+	// Set origin header for Anthropic Messages API requests if not already set.
+	// This enables proper response format detection in the recorder.
+	if strings.HasSuffix(r.URL.Path, "/v1/messages") && r.Header.Get(inference.RequestOriginHeader) == "" {
+		r.Header.Set(inference.RequestOriginHeader, inference.OriginAnthropicMessages)
 	}
 
 	// Decode the model specification portion of the request body.


### PR DESCRIPTION
The OpenAIRecorder now properly records responses for Anthropic requests.

```
MODEL_RUNNER_PORT=8080 make run LOCAL_LLAMA=1
```

```
curl http://localhost:8080/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "smollm2",
    "stream": true,
    "messages": [
      {"role": "user", "content": "Hello!"}
    ]
  }'
```

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model
requests --model smollm2 | jq .
[
  {
    "count": 1,
    "model": "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9",
    "config": {},
    "records": [
      {
        "id": "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9_1768999211627027000",
        "model": "smollm2",
        "method": "POST",
        "url": "/engines/v1/messages",
        "request": "{\"messages\":[{\"content\":\"Hello!\",\"role\":\"user\"}],\"model\":\"smollm2\",\"stream\":true}",
        "response": "{\"content\":[{\"text\":\"Hello! How can I assist you today?\",\"type\":\"text\"}],\"id\":\"chatcmpl-AyGEMVnmV8hRABRX4CFmfcnp77q2lUXz\",\"model\":\"model.gguf\",\"role\":\"assistant\",\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"type\":\"message\",\"usage\":{\"output_tokens\":10}}",
        "timestamp": 1768999211,
        "status_code": 200,
        "user_agent": "curl/8.7.1",
        "origin": "anthropic/messages"
      }
    ]
  }
]
```