### PR TITLE
Implement parallel layer pushing with error handling

### DIFF
--- a/pkg/distribution/oci/remote/remote.go
+++ b/pkg/distribution/oci/remote/remote.go
@@ -778,7 +778,7 @@ func Write(ref reference.Reference, img oci.Image, w io.Writer, opts ...Option) 
 
 			desc := v1.Descriptor{
 				MediaType: string(mt),
-				Digest:    godigest.Digest(digest.String()),
+				Digest:    godigest.Digest(digestStr),
 				Size:      size,
 			}
 


### PR DESCRIPTION
This pull request improves the performance and reliability of the `Write` function in `pkg/distribution/oci/remote/remote.go` by parallelizing the layer upload process and enhancing error handling. Layers are now pushed concurrently, and errors from each upload are collected and reported together.

**Parallelization and concurrency improvements:**

* Modified the `Write` function to push image layers in parallel using goroutines and a `sync.WaitGroup`, which can significantly speed up the upload process for multi-layer images.
* Introduced a `pushLayerResult` struct and a results array to capture the outcome (success, already exists, or error) of each concurrent layer upload.

**Error handling enhancements:**

* Changed error handling so that each layer upload's error is recorded in the results array, and after all uploads complete, errors are collected and joined using `errors.Join` for comprehensive reporting.
* Updated the logic to ensure that resources (progress reporters, writers, and readers) are properly closed and errors are handled in all code paths, including when a layer already exists or an error occurs during upload, compression, or commit.
