### PR TITLE
refactor: resolve Docker credentials on CLI side instead of copying config

### DIFF
--- a/pkg/distribution/distribution/client_test.go
+++ b/pkg/distribution/distribution/client_test.go
@@ -79,7 +79,7 @@ func TestClientPullModel(t *testing.T) {
 
 	t.Run("pull without progress writer", func(t *testing.T) {
 		// Pull model from registry without progress writer
-		err := client.PullModel(t.Context(), tag, nil)
+		err := client.PullModel(t.Context(), tag, nil, nil)
 		if err != nil {
 			t.Fatalf("Failed to pull model: %v", err)
 		}
@@ -112,7 +112,7 @@ func TestClientPullModel(t *testing.T) {
 		var progressBuffer bytes.Buffer
 
 		// Pull model from registry with progress writer
-		if err := client.PullModel(t.Context(), tag, &progressBuffer); err != nil {
+		if err := client.PullModel(t.Context(), tag, &progressBuffer, nil); err != nil {
 			t.Fatalf("Failed to pull model: %v", err)
 		}
 
@@ -160,7 +160,7 @@ func TestClientPullModel(t *testing.T) {
 
 		// Test with non-existent repository
 		nonExistentRef := registryHost + "/nonexistent/model:v1.0.0"
-		err = testClient.PullModel(t.Context(), nonExistentRef, &progressBuffer)
+		err = testClient.PullModel(t.Context(), nonExistentRef, &progressBuffer, nil)
 		if err == nil {
 			t.Fatal("Expected error for non-existent model, got nil")
 		}
@@ -216,7 +216,7 @@ func TestClientPullModel(t *testing.T) {
 		}
 
 		// Push model to registry
-		if err := testClient.PushModel(t.Context(), testTag, nil); err != nil {
+		if err := testClient.PushModel(t.Context(), testTag, nil, nil); err != nil {
 			t.Fatalf("Failed to pull model: %v", err)
 		}
 
@@ -262,7 +262,7 @@ func TestClientPullModel(t *testing.T) {
 		var progressBuffer bytes.Buffer
 
 		// Pull the model again - this should detect the incomplete file and pull again
-		if err := testClient.PullModel(t.Context(), testTag, &progressBuffer); err != nil {
+		if err := testClient.PullModel(t.Context(), testTag, &progressBuffer, nil); err != nil {
 			t.Fatalf("Failed to pull model: %v", err)
 		}
 
@@ -315,7 +315,7 @@ func TestClientPullModel(t *testing.T) {
 		}
 
 		// Pull first version of model
-		if err := testClient.PullModel(t.Context(), testTag, nil); err != nil {
+		if err := testClient.PullModel(t.Context(), testTag, nil, nil); err != nil {
 			t.Fatalf("Failed to pull first version of model: %v", err)
 		}
 
@@ -359,7 +359,7 @@ func TestClientPullModel(t *testing.T) {
 		var progressBuffer bytes.Buffer
 
 		// Pull model again - should get the updated version
-		if err := testClient.PullModel(t.Context(), testTag, &progressBuffer); err != nil {
+		if err := testClient.PullModel(t.Context(), testTag, &progressBuffer, nil); err != nil {
 			t.Fatalf("Failed to pull updated model: %v", err)
 		}
 
@@ -405,7 +405,7 @@ func TestClientPullModel(t *testing.T) {
 		if err := remote.Write(ref, newMdl, nil, remote.WithPlainHTTP(true)); err != nil {
 			t.Fatalf("Failed to push model: %v", err)
 		}
-		if err := client.PullModel(t.Context(), testTag, nil); err == nil || !errors.Is(err, ErrUnsupportedMediaType) {
+		if err := client.PullModel(t.Context(), testTag, nil, nil); err == nil || !errors.Is(err, ErrUnsupportedMediaType) {
 			t.Fatalf("Expected artifact version error, got %v", err)
 		}
 	})
@@ -446,7 +446,7 @@ func TestClientPullModel(t *testing.T) {
 
 		// Try to pull the safetensors model with a progress writer to capture warnings
 		var progressBuf bytes.Buffer
-		err = testClient.PullModel(t.Context(), testTag, &progressBuf)
+		err = testClient.PullModel(t.Context(), testTag, &progressBuf, nil)
 
 		// Pull should succeed on all platforms now (with a warning on non-Linux)
 		if err != nil {
@@ -478,7 +478,7 @@ func TestClientPullModel(t *testing.T) {
 		var progressBuffer bytes.Buffer
 
 		// Pull model from registry with progress writer
-		if err := testClient.PullModel(t.Context(), tag, &progressBuffer); err != nil {
+		if err := testClient.PullModel(t.Context(), tag, &progressBuffer, nil); err != nil {
 			t.Fatalf("Failed to pull model: %v", err)
 		}
 
@@ -555,7 +555,7 @@ func TestClientPullModel(t *testing.T) {
 
 		// Test with non-existent model
 		nonExistentRef := registryHost + "/nonexistent/model:v1.0.0"
-		err = testClient.PullModel(t.Context(), nonExistentRef, &progressBuffer)
+		err = testClient.PullModel(t.Context(), nonExistentRef, &progressBuffer, nil)
 
 		// Expect an error
 		if err == nil {
@@ -813,7 +813,7 @@ func TestNewReferenceError(t *testing.T) {
 
 	// Test with invalid reference
 	invalidRef := "invalid:reference:format"
-	err = client.PullModel(t.Context(), invalidRef, nil)
+	err = client.PullModel(t.Context(), invalidRef, nil, nil)
 	if err == nil {
 		t.Fatal("Expected error for invalid reference, got nil")
 	}
@@ -858,7 +858,7 @@ func TestPush(t *testing.T) {
 	}
 
 	// Push the model to the registry
-	if err := client.PushModel(t.Context(), tag, nil); err != nil {
+	if err := client.PushModel(t.Context(), tag, nil, nil); err != nil {
 		t.Fatalf("Failed to push model: %v", err)
 	}
 
@@ -868,7 +868,7 @@ func TestPush(t *testing.T) {
 	}
 
 	// Test that model can be pulled successfully
-	if err := client.PullModel(t.Context(), tag, nil); err != nil {
+	if err := client.PullModel(t.Context(), tag, nil, nil); err != nil {
 		t.Fatalf("Failed to pull model: %v", err)
 	}
 
@@ -929,7 +929,7 @@ func TestPushProgress(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		defer pw.Close()
-		done <- client.PushModel(t.Context(), tag, pw)
+		done <- client.PushModel(t.Context(), tag, pw, nil)
 		close(done)
 	}()
 
@@ -1051,7 +1051,7 @@ func TestClientPushModelNotFound(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	if err := client.PushModel(t.Context(), "non-existent-model:latest", nil); !errors.Is(err, ErrModelNotFound) {
+	if err := client.PushModel(t.Context(), "non-existent-model:latest", nil, nil); !errors.Is(err, ErrModelNotFound) {
 		t.Fatalf("Expected ErrModelNotFound got: %v", err)
 	}
 }

--- a/pkg/distribution/distribution/ecr_test.go
+++ b/pkg/distribution/distribution/ecr_test.go
@@ -43,7 +43,7 @@ func TestECRIntegration(t *testing.T) {
 		if err := client.store.Write(mdl, []string{ecrTag}, nil); err != nil {
 			t.Fatalf("Failed to write model to store: %v", err)
 		}
-		if err := client.PushModel(t.Context(), ecrTag, nil); err != nil {
+		if err := client.PushModel(t.Context(), ecrTag, nil, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
 		if _, err := client.DeleteModel(ecrTag, false); err != nil { // cleanup
@@ -53,7 +53,7 @@ func TestECRIntegration(t *testing.T) {
 
 	// Test pull from ECR
 	t.Run("Pull without progress", func(t *testing.T) {
-		err := client.PullModel(t.Context(), ecrTag, nil)
+		err := client.PullModel(t.Context(), ecrTag, nil, nil)
 		if err != nil {
 			t.Fatalf("Failed to pull model from ECR: %v", err)
 		}

--- a/pkg/distribution/distribution/gar_test.go
+++ b/pkg/distribution/distribution/gar_test.go
@@ -44,7 +44,7 @@ func TestGARIntegration(t *testing.T) {
 		if err := client.store.Write(mdl, []string{garTag}, nil); err != nil {
 			t.Fatalf("Failed to write model to store: %v", err)
 		}
-		if err := client.PushModel(t.Context(), garTag, nil); err != nil {
+		if err := client.PushModel(t.Context(), garTag, nil, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
 		if _, err := client.DeleteModel(garTag, false); err != nil { // cleanup
@@ -54,7 +54,7 @@ func TestGARIntegration(t *testing.T) {
 
 	// Test pull from GAR
 	t.Run("Pull without progress", func(t *testing.T) {
-		err := client.PullModel(t.Context(), garTag, nil)
+		err := client.PullModel(t.Context(), garTag, nil, nil)
 		if err != nil {
 			t.Fatalf("Failed to pull model from GAR: %v", err)
 		}

--- a/pkg/inference/models/api.go
+++ b/pkg/inference/models/api.go
@@ -16,6 +16,20 @@ import (
 type ModelCreateRequest struct {
 	// From is the name of the model to pull.
 	From string `json:"from"`
+	// BearerToken is an optional bearer token for authentication (e.g., for Hugging Face).
+	BearerToken string `json:"bearer-token,omitempty"`
+	// Username is an optional username for registry authentication.
+	Username string `json:"username,omitempty"`
+	// Password is an optional password for registry authentication.
+	Password string `json:"password,omitempty"`
+}
+
+// ModelPushRequest represents a model push request.
+type ModelPushRequest struct {
+	// Username is an optional username for registry authentication.
+	Username string `json:"username,omitempty"`
+	// Password is an optional password for registry authentication.
+	Password string `json:"password,omitempty"`
 	// BearerToken is an optional bearer token for authentication.
 	BearerToken string `json:"bearer-token,omitempty"`
 }

--- a/pkg/inference/models/handler_test.go
+++ b/pkg/inference/models/handler_test.go
@@ -114,7 +114,7 @@ func TestPullModel(t *testing.T) {
 			}
 
 			w := httptest.NewRecorder()
-			err = handler.manager.Pull(tag, "", r, w)
+			err = handler.manager.Pull(tag, nil, r, w)
 			if err != nil {
 				t.Fatalf("Failed to pull model: %v", err)
 			}
@@ -221,7 +221,7 @@ func TestHandleGetModel(t *testing.T) {
 			if !tt.remote && !strings.Contains(tt.modelName, "nonexistent") {
 				r := httptest.NewRequest(http.MethodPost, "/models/create", strings.NewReader(`{"from": "`+tt.modelName+`"}`))
 				w := httptest.NewRecorder()
-				err = handler.manager.Pull(tt.modelName, "", r, w)
+				err = handler.manager.Pull(tt.modelName, nil, r, w)
 				if err != nil {
 					t.Fatalf("Failed to pull model: %v", err)
 				}

--- a/pkg/ollama/http_handler.go
+++ b/pkg/ollama/http_handler.go
@@ -651,7 +651,7 @@ func (h *HTTPHandler) handlePull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call the model manager's Pull method with the wrapped writer
-	if err := h.modelManager.Pull(modelName, "", r, ollamaWriter); err != nil {
+	if err := h.modelManager.Pull(modelName, nil, r, ollamaWriter); err != nil {
 		h.log.Errorf("Failed to pull model: %s", utils.SanitizeForLog(err.Error(), -1))
 
 		// Send error in Ollama JSON format


### PR DESCRIPTION
Instead of copying ~/.docker/config.json into the container, credentials are now resolved on the CLI side using the Docker credential helpers and sent with pull/push requests. This simplifies container setup and avoids exposing the full Docker config inside the container.

To test following the next steps, you'd need to either connect to Offload or use `_MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY=1`.

```
make docker-build DOCKER_IMAGE=docker/model-runner:test-docker-cli-auth
```

```
MODEL_RUNNER_CONTROLLER_VERSION=test-docker-cli-auth MODEL_RUNNER_CONTROLLER_VARIANT=cpu docker model start-runner
```
```
$ docker model package --gguf /Users/dorin/.cache/huggingface/hub/models--HuggingFaceTB--SmolLM2-360M-Instruct-GGUF/snapshots/593b5a2e04c8f3e4ee880263f93e0bd2901ad47f/smollm2-360m-instruct-q8_0.gguf --push doringeman657/my-smollm2
Adding GGUF file from "/Users/dorin/.cache/huggingface/hub/models--HuggingFaceTB--SmolLM2-360M-Instruct-GGUF/snapshots/593b5a2e04c8f3e4ee880263f93e0bd2901ad47f/smollm2-360m-instruct-q8_0.gguf"
Pushing model to registry...
WARN[0001] reference for unknown type: application/vnd.docker.ai.gguf.v3
Uploaded: 368.50 MB
Model pushed successfully
```

Resolves #560.
I'd merge this once we get https://github.com/docker/model-runner/pull/582 merged as well.