### PR TITLE
fix(tls): use t.TempDir() instead of os.MkdirTemp in tests

### DIFF
--- a/pkg/tls/certs_test.go
+++ b/pkg/tls/certs_test.go
@@ -16,6 +16,26 @@ import (
 	"time"
 )
 
+func testCertPaths(t *testing.T) *CertPaths {
+	t.Helper()
+	tmpDir := t.TempDir()
+	return &CertPaths{
+		CACert:     filepath.Join(tmpDir, CACertFile),
+		CAKey:      filepath.Join(tmpDir, CAKeyFile),
+		ServerCert: filepath.Join(tmpDir, ServerCertFile),
+		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
+	}
+}
+
+func setupTestCerts(t *testing.T) *CertPaths {
+	t.Helper()
+	paths := testCertPaths(t)
+	if err := GenerateCertificates(paths); err != nil {
+		t.Fatalf("GenerateCertificates() error = %v", err)
+	}
+	return paths
+}
+
 func TestGenerateSelfSignedCA(t *testing.T) {
 	key, cert, err := GenerateSelfSignedCA()
 	if err != nil {
@@ -109,19 +129,7 @@ func TestGenerateServerCert(t *testing.T) {
 }
 
 func TestGenerateCertificates(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Verify all files exist
 	for _, path := range []string{paths.CACert, paths.CAKey, paths.ServerCert, paths.ServerKey} {
@@ -145,19 +153,7 @@ func TestGenerateCertificates(t *testing.T) {
 }
 
 func TestLoadTLSConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Load TLS config
 	tlsConfig, err := LoadTLSConfig(paths.ServerCert, paths.ServerKey)
@@ -180,19 +176,7 @@ func TestLoadTLSConfig(t *testing.T) {
 }
 
 func TestLoadClientTLSConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Test loading with CA cert
 	tlsConfig, err := LoadClientTLSConfig(paths.CACert, false)
@@ -258,19 +242,7 @@ func TestLoadClientTLSConfig_CAErrors(t *testing.T) {
 }
 
 func TestEnsureCertificates_CustomPaths(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Generate certs first
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Test with custom paths
 	cert, key, err := EnsureCertificates(paths.ServerCert, paths.ServerKey)
@@ -295,14 +267,7 @@ func TestEnsureCertificates_MissingFile(t *testing.T) {
 }
 
 func TestCertsExistAndValid(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
+	paths := testCertPaths(t)
 
 	// Should return false when files don't exist
 	if certsExistAndValid(paths) {
@@ -310,8 +275,7 @@ func TestCertsExistAndValid(t *testing.T) {
 	}
 
 	// Generate certs
-	err := GenerateCertificates(paths)
-	if err != nil {
+	if err := GenerateCertificates(paths); err != nil {
 		t.Fatalf("GenerateCertificates() error = %v", err)
 	}
 
@@ -401,19 +365,7 @@ func TestCertsExistAndValid(t *testing.T) {
 }
 
 func TestTLSServerIntegration(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Load server TLS config
 	serverTLSConfig, err := LoadTLSConfig(paths.ServerCert, paths.ServerKey)
@@ -456,19 +408,7 @@ func TestTLSServerIntegration(t *testing.T) {
 }
 
 func TestCertificatePEMEncoding(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	paths := &CertPaths{
-		CACert:     filepath.Join(tmpDir, CACertFile),
-		CAKey:      filepath.Join(tmpDir, CAKeyFile),
-		ServerCert: filepath.Join(tmpDir, ServerCertFile),
-		ServerKey:  filepath.Join(tmpDir, ServerKeyFile),
-	}
-
-	err := GenerateCertificates(paths)
-	if err != nil {
-		t.Fatalf("GenerateCertificates() error = %v", err)
-	}
+	paths := setupTestCerts(t)
 
 	// Read and verify PEM encoding of certificate
 	certPEM, err := os.ReadFile(paths.ServerCert)


### PR DESCRIPTION
Fix lint on main.

```
$ make lint
Running golangci-lint on root module...
golangci-lint run ./...
0 issues.
Running golangci-lint on cmd/cli module...
cd cmd/cli && golangci-lint run ./...
0 issues.
✓ Go linting passed!
```