### PR TITLE
fix(containers): improve port binding error message for clarity

### DIFF
--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -566,7 +566,7 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 			_ = dockerClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		}
 		if isPortBindingError(err) {
-			return fmt.Errorf("failed to start container %s: %w\n\nThe port may already be in use by Docker Desktop's model runner.\nTry running: docker desktop disable model-runner", controllerContainerName, err)
+			return fmt.Errorf("failed to start container %s: %w\n\nThe port may already be in use by Docker Desktop's Model Runner.\nTry running: docker desktop disable model-runner", controllerContainerName, err)
 		}
 		return fmt.Errorf("failed to start container %s: %w", controllerContainerName, err)
 	}


### PR DESCRIPTION
Address https://github.com/docker/model-runner/issues/526 by providing the command to disable DD TCP:
```
Starting model runner container docker-model-runner...
Error: unable to initialize standalone model runner container: failed to start container docker-model-runner: Error response from daemon: ports are not available: exposing port TCP 127.0.0.1:12434 -> 127.0.0.1:0: listen tcp4 127.0.0.1:12434: bind: address already in use

The port may already be in use by Docker Desktop's model runner.
Try running: docker desktop disable model-runner
```