### PR TITLE
fix(vllm): add pooling runner for embedding mode and update tests

### DIFF
--- a/pkg/inference/backends/vllm/vllm_config.go
+++ b/pkg/inference/backends/vllm/vllm_config.go
@@ -45,8 +45,8 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	case inference.BackendModeCompletion:
 		// Default mode for vLLM
 	case inference.BackendModeEmbedding:
-		// vLLM doesn't have a specific embedding flag like llama.cpp
-		// Embedding models are detected automatically
+		// Use pooling runner for embedding models
+		args = append(args, "--runner", "pooling")
 	case inference.BackendModeReranking:
 		// vLLM does not have a specific flag for reranking
 	case inference.BackendModeImageGeneration:


### PR DESCRIPTION
For embeddings explicitly set `--runner pooling` otherwise vllm it fails to load certain models like `all-minilm-l6-v2-vllm`

```
Traceback (most recent call last):" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/bin/vllm\", line 10, in <module>" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    sys.exit(main())" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="             ^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/cli/main.py\", line 66, in main" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/cli/serve.py\", line 72, in subparser_init" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    serve_parser = make_arg_parser(serve_parser)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/openai/cli_args.py\", line 278, in make_arg_parser" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    parser = AsyncEngineArgs.add_cli_args(parser)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 2040, in add_cli_args" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    parser = EngineArgs.add_cli_args(parser)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 1108, in add_cli_args" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    vllm_kwargs = get_kwargs(VllmConfig)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="                  ^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 347, in get_kwargs" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    return copy.deepcopy(_compute_kwargs(cls))" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="                         ^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 257, in _compute_kwargs" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    default = default.default_factory()" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="              ^^^^^^^^^^^^^^^^^^^^^^^^^" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py\", line 121, in __init__" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/config/device.py\", line 58, in __post_init__" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="    raise RuntimeError(" component=vllm
time="2026-01-29T14:55:54Z" level=info msg="RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue." component=vllm
time="2026-01-29T14:55:55Z" level=warning msg="Backend vllm running model all-minilm-l6-v2-vllm exited with error: vLLM terminated unexpectedly: vLLM failed:     vllm_kwargs = get_kwargs(VllmConfig)\n                  ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 347, in get_kwargs\n    return copy.deepcopy(_compute_kwargs(cls))\n                         ^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/engine/arg_utils.py\", line 257, in _compute_kwargs\n    default = default.default_factory()\n              ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/vllm-env/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py\", line 121, in __init__\n    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)\n  File \"/opt/vllm-env/lib/python3.12/site-packages/vllm/config/device.py\", line 58, in __post_init__\n    raise RuntimeError(\nRuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.\npython3.12/site-packages/vllm/engine/arg_utils.py\", line 1108, in add_cli_args\n"
time="2026-01-29T14:55:55Z" level=info msg="Getting model by reference: sha256:abc7e6f6f162450cd292926a9f6669c5da402cc87c6bd5d706d5f77dc756f9ff" component=model-manager
time="2026-01-29T14:55:55Z" level=info msg="Listing available models" component=model-manager
```