### PR TITLE
fix: check local store before pulling HuggingFace models

### DIFF
--- a/pkg/distribution/distribution/client.go
+++ b/pkg/distribution/distribution/client.go
@@ -251,7 +251,8 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 		c.log.Infoln("Using native HuggingFace pull for:", utils.SanitizeForLog(reference))
 
 		// Check if model already exists in local store (reference is already normalized)
-		if localModel, err := c.store.Read(reference); err == nil {
+		localModel, err := c.store.Read(reference)
+		if err == nil {
 			c.log.Infoln("HuggingFace model found in local store:", utils.SanitizeForLog(reference))
 			cfg, err := localModel.Config()
 			if err != nil {
@@ -261,6 +262,9 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 				c.log.Warnf("Writing progress: %v", err)
 			}
 			return nil
+		}
+		if !errors.Is(err, ErrModelNotFound) {
+			return fmt.Errorf("checking for cached HuggingFace model: %w", err)
 		}
 
 		// Pass original reference to preserve case-sensitivity for HuggingFace API


### PR DESCRIPTION
## Summary

Fixes #616

Previously, HuggingFace models were always downloaded from the Hub even if the same model already existed in the local store. This caused unnecessary bandwidth usage and slower pull times.

## Changes

- Added cache check in `PullModel()` before calling `pullNativeHuggingFace()`
- If model exists in local store, returns immediately with "Using cached model" message
- Added `hf.co` to `huggingface.co` URL normalization in `normalizeModelName()` for consistent cache lookups
- Added unit tests for both full URL and short URL cache scenarios

## Testing

```bash
go test ./pkg/distribution/distribution/... -v -run "TestPullHuggingFace"
```

Both new test cases pass:
- `TestPullHuggingFaceModelFromCache` - tests cache hit with full huggingface.co URL
- `TestPullHuggingFaceModelFromCacheWithShortURL` - tests cache hit when pulling with hf.co URL

## Result

After this change:
- First pull: downloads from HuggingFace Hub as normal
- Subsequent pulls: uses cached model, no network request needed
- Works with both `huggingface.co/...` and `hf.co/...` URL formats