### PR TITLE
fix(launch): improve error message for missing arguments

### DIFF
--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -91,7 +91,7 @@ func newLaunchCmd() *cobra.Command {
 		Long: fmt.Sprintf(`Launch an app configured to use Docker Model Runner.
 
 Supported apps: %s`, strings.Join(supportedApps, ", ")),
-		Args:      cobra.MinimumNArgs(1),
+		Args:      requireMinArgs(1, "launch", "APP [-- APP_ARGS...]"),
 		ValidArgs: supportedApps,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := strings.ToLower(args[0])


### PR DESCRIPTION
Now:
```
$ docker model launch
'docker model launch' requires at least 1 argument(s).

Usage:  docker model launch APP [-- APP_ARGS...]

See 'docker model launch --help' for more information
```

Before:
```
$ docker model launch
requires at least 1 arg(s), only received 0
```

CC @denyszhak 