### PR TITLE
fix: build vLLM from source for ARM64 CUDA 13 (NVIDIA DGX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DOCKER_TARGET ?= final-llamacpp
 PORT := 8080
 MODELS_PATH := $(shell pwd)/models-store
 LLAMA_ARGS ?=
+EXTRA_DOCKER_BUILD_ARGS ?=
 DOCKER_BUILD_ARGS := \
 	--load \
 	--platform linux/$(shell docker version --format '{{.Server.Arch}}') \
@@ -84,11 +85,11 @@ lint:
 
 # Build Docker image
 docker-build:
-	docker buildx build $(DOCKER_BUILD_ARGS) .
+	docker buildx build $(DOCKER_BUILD_ARGS) $(EXTRA_DOCKER_BUILD_ARGS) .
 
 # Build multi-platform Docker image
 docker-build-multiplatform:
-	docker buildx build --platform linux/amd64,linux/arm64 $(DOCKER_BUILD_ARGS) .
+	docker buildx build --platform linux/amd64,linux/arm64 $(DOCKER_BUILD_ARGS) $(EXTRA_DOCKER_BUILD_ARGS) .
 
 # Run in Docker container with TCP port access and mounted model storage
 docker-run: docker-build


### PR DESCRIPTION
The prebuilt vLLM ARM64 wheels have ABI incompatibility with PyTorch CUDA 13 nightly builds. For ARM64 with CUDA 13 (e.g., NVIDIA DGX GB300 Blackwell, DGX GB200):
- Install CUDA toolkit 13.0 for compilation
- Use PyTorch nightly with cu130 support
- Build vLLM from source to ensure ABI compatibility

Add VLLM_ARM64_BUILD_FROM_SOURCE build arg (default: true) to allow opting out of source builds for faster build times on non-CUDA 13 systems.

Also:
- Update AMD64 wheel path to manylinux_2_35 (required for cu130)
- Bump vLLM to 0.15.1

See https://docs.vllm.ai/en/latest/getting_started/installation/gpu/#use-the-local-cutlass-for-compilation.

---

```
# Default: build from source (NVIDIA DGX / CUDA 13)
$ make docker-run-vllm

# Opt-out: use prebuilt wheel (faster build, may not work on CUDA 13)
$ make docker-run-vllm EXTRA_DOCKER_BUILD_ARGS="--build-arg VLLM_ARM64_BUILD_FROM_SOURCE=false"
```

```
$ sudo dmidecode -s system-product-name
DGX Station GB300

$ make docker-run-vllm # took ~42 min (built vLLM from source)
```

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run smollm2-vllm hi
Hello there! I’m here to help with an interesting task. What can I assist you with?
```