### PR TITLE
fix: add daemon-side model repackaging for Linux support

### DIFF
--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -416,3 +416,23 @@ func (m *Manager) Purge() error {
 	}
 	return nil
 }
+
+func (m *Manager) Export(ref string, w io.Writer) error {
+	if m.distributionClient == nil {
+		return fmt.Errorf("model distribution service unavailable")
+	}
+	return m.distributionClient.ExportModel(ref, w)
+}
+
+type RepackageOptions struct {
+	ContextSize *uint64 `json:"context_size,omitempty"`
+}
+
+func (m *Manager) Repackage(sourceRef string, targetRef string, opts RepackageOptions) error {
+	if m.distributionClient == nil {
+		return fmt.Errorf("model distribution service unavailable")
+	}
+	return m.distributionClient.RepackageModel(sourceRef, targetRef, distribution.RepackageOptions{
+		ContextSize: opts.ContextSize,
+	})
+}


### PR DESCRIPTION
When packaging a model with --from on Linux, the CLI cannot access the model store directly since it's in a Docker volume. This adds a /models/{name}/repackage endpoint that allows the daemon to perform config-only changes (like context-size) server-side.

For simple cases (--from with only --context-size), the CLI now calls the daemon's repackage API directly. For complex cases (adding licenses, pushing to registry), it falls back to exporting the model as a tarball.

Fixes #633

CC @ilopezluna This is a fairly quick fix. Eventually we can deduplicate some logic existing both in the CLI and inside these new handlers from the backend.

---

```
make docker-run
```

```
MODEL_RUNNER_HOST=http://localhost:8080 docker model pull smollm2
MODEL_RUNNER_HOST=http://localhost:8080 docker model package --from ai/smollm2 --context-size 1024 my-smollm2
MODEL_RUNNER_HOST=http://localhost:8080 docker model run my-smollm2 hi
```