### PR TITLE
feat: add per-model keep_alive configuration for idle eviction

### DIFF
--- a/cmd/cli/commands/configure.go
+++ b/cmd/cli/commands/configure.go
@@ -11,7 +11,7 @@ func newConfigureCmd() *cobra.Command {
 	var flags ConfigureFlags
 
 	c := &cobra.Command{
-		Use:     "configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] MODEL [-- <runtime-flags...>]",
+		Use:     "configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] [--keep-alive=<duration>] MODEL [-- <runtime-flags...>]",
 		Aliases: []string{"config"},
 		Short:   "Manage model runtime configurations",
 		Hidden:  true,

--- a/cmd/cli/desktop/desktop.go
+++ b/cmd/cli/desktop/desktop.go
@@ -650,16 +650,12 @@ func (c *Client) Remove(modelArgs []string, force bool) (string, error) {
 
 // BackendStatus to be imported from docker/model-runner when https://github.com/docker/model-runner/pull/42 is merged.
 type BackendStatus struct {
-	// BackendName is the name of the backend
-	BackendName string `json:"backend_name"`
-	// ModelName is the name of the model loaded in the backend
-	ModelName string `json:"model_name"`
-	// Mode is the mode the backend is operating in
-	Mode string `json:"mode"`
-	// LastUsed represents when this backend was last used (if it's idle)
-	LastUsed time.Time `json:"last_used,omitempty"`
-	// InUse indicates whether this backend is currently handling a request
-	InUse bool `json:"in_use,omitempty"`
+	BackendName string               `json:"backend_name"`
+	ModelName   string               `json:"model_name"`
+	Mode        string               `json:"mode"`
+	LastUsed    time.Time            `json:"last_used,omitempty"`
+	InUse       bool                 `json:"in_use,omitempty"`
+	KeepAlive   *inference.KeepAlive `json:"keep_alive,omitempty"`
 }
 
 func (c *Client) PS() ([]BackendStatus, error) {

--- a/cmd/cli/docs/reference/docker_model_configure.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure.yaml
@@ -2,7 +2,7 @@ command: docker model configure
 aliases: docker model configure, docker model config
 short: Manage model runtime configurations
 long: Manage model runtime configurations
-usage: docker model configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] MODEL [-- <runtime-flags...>]
+usage: docker model configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] [--keep-alive=<duration>] MODEL [-- <runtime-flags...>]
 pname: docker model
 plink: docker_model.yaml
 cname:
@@ -32,6 +32,16 @@ options:
     - option: hf_overrides
       value_type: string
       description: HuggingFace model config overrides (JSON) - vLLM only
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: keep-alive
+      value_type: string
+      description: |
+        duration to keep model loaded (e.g., '5m', '1h', '0' to unload immediately, '-1' to never unload)
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/inference/backend_test.go
+++ b/pkg/inference/backend_test.go
@@ -1,0 +1,216 @@
+package inference
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestParseKeepAlive(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    KeepAlive
+		expectError bool
+	}{
+		{
+			name:     "zero means unload immediately",
+			input:    "0",
+			expected: KeepAliveImmediate,
+		},
+		{
+			name:     "negative one means never unload",
+			input:    "-1",
+			expected: KeepAliveForever,
+		},
+		{
+			name:     "negative duration means never unload",
+			input:    "-1m",
+			expected: KeepAliveForever,
+		},
+		{
+			name:     "5 minutes",
+			input:    "5m",
+			expected: KeepAlive(5 * time.Minute),
+		},
+		{
+			name:     "1 hour",
+			input:    "1h",
+			expected: KeepAlive(1 * time.Hour),
+		},
+		{
+			name:     "30 seconds",
+			input:    "30s",
+			expected: KeepAlive(30 * time.Second),
+		},
+		{
+			name:     "24 hours",
+			input:    "24h",
+			expected: KeepAlive(24 * time.Hour),
+		},
+		{
+			name:     "complex duration",
+			input:    "1h30m",
+			expected: KeepAlive(1*time.Hour + 30*time.Minute),
+		},
+		{
+			name:        "invalid string",
+			input:       "abc",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := ParseKeepAlive(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error for input %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for input %q: %v", tt.input, err)
+				return
+			}
+			if d != tt.expected {
+				t.Errorf("expected %v for input %q, got %v", tt.expected, tt.input, d)
+			}
+		})
+	}
+}
+
+func TestKeepAliveDuration(t *testing.T) {
+	ka := KeepAlive(5 * time.Minute)
+	if ka.Duration() != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", ka.Duration())
+	}
+
+	if KeepAliveForever.Duration() != -1 {
+		t.Errorf("expected -1ns, got %v", KeepAliveForever.Duration())
+	}
+
+	if KeepAliveImmediate.Duration() != 0 {
+		t.Errorf("expected 0, got %v", KeepAliveImmediate.Duration())
+	}
+
+	if KeepAliveDefault.Duration() != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", KeepAliveDefault.Duration())
+	}
+}
+
+func TestKeepAliveJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    KeepAlive
+		expected string
+	}{
+		{
+			name:     "5 minutes",
+			input:    KeepAlive(5 * time.Minute),
+			expected: `"5m0s"`,
+		},
+		{
+			name:     "never unload",
+			input:    KeepAliveForever,
+			expected: `"-1"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("marshal "+tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, string(data))
+			}
+		})
+
+		t.Run("roundtrip "+tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			var result KeepAlive
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if result != tt.input {
+				t.Errorf("roundtrip mismatch: expected %v, got %v", tt.input, result)
+			}
+		})
+	}
+
+	t.Run("unmarshal 0", func(t *testing.T) {
+		var ka KeepAlive
+		if err := json.Unmarshal([]byte(`"0"`), &ka); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ka != KeepAliveImmediate {
+			t.Errorf("expected KeepAliveImmediate, got %v", ka)
+		}
+	})
+
+	t.Run("unmarshal -1", func(t *testing.T) {
+		var ka KeepAlive
+		if err := json.Unmarshal([]byte(`"-1"`), &ka); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ka != KeepAliveForever {
+			t.Errorf("expected KeepAliveForever, got %v", ka)
+		}
+	})
+
+	t.Run("unmarshal invalid", func(t *testing.T) {
+		var ka KeepAlive
+		if err := json.Unmarshal([]byte(`"abc"`), &ka); err == nil {
+			t.Error("expected error for invalid duration string")
+		}
+	})
+}
+
+func TestKeepAliveInBackendConfiguration(t *testing.T) {
+	ka := KeepAlive(10 * time.Minute)
+	config := BackendConfiguration{
+		KeepAlive: &ka,
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var result BackendConfiguration
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if result.KeepAlive == nil {
+		t.Fatal("expected KeepAlive to be set")
+	}
+	if *result.KeepAlive != ka {
+		t.Errorf("expected %v, got %v", ka, *result.KeepAlive)
+	}
+
+	// Test nil KeepAlive
+	config2 := BackendConfiguration{}
+	data2, err := json.Marshal(config2)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var result2 BackendConfiguration
+	if err := json.Unmarshal(data2, &result2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result2.KeepAlive != nil {
+		t.Errorf("expected nil KeepAlive, got %v", *result2.KeepAlive)
+	}
+}

--- a/pkg/inference/scheduling/api.go
+++ b/pkg/inference/scheduling/api.go
@@ -76,7 +76,8 @@ type BackendStatus struct {
 	// LastUsed represents when this (backend, model, mode) tuple was last used
 	LastUsed time.Time `json:"last_used,omitempty"`
 	// InUse indicates whether this backend is currently handling a request
-	InUse bool `json:"in_use,omitempty"`
+	InUse     bool                 `json:"in_use,omitempty"`
+	KeepAlive *inference.KeepAlive `json:"keep_alive,omitempty"`
 }
 
 // DiskUsage represents the disk usage of the models and default backend.

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -162,6 +162,11 @@ func (s *Scheduler) getLoaderStatus(ctx context.Context) []BackendStatus {
 				status.LastUsed = s.loader.timestamps[runnerInfo.slot]
 			}
 
+			configKey := makeConfigKey(key.backend, key.modelID, key.mode)
+			if cfg, ok := s.loader.runnerConfigs[configKey]; ok && cfg.KeepAlive != nil {
+				status.KeepAlive = cfg.KeepAlive
+			}
+
 			result = append(result, status)
 		}
 	}
@@ -263,11 +268,11 @@ func (s *Scheduler) ConfigureRunner(ctx context.Context, backend inference.Backe
 		return nil, err
 	}
 
-	// Build runner configuration with shared settings
 	var runnerConfig inference.BackendConfiguration
 	runnerConfig.ContextSize = req.ContextSize
 	runnerConfig.Speculative = req.Speculative
 	runnerConfig.RuntimeFlags = runtimeFlags
+	runnerConfig.KeepAlive = req.KeepAlive
 
 	// Set vLLM-specific configuration if provided
 	if req.VLLM != nil {


### PR DESCRIPTION
Allow developers to control how long a model stays loaded in memory before being evicted, following [Ollama API semantics](https://github.com/ollama/ollama/blob/9ec733e5279385006e2b8c302e24573bdd861049/docs/faq.mdx#how-do-i-keep-a-model-loaded-in-memory-or-make-it-unload-immediately). Supports duration strings (5m, 1h), 0 for immediate unload, and -1 for never.

Implements https://github.com/docker/model-runner/issues/84.

---

```
MODEL_RUNNER_PORT=8080 make run
```

DMR:
```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model configure smollm2 --keep-alive 10m
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model ps
MODEL NAME  BACKEND    MODE        UNTIL
smollm2     llama.cpp  completion  9 minutes from now
```

Also works for the Ollama API:
```
$ curl http://localhost:8080/api/generate -d '{"model": "smollm2", "keep_alive": 60}'
$ OLLAMA_HOST=localhost:8080 ollama run smollm2 hi
...
$ OLLAMA_HOST=localhost:8080 ollama ps
NAME                           ID              SIZE    PROCESSOR    CONTEXT    UNTIL
docker.io/ai/smollm2:latest    sha256:354bf    0 B     100% CPU     0          59 seconds from now
```