### PR TITLE
fix(store): handle non-existent directory by initializing store

### DIFF
--- a/pkg/distribution/internal/store/store.go
+++ b/pkg/distribution/internal/store/store.go
@@ -60,6 +60,15 @@ func (s *LocalStore) Reset() error {
 		return fmt.Errorf("reading store directory: %w", err)
 	}
 
+	// Safeguard: if the directory is non-empty, verify it's a valid store
+	// by checking for the layout.json marker file before deleting anything.
+	// This prevents catastrophic data loss if rootPath is misconfigured.
+	if len(entries) > 0 {
+		if _, statErr := os.Stat(s.layoutPath()); errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("refusing to reset: directory %q does not appear to be a model store (missing layout.json)", s.rootPath)
+		}
+	}
+
 	for _, entry := range entries {
 		entryPath := filepath.Join(s.rootPath, entry.Name())
 		if err := os.RemoveAll(entryPath); err != nil {


### PR DESCRIPTION
This pull request improves the robustness of the `LocalStore` by handling cases where the store directory has been externally deleted, and adds a comprehensive test to verify this behavior.
