### PR TITLE
fix: set working directory for Windows sandbox to resolve DLL loading

### DIFF
--- a/pkg/sandbox/sandbox_windows.go
+++ b/pkg/sandbox/sandbox_windows.go
@@ -82,6 +82,8 @@ func Create(ctx context.Context, configuration string, modifier func(*exec.Cmd),
 	if modifier != nil {
 		modifier(command)
 	}
+	// Set the working directory to where the binary and its DLLs are located.
+	command.Dir = updatedBinPath
 
 	// Create the and start the job.
 	job, err := winjob.Start(command, limits...)


### PR DESCRIPTION
When llama.cpp is dynamically updated, it's placed in a different directory. This directory must be set as the working directory so the executable can find its required DLLs.