### PR TITLE
fix: acquire read lock for r.blobs in test registry POST handler

### DIFF
--- a/pkg/distribution/registry/testregistry/registry.go
+++ b/pkg/distribution/registry/testregistry/registry.go
@@ -69,7 +69,9 @@ func (r *Registry) handleBlobUpload(w http.ResponseWriter, req *http.Request, pa
 	switch req.Method {
 	case http.MethodPost:
 		// Start upload
+		r.mu.RLock()
 		uploadID := fmt.Sprintf("upload-%d", len(r.blobs))
+		r.mu.RUnlock()
 		location := fmt.Sprintf("/v2/%s/blobs/uploads/%s", repo, uploadID)
 		w.Header().Set("Location", location)
 		w.Header().Set("Docker-Upload-UUID", uploadID)


### PR DESCRIPTION
## Summary
- Fixes a pre-existing data race in the test registry detected by `go test -race` on PR #675
- The `len(r.blobs)` read in the POST handler was unprotected while concurrent PUT/PATCH handlers write to the map under `r.mu.Lock()`
- Wraps the read with `r.mu.RLock()`/`r.mu.RUnlock()` to match every other access in the file

## Test plan
- [x] `go test -race ./pkg/inference/models/ -run TestHandleGetModel -count=5` — passes with no race
- [x] `go test -race ./pkg/distribution/registry/... ./pkg/inference/models/...` — passes
- [x] `go test -race ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)