### PR TITLE
ci: add llama.cpp bump script and scheduled workflow

### DIFF
--- a/.github/workflows/bump-llamacpp.yml
+++ b/.github/workflows/bump-llamacpp.yml
@@ -1,0 +1,55 @@
+name: Bump llama.cpp
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'llama.cpp tag to bump to (e.g. b8068). Defaults to latest.'
+        required: false
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: recursive
+
+      - name: Bump llama.cpp
+        id: bump
+        run: |
+          OUTPUT=$(./scripts/bump-llamacpp.sh ${{ inputs.tag }})
+          echo "$OUTPUT"
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            COMMIT_MSG=$(echo "$OUTPUT" | grep -oP "(?<=-m ').*(?=')")
+            echo "commit-msg=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: ${{ steps.bump.outputs.commit-msg }}
+        run: |
+          TAG=$(echo "$COMMIT_MSG" | grep -oP '[^/]+(?=\)$)')
+          gh api -X PATCH "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            -f name="Bump llama.cpp to $TAG"
+          BRANCH="bump-llamacpp-$TAG"
+          git checkout -b "$BRANCH"
+          git commit --signoff -m "$COMMIT_MSG"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump llama.cpp to $TAG" \
+            --body "Bumps llama.cpp submodule to [$TAG](https://github.com/ggml-org/llama.cpp/releases/$TAG)."

--- a/scripts/bump-llamacpp.sh
+++ b/scripts/bump-llamacpp.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Bump llama.cpp submodule to the latest (or specified) tagged release.
+# Usage: ./scripts/bump-llamacpp.sh [<tag>]
+#   <tag>  - a specific llama.cpp tag (e.g. b8068). Defaults to the latest b* tag.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUBMODULE_PATH="llamacpp/native/vendor/llama.cpp"
+SUBMODULE_DIR="$REPO_ROOT/$SUBMODULE_PATH"
+
+if git -C "$REPO_ROOT" submodule status -- "$SUBMODULE_PATH" | grep -q '^-'; then
+    echo "Submodule not initialized. Initializing..."
+    git -C "$REPO_ROOT" submodule update --init --recursive -- "$SUBMODULE_PATH"
+fi
+
+echo "Fetching latest tags from llama.cpp..."
+git -C "$SUBMODULE_DIR" fetch --tags origin --quiet
+
+CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD:"$SUBMODULE_PATH")
+CURRENT_TAG=$(git -C "$SUBMODULE_DIR" describe --tags --exact-match "$CURRENT_SHA" 2>/dev/null || \
+              git -C "$SUBMODULE_DIR" describe --tags "$CURRENT_SHA" 2>/dev/null || \
+              echo "$CURRENT_SHA")
+
+if [[ -n "${1:-}" ]]; then
+    TARGET_TAG="$1"
+    # Verify the specified <tag> exists.
+    if ! git -C "$SUBMODULE_DIR" rev-parse --verify "refs/tags/$TARGET_TAG" >/dev/null 2>&1; then
+        echo "Error: tag '$TARGET_TAG' not found in llama.cpp" >&2
+        exit 1
+    fi
+else
+    # Find the latest b* tag by sorting numerically on the part after 'b'
+    TARGET_TAG=$(git -C "$SUBMODULE_DIR" tag -l 'b[0-9]*' --sort=-v:refname | head -1 || true)
+    if [[ -z "$TARGET_TAG" ]]; then
+        echo "Error: no b* tags found in llama.cpp" >&2
+        exit 1
+    fi
+fi
+
+TARGET_SHA=$(git -C "$SUBMODULE_DIR" rev-parse "refs/tags/$TARGET_TAG")
+
+echo "Current: $CURRENT_TAG ($CURRENT_SHA)"
+echo "Target:  $TARGET_TAG ($TARGET_SHA)"
+
+if [[ "$CURRENT_SHA" == "$TARGET_SHA" ]]; then
+    echo "Already up to date."
+    exit 0
+fi
+
+echo ""
+echo "Updating submodule to $TARGET_TAG..."
+git -C "$SUBMODULE_DIR" checkout --quiet "$TARGET_SHA"
+
+echo "Staging submodule change..."
+git -C "$REPO_ROOT" add -f "$SUBMODULE_PATH"
+
+COMMIT_MSG="chore: bump llama.cpp (https://github.com/ggml-org/llama.cpp/releases/$TARGET_TAG)"
+echo ""
+echo "Done. Commit with:"
+echo "  git commit --signoff -S -m '$COMMIT_MSG'"


### PR DESCRIPTION
E.g.,

```
$ ./scripts/bump-llamacpp.sh
Fetching latest tags from llama.cpp...
Current: b7923 (c55bce415926c7e8484f20d854afebe0168f7513)
Target:  b8068 (267ba5a1d957158316a4fc85b1f0cf316d9a5233)

Updating submodule to b8068...
Staging submodule change...

Done. Commit with:
  git commit --signoff -S -m 'chore: bump llama.cpp (https://github.com/ggml-org/llama.cpp/releases/b8068)'
```

The workflow runs the script every Monday or on manual dispatch, and opens a PR with the update.

In a follow-up PR I'll add some build and test steps to verify the new llama.cpp compiles and works as expected.