### PR TITLE
Enhance opencode integration with model-runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ BUILD_DMR ?= 1
 build:
 	CGO_ENABLED=1 go build -ldflags="-s -w" -o $(APP_NAME) .
 
+build-cli:
+	$(MAKE) -C cmd/cli
+
+docs:
+	$(MAKE) -C cmd/cli docs
+
 # Run the application locally
 run: build
 	@LLAMACPP_BIN="llamacpp/install/bin"; \

--- a/cmd/cli/commands/launch_test.go
+++ b/cmd/cli/commands/launch_test.go
@@ -230,7 +230,7 @@ func TestLaunchHostAppDryRunOpenai(t *testing.T) {
 
 	cli := hostApp{envFn: openaiEnv(openaiPathSuffix)}
 	// Use "ls" as a bin that exists in PATH
-	err := launchHostApp(cmd, "ls", testBaseURL, cli, nil, true)
+	err := launchHostApp(cmd, "ls", testBaseURL, cli, "", nil, nil, true)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -245,7 +245,7 @@ func TestLaunchHostAppDryRunCodex(t *testing.T) {
 	cmd := newTestCmd(buf)
 
 	cli := hostApp{envFn: openaiEnv("/v1")}
-	err := launchHostApp(cmd, "ls", testBaseURL, cli, nil, true)
+	err := launchHostApp(cmd, "ls", testBaseURL, cli, "", nil, nil, true)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -260,7 +260,7 @@ func TestLaunchHostAppDryRunWithArgs(t *testing.T) {
 	cmd := newTestCmd(buf)
 
 	cli := hostApp{envFn: openaiEnv(openaiPathSuffix)}
-	err := launchHostApp(cmd, "ls", testBaseURL, cli, []string{"-m", "ai/qwen3"}, true)
+	err := launchHostApp(cmd, "ls", testBaseURL, cli, "", nil, []string{"-m", "ai/qwen3"}, true)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -272,7 +272,7 @@ func TestLaunchHostAppDryRunAnthropic(t *testing.T) {
 	cmd := newTestCmd(buf)
 
 	cli := hostApp{envFn: anthropicEnv}
-	err := launchHostApp(cmd, "ls", testBaseURL, cli, nil, true)
+	err := launchHostApp(cmd, "ls", testBaseURL, cli, "", nil, nil, true)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -290,7 +290,7 @@ func TestLaunchHostAppNotFound(t *testing.T) {
 	cmd.SetErr(stderr)
 
 	cli := hostApp{envFn: openaiEnv(openaiPathSuffix)}
-	err := launchHostApp(cmd, "nonexistent-binary-xyz", testBaseURL, cli, nil, false)
+	err := launchHostApp(cmd, "nonexistent-binary-xyz", testBaseURL, cli, "", nil, nil, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 
@@ -307,7 +307,7 @@ func TestLaunchHostAppNotFoundNilEnvFn(t *testing.T) {
 	cmd.SetErr(stderr)
 
 	cli := hostApp{envFn: nil}
-	err := launchHostApp(cmd, "nonexistent-binary-xyz", testBaseURL, cli, nil, false)
+	err := launchHostApp(cmd, "nonexistent-binary-xyz", testBaseURL, cli, "", nil, nil, false)
 	require.Error(t, err)
 
 	errOutput := stderr.String()

--- a/cmd/cli/commands/opencode.go
+++ b/cmd/cli/commands/opencode.go
@@ -1,0 +1,264 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// determineHostPort determines the port to use for host access to model-runner.
+//
+// The function uses the following logic:
+//   - For Desktop engine kind: returns the default port (modelRunner global is used)
+//   - For Cloud/Moby engine kinds: uses the port from the runner parameter if available
+//   - Falls back to default port if no port is found
+//
+// Note: The runner parameter is only used for Cloud/Moby engine kinds.
+// For Desktop engine kinds, the global modelRunner context is used instead.
+func determineHostPort(runner *standaloneRunner) uint16 {
+	kind := modelRunner.EngineKind()
+
+	// For Desktop, use the default port
+	if kind == types.ModelRunnerEngineKindDesktop {
+		return standalone.DefaultControllerPortMoby
+	}
+
+	// For Cloud/Moby, use the actual port from the runner
+	if runner != nil && runner.hostPort != 0 {
+		return runner.hostPort
+	}
+
+	if runner != nil && runner.gatewayPort != 0 {
+		return runner.gatewayPort
+	}
+
+	// Fallback to default
+	return standalone.DefaultControllerPortMoby
+}
+
+// setupOpenCode writes the opencode.json and model.json configuration files.
+func setupOpenCode(cmd *cobra.Command, runner *standaloneRunner, model string) error {
+	// Check if model exists, pull if not
+	if err := ensureModelExists(cmd, model); err != nil {
+		return err
+	}
+
+	// Write opencode.json config
+	if err := writeOpenCodeConfig(runner, model); err != nil {
+		return fmt.Errorf("failed to write opencode config: %w", err)
+	}
+
+	// Write model.json state
+	if err := writeOpenCodeState(model); err != nil {
+		return fmt.Errorf("failed to write opencode state: %w", err)
+	}
+
+	return nil
+}
+
+// ensureModelExists checks if the model exists locally, and pulls it if not.
+func ensureModelExists(cmd *cobra.Command, model string) error {
+	models, err := desktopClient.List()
+	if err != nil {
+		return fmt.Errorf("failed to list models: %w", err)
+	}
+
+	// Check if model exists
+	modelExists := false
+	for _, m := range models {
+		for _, tag := range m.Tags {
+			if tag == model || strings.TrimPrefix(tag, "ai/") == model {
+				modelExists = true
+				break
+			}
+		}
+		if modelExists {
+			break
+		}
+	}
+
+	if !modelExists {
+		cmd.Printf("Model %s not found locally. Pulling...\n", model)
+		if err := pullModel(cmd, desktopClient, model); err != nil {
+			return fmt.Errorf("failed to pull model: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// writeOpenCodeConfig writes the ~/.config/opencode/opencode.json file.
+func writeOpenCodeConfig(runner *standaloneRunner, model string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+
+	config := make(map[string]any)
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = json.Unmarshal(data, &config) // Ignore parse errors; treat missing/corrupt files as empty
+	}
+
+	config["$schema"] = "https://opencode.ai/config.json"
+
+	provider, ok := config["provider"].(map[string]any)
+	if !ok {
+		provider = make(map[string]any)
+	}
+
+	// Determine the correct port for host access
+	port := determineHostPort(runner)
+	opencodeBaseURL := fmt.Sprintf("http://127.0.0.1:%d/v1", port)
+
+	dmr, ok := provider["dmr"].(map[string]any)
+	if !ok {
+		dmr = map[string]any{
+			"npm":  "@ai-sdk/openai-compatible",
+			"name": "Docker Model Runner (local)",
+			"options": map[string]any{
+				"baseURL": opencodeBaseURL,
+			},
+		}
+	} else {
+		// Update baseURL in existing config
+		if options, ok := dmr["options"].(map[string]any); ok {
+			options["baseURL"] = opencodeBaseURL
+		} else {
+			dmr["options"] = map[string]any{
+				"baseURL": opencodeBaseURL,
+			}
+		}
+	}
+
+	models, ok := dmr["models"].(map[string]any)
+	if !ok {
+		models = make(map[string]any)
+	}
+
+	// Add model entry
+	entry := map[string]any{
+		"name":    model,
+		"_launch": true,
+	}
+	models[model] = entry
+
+	dmr["models"] = models
+	provider["dmr"] = dmr
+	config["provider"] = provider
+
+	configData, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(configPath, configData, 0o644)
+}
+
+// writeOpenCodeState writes the ~/.local/state/opencode/model.json file.
+func writeOpenCodeState(model string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	statePath := filepath.Join(home, ".local", "state", "opencode", "model.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return err
+	}
+
+	state := map[string]any{
+		"recent":   []any{},
+		"favorite": []any{},
+		"variant":  map[string]any{},
+	}
+	if data, err := os.ReadFile(statePath); err == nil {
+		_ = json.Unmarshal(data, &state) // Ignore parse errors; use defaults
+	}
+
+	recent, _ := state["recent"].([]any)
+
+	// Remove existing entry for this model if present
+	newRecent := []any{}
+	for _, entry := range recent {
+		e, ok := entry.(map[string]any)
+		if !ok || e["providerID"] != "dmr" {
+			newRecent = append(newRecent, entry)
+			continue
+		}
+		modelID, ok := e["modelID"].(string)
+		if !ok || modelID != model {
+			newRecent = append(newRecent, entry)
+		}
+	}
+
+	// Prepend the new model
+	newRecent = append([]any{
+		map[string]any{
+			"providerID": "dmr",
+			"modelID":    model,
+		},
+	}, newRecent...)
+
+	// Keep only the most recent 10 models
+	const maxRecentModels = 10
+	if len(newRecent) > maxRecentModels {
+		newRecent = newRecent[:maxRecentModels]
+	}
+
+	state["recent"] = newRecent
+
+	stateData, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(statePath, stateData, 0o644)
+}
+
+// launchOpenCode launches opencode with automatic configuration.
+// It handles model verification, config file creation, and state management.
+func launchOpenCode(cmd *cobra.Command, baseURL string, model string, runner *standaloneRunner, appArgs []string, dryRun bool) error {
+	if !dryRun {
+		if _, err := exec.LookPath("opencode"); err != nil {
+			cmd.PrintErrf("%q executable not found in PATH.\n", "opencode")
+			cmd.PrintErrf("Configure your app to use:\n")
+			env := openaiEnv(openaiPathSuffix)(baseURL)
+			for _, e := range env {
+				cmd.PrintErrf("  %s\n", e)
+			}
+			return fmt.Errorf("opencode not found; please install it and re-run")
+		}
+	}
+
+	// Setup opencode configuration (skip in dry-run mode)
+	if model != "" && !dryRun {
+		if err := setupOpenCode(cmd, runner, model); err != nil {
+			return fmt.Errorf("failed to setup opencode: %w", err)
+		}
+	}
+
+	env := openaiEnv(openaiPathSuffix)(baseURL)
+	if dryRun {
+		cmd.Printf("Would run: opencode %s\n", strings.Join(appArgs, " "))
+		for _, e := range env {
+			cmd.Printf("  %s\n", e)
+		}
+		if model != "" {
+			cmd.Printf("Would configure opencode with model: %s\n", model)
+		}
+		return nil
+	}
+	return runExternal(cmd, withEnv(env...), "opencode", appArgs...)
+}

--- a/cmd/cli/commands/opencode_test.go
+++ b/cmd/cli/commands/opencode_test.go
@@ -1,0 +1,621 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
+	"github.com/docker/model-runner/cmd/cli/pkg/types"
+	"github.com/docker/model-runner/pkg/inference"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineHostPortDesktop(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	// For Desktop, always returns default port regardless of runner
+	port := determineHostPort(nil)
+	require.Equal(t, uint16(standalone.DefaultControllerPortMoby), port)
+
+	// Even with a runner, Desktop uses default port
+	runner := &standaloneRunner{
+		hostPort: 9999,
+	}
+	port = determineHostPort(runner)
+	require.Equal(t, uint16(standalone.DefaultControllerPortMoby), port)
+}
+
+func TestDetermineHostPortCloudWithGateway(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost:12435",
+		nil,
+		types.ModelRunnerEngineKindCloud,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	runner := &standaloneRunner{
+		gatewayIP:   "172.17.0.1",
+		gatewayPort: 12435,
+	}
+	port := determineHostPort(runner)
+	require.Equal(t, uint16(12435), port)
+}
+
+func TestDetermineHostPortMobyWithHostPort(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost:12434",
+		nil,
+		types.ModelRunnerEngineKindMoby,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	runner := &standaloneRunner{
+		hostPort: 12434,
+	}
+	port := determineHostPort(runner)
+	require.Equal(t, uint16(12434), port)
+}
+
+func TestDetermineHostPortFallback(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost:12434",
+		nil,
+		types.ModelRunnerEngineKindMoby,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	// Nil runner should fallback to default
+	port := determineHostPort(nil)
+	require.Equal(t, uint16(standalone.DefaultControllerPortMoby), port)
+
+	// Runner with no ports should fallback to default
+	runner := &standaloneRunner{
+		gatewayIP:   "172.17.0.1",
+		gatewayPort: 0,
+		hostPort:    0,
+	}
+	port = determineHostPort(runner)
+	require.Equal(t, uint16(standalone.DefaultControllerPortMoby), port)
+}
+
+func TestWriteOpenCodeConfig(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	runner := &standaloneRunner{
+		hostPort: 12434,
+	}
+
+	model := "ai/test-model"
+	err = writeOpenCodeConfig(runner, model)
+	require.NoError(t, err)
+
+	// Verify config file was created
+	configPath := filepath.Join(tmpDir, ".config", "opencode", "opencode.json")
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var config map[string]any
+	err = json.Unmarshal(data, &config)
+	require.NoError(t, err)
+
+	// Verify schema
+	require.Equal(t, "https://opencode.ai/config.json", config["$schema"])
+
+	// Verify provider configuration
+	provider, ok := config["provider"].(map[string]any)
+	require.True(t, ok)
+
+	dmr, ok := provider["dmr"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "@ai-sdk/openai-compatible", dmr["npm"])
+	require.Equal(t, "Docker Model Runner (local)", dmr["name"])
+
+	options, ok := dmr["options"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "http://127.0.0.1:12434/v1", options["baseURL"])
+
+	// Verify model configuration
+	models, ok := dmr["models"].(map[string]any)
+	require.True(t, ok)
+
+	modelEntry, ok := models[model].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, model, modelEntry["name"])
+	require.Equal(t, true, modelEntry["_launch"])
+}
+
+func TestWriteOpenCodeConfigUpdatesExisting(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	// Create existing config
+	configDir := filepath.Join(tmpDir, ".config", "opencode")
+	err = os.MkdirAll(configDir, 0o755)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(configDir, "opencode.json")
+	existingConfig := map[string]any{
+		"existing": "value",
+		"provider": map[string]any{
+			"other": map[string]any{
+				"key": "value",
+			},
+		},
+	}
+	data, err := json.MarshalIndent(existingConfig, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(configPath, data, 0o644)
+	require.NoError(t, err)
+
+	// For Desktop engine kind, the port is always the default
+	runner := &standaloneRunner{
+		hostPort: 9999,
+	}
+
+	model := "ai/new-model"
+	err = writeOpenCodeConfig(runner, model)
+	require.NoError(t, err)
+
+	// Verify config was updated
+	data, err = os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var config map[string]any
+	err = json.Unmarshal(data, &config)
+	require.NoError(t, err)
+
+	// Verify existing values are preserved
+	require.Equal(t, "value", config["existing"])
+
+	provider, ok := config["provider"].(map[string]any)
+	require.True(t, ok)
+
+	// Verify other provider is preserved
+	other, ok := provider["other"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "value", other["key"])
+
+	// Verify dmr was added/updated
+	dmr, ok := provider["dmr"].(map[string]any)
+	require.True(t, ok)
+	options, ok := dmr["options"].(map[string]any)
+	require.True(t, ok)
+	// For Desktop, uses default port regardless of runner port
+	require.Equal(t, "http://127.0.0.1:12434/v1", options["baseURL"])
+
+	// Verify new model was added
+	models, ok := dmr["models"].(map[string]any)
+	require.True(t, ok)
+	_, ok = models[model].(map[string]any)
+	require.True(t, ok)
+}
+
+func TestWriteOpenCodeConfigCreatesDirectory(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	runner := &standaloneRunner{
+		hostPort: 12434,
+	}
+
+	model := "ai/test-model"
+	err = writeOpenCodeConfig(runner, model)
+	require.NoError(t, err)
+
+	// Verify directory was created
+	configDir := filepath.Join(tmpDir, ".config", "opencode")
+	_, err = os.Stat(configDir)
+	require.NoError(t, err)
+}
+
+func TestWriteOpenCodeState(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	model := "ai/test-model"
+	err := writeOpenCodeState(model)
+	require.NoError(t, err)
+
+	// Verify state file was created
+	statePath := filepath.Join(tmpDir, ".local", "state", "opencode", "model.json")
+	data, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	// Verify recent models
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 1)
+
+	entry, ok := recent[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "dmr", entry["providerID"])
+	require.Equal(t, model, entry["modelID"])
+
+	// Verify favorite and variant are empty/default
+	favorite, ok := state["favorite"].([]any)
+	require.True(t, ok)
+	require.Empty(t, favorite)
+
+	variant, ok := state["variant"].(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, variant)
+}
+
+func TestWriteOpenCodeStatePrependsNewModel(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	// Create existing state
+	stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+	err := os.MkdirAll(stateDir, 0o755)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(stateDir, "model.json")
+	existingState := map[string]any{
+		"recent": []any{
+			map[string]any{
+				"providerID": "dmr",
+				"modelID":    "ai/old-model",
+			},
+			map[string]any{
+				"providerID": "other",
+				"modelID":    "other-model",
+			},
+		},
+	}
+	data, err := json.MarshalIndent(existingState, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(statePath, data, 0o644)
+	require.NoError(t, err)
+
+	newModel := "ai/new-model"
+	err = writeOpenCodeState(newModel)
+	require.NoError(t, err)
+
+	// Verify state was updated
+	data, err = os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 3)
+
+	// Verify new model is first
+	firstEntry, ok := recent[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "dmr", firstEntry["providerID"])
+	require.Equal(t, newModel, firstEntry["modelID"])
+
+	// Verify old dmr model is still there but after the new one
+	secondEntry, ok := recent[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "dmr", secondEntry["providerID"])
+	require.Equal(t, "ai/old-model", secondEntry["modelID"])
+}
+
+func TestWriteOpenCodeStateRemovesDuplicate(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	// Create existing state with duplicate model
+	stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+	err := os.MkdirAll(stateDir, 0o755)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(stateDir, "model.json")
+	existingState := map[string]any{
+		"recent": []any{
+			map[string]any{
+				"providerID": "dmr",
+				"modelID":    "ai/existing-model",
+			},
+			map[string]any{
+				"providerID": "other",
+				"modelID":    "other-model",
+			},
+		},
+	}
+	data, err := json.MarshalIndent(existingState, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(statePath, data, 0o644)
+	require.NoError(t, err)
+
+	existingModel := "ai/existing-model"
+	err = writeOpenCodeState(existingModel)
+	require.NoError(t, err)
+
+	// Verify state was updated (no duplicates)
+	data, err = os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 2)
+
+	// Verify existing model is first (moved to top)
+	firstEntry, ok := recent[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "dmr", firstEntry["providerID"])
+	require.Equal(t, existingModel, firstEntry["modelID"])
+
+	// Verify other model is still there
+	secondEntry, ok := recent[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "other", secondEntry["providerID"])
+}
+
+func TestWriteOpenCodeStateLimitsToMaxRecent(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	// Create existing state with many models
+	stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+	err := os.MkdirAll(stateDir, 0o755)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(stateDir, "model.json")
+
+	// Create 15 existing models
+	existingRecent := make([]any, 15)
+	for i := 0; i < 15; i++ {
+		existingRecent[i] = map[string]any{
+			"providerID": "dmr",
+			"modelID":    "ai/model-" + string(rune('a'+i)),
+		}
+	}
+
+	existingState := map[string]any{
+		"recent": existingRecent,
+	}
+	data, err := json.MarshalIndent(existingState, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(statePath, data, 0o644)
+	require.NoError(t, err)
+
+	newModel := "ai/new-model"
+	err = writeOpenCodeState(newModel)
+	require.NoError(t, err)
+
+	// Verify state was limited to max
+	data, err = os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 10)
+
+	// Verify new model is first
+	firstEntry, ok := recent[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "dmr", firstEntry["providerID"])
+	require.Equal(t, newModel, firstEntry["modelID"])
+}
+
+func TestWriteOpenCodeStateHandlesCorruptFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	// Create corrupt state file
+	stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+	err := os.MkdirAll(stateDir, 0o755)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(stateDir, "model.json")
+	err = os.WriteFile(statePath, []byte("not valid json"), 0o644)
+	require.NoError(t, err)
+
+	model := "ai/test-model"
+	err = writeOpenCodeState(model)
+	require.NoError(t, err)
+
+	// Verify state was written with defaults
+	data, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 1)
+}
+
+func TestWriteOpenCodeStateHandlesMissingFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	model := "ai/test-model"
+	err := writeOpenCodeState(model)
+	require.NoError(t, err)
+
+	// Verify state was written
+	statePath := filepath.Join(tmpDir, ".local", "state", "opencode", "model.json")
+	_, err = os.Stat(statePath)
+	require.NoError(t, err)
+}
+
+func TestWriteOpenCodeStatePreservesNonDmrModels(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Mock home directory
+	t.Setenv("HOME", tmpDir)
+
+	// Create existing state with non-dmr models
+	stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+	err := os.MkdirAll(stateDir, 0o755)
+	require.NoError(t, err)
+
+	statePath := filepath.Join(stateDir, "model.json")
+	existingState := map[string]any{
+		"recent": []any{
+			map[string]any{
+				"providerID": "other-provider",
+				"modelID":    "other-model",
+			},
+		},
+	}
+	data, err := json.MarshalIndent(existingState, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(statePath, data, 0o644)
+	require.NoError(t, err)
+
+	model := "ai/test-model"
+	err = writeOpenCodeState(model)
+	require.NoError(t, err)
+
+	// Verify state was updated
+	data, err = os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var state map[string]any
+	err = json.Unmarshal(data, &state)
+	require.NoError(t, err)
+
+	recent, ok := state["recent"].([]any)
+	require.True(t, ok)
+	require.Len(t, recent, 2)
+
+	// Verify non-dmr model is preserved
+	foundNonDmr := false
+	for _, entry := range recent {
+		e, ok := entry.(map[string]any)
+		require.True(t, ok)
+		if e["providerID"] == "other-provider" {
+			foundNonDmr = true
+			require.Equal(t, "other-model", e["modelID"])
+		}
+	}
+	require.True(t, foundNonDmr)
+}
+
+func TestLaunchOpenCodeDryRun(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	buf := new(bytes.Buffer)
+	cmd := newTestCmd(buf)
+
+	runner := &standaloneRunner{
+		hostPort: 12434,
+	}
+
+	err = launchOpenCode(cmd, testBaseURL, "ai/test-model", runner, []string{"--help"}, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, "Would run: opencode --help")
+	require.Contains(t, output, "OPENAI_API_BASE="+testBaseURL+"/engines/v1")
+	require.Contains(t, output, "Would configure opencode with model: ai/test-model")
+}
+
+func TestLaunchOpenCodeDryRunNoModel(t *testing.T) {
+	ctx, err := desktop.NewContextForTest(
+		"http://localhost"+inference.ExperimentalEndpointsPrefix,
+		nil,
+		types.ModelRunnerEngineKindDesktop,
+	)
+	require.NoError(t, err)
+	modelRunner = ctx
+
+	buf := new(bytes.Buffer)
+	cmd := newTestCmd(buf)
+
+	runner := &standaloneRunner{
+		hostPort: 12434,
+	}
+
+	err = launchOpenCode(cmd, testBaseURL, "", runner, nil, true)
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, "Would run: opencode")
+	require.NotContains(t, output, "Would configure opencode with model")
+}

--- a/cmd/cli/docs/reference/docker_model_launch.yaml
+++ b/cmd/cli/docs/reference/docker_model_launch.yaml
@@ -56,6 +56,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: model
+      value_type: string
+      description: Model to use (for opencode)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: port
       value_type: int
       default_value: "0"

--- a/cmd/cli/docs/reference/model_launch.md
+++ b/cmd/cli/docs/reference/model_launch.md
@@ -22,6 +22,7 @@ Examples:
 | `--detach`  | `bool`   |         | Run containerized app in background             |
 | `--dry-run` | `bool`   |         | Print what would be executed without running it |
 | `--image`   | `string` |         | Override container image for containerized apps |
+| `--model`   | `string` |         | Model to use (for opencode)                     |
 | `--port`    | `int`    | `0`     | Host port to expose (web UIs)                   |
 
 


### PR DESCRIPTION
Added a `build-cli` target to Makefile. Modified `launchHostApp` function signature to include model and runner parameters. Added special handling for opencode to write config files before launching.