### PR TITLE
feat: add install-cli Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCKER_BUILD_ARGS := \
 BUILD_DMR ?= 1
 
 # Main targets
-.PHONY: build run clean test integration-tests test-docker-ce-installation docker-build docker-build-multiplatform docker-run docker-build-vllm docker-run-vllm docker-build-sglang docker-run-sglang docker-run-impl help validate lint docker-build-diffusers docker-run-diffusers vllm-metal-build vllm-metal-install vllm-metal-dev vllm-metal-clean
+.PHONY: build run clean test integration-tests test-docker-ce-installation docker-build docker-build-multiplatform docker-run docker-build-vllm docker-run-vllm docker-build-sglang docker-run-sglang docker-run-impl help validate lint docker-build-diffusers docker-run-diffusers vllm-metal-build vllm-metal-install vllm-metal-dev vllm-metal-clean build-cli install-cli
 # Default target
 .DEFAULT_GOAL := build
 
@@ -36,6 +36,9 @@ build:
 
 build-cli:
 	$(MAKE) -C cmd/cli
+
+install-cli:
+	$(MAKE) -C cmd/cli install
 
 docs:
 	$(MAKE) -C cmd/cli docs


### PR DESCRIPTION
```
$ make install-cli
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=v1.0.11-43-g536df780" -o model-cli .
Using existing binary model-cli
Linking model-cli to Docker CLI plugins directory...
Link created: /Users/dorin/.docker/cli-plugins/docker-model
```