### PR TITLE
Add stream error patterns to retryable errors

### DIFF
--- a/cmd/cli/desktop/desktop.go
+++ b/cmd/cli/desktop/desktop.go
@@ -177,6 +177,9 @@ func isRetryableError(err error) bool {
 		"no route to host",
 		"network is unreachable",
 		"i/o timeout",
+		"stream error",
+		"internal_error",
+		"protocol_error",
 	}
 
 	for _, pattern := range retryablePatterns {


### PR DESCRIPTION
Treat HTTP/2 stream errors as retryable failures. These errors indicate transient network or protocol issues that often resolve on subsequent attempts. Adding stream error, INTERNAL_ERROR, and PROTOCOL_ERROR patterns prevents premature failure when encountering temporary connection problems.