### PR TITLE
fix(cli): drop cmd/cli tag prefix

### DIFF
--- a/cmd/cli/Makefile
+++ b/cmd/cli/Makefile
@@ -14,7 +14,7 @@ all: build
 
 build:
 	@echo "Building $(BINARY_NAME)..."
-	go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=$(shell git describe --tags --always --dirty --match "cmd/cli*" | sed 's|^cmd/cli/||')" -o $(BINARY_NAME) .
+	go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=$(shell git describe --tags --always --dirty --match 'v*')" -o $(BINARY_NAME) .
 
 link:
 	@if [ ! -f $(BINARY_NAME) ]; then \


### PR DESCRIPTION
We stopped using the cmd/cli tag prefix for CLI releases with https://github.com/docker/model-runner/pull/682.

```
$ make install-cli
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=v1.0.24-12-g58bf78d0-dirty" -o model-cli .
Using existing binary model-cli
Linking model-cli to Docker CLI plugins directory...
Link created: /Users/dorin/.docker/cli-plugins/docker-model

$ docker model version
Docker Model Runner version v1.0.24-12-g58bf78d0-dirty
Docker Engine Kind: Docker Desktop
```