### PR TITLE
refactor: unify vllm and vllm-metal into a single "vllm" backend

### DIFF
--- a/cmd/cli/docs/reference/docker_model_install-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_install-runner.yaml
@@ -8,8 +8,7 @@ plink: docker_model.yaml
 options:
     - option: backend
       value_type: string
-      description: |
-        Specify backend (llama.cpp|vllm|diffusers|vllm-metal). Default: llama.cpp
+      description: 'Specify backend (llama.cpp|vllm|diffusers). Default: llama.cpp'
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
@@ -8,8 +8,7 @@ plink: docker_model.yaml
 options:
     - option: backend
       value_type: string
-      description: |
-        Specify backend (llama.cpp|vllm|diffusers|vllm-metal). Default: llama.cpp
+      description: 'Specify backend (llama.cpp|vllm|diffusers). Default: llama.cpp'
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/docker_model_start-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_start-runner.yaml
@@ -10,8 +10,7 @@ plink: docker_model.yaml
 options:
     - option: backend
       value_type: string
-      description: |
-        Specify backend (llama.cpp|vllm|diffusers|vllm-metal). Default: llama.cpp
+      description: 'Specify backend (llama.cpp|vllm|diffusers). Default: llama.cpp'
       deprecated: false
       hidden: false
       experimental: false

--- a/cmd/cli/docs/reference/model_install-runner.md
+++ b/cmd/cli/docs/reference/model_install-runner.md
@@ -7,7 +7,7 @@ Install Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default     | Description                                                                                            |
 |:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
-| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers\|vllm-metal). Default: llama.cpp                           |
+| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                       |
 | `--debug`        | `bool`   |             | Enable debug logging                                                                                   |
 | `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |

--- a/cmd/cli/docs/reference/model_reinstall-runner.md
+++ b/cmd/cli/docs/reference/model_reinstall-runner.md
@@ -7,7 +7,7 @@ Reinstall Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default     | Description                                                                                            |
 |:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
-| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers\|vllm-metal). Default: llama.cpp                           |
+| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                       |
 | `--debug`        | `bool`   |             | Enable debug logging                                                                                   |
 | `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |

--- a/cmd/cli/docs/reference/model_start-runner.md
+++ b/cmd/cli/docs/reference/model_start-runner.md
@@ -7,7 +7,7 @@ Start Docker Model Runner (Docker Engine only)
 
 | Name             | Type     | Default     | Description                                                                                            |
 |:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
-| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers\|vllm-metal). Default: llama.cpp                           |
+| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                       |
 | `--debug`        | `bool`   |             | Enable debug logging                                                                                   |
 | `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
 | `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 			Logger:        log.WithFields(logrus.Fields{"component": "model-manager"}),
 			Transport:     baseTransport,
 		},
-		Backends: append(append(
+		Backends: append(
 			routing.DefaultBackendDefs(routing.BackendsConfig{
 				Log:                  log,
 				LlamaCppVendoredPath: llamaServerPath,
@@ -130,6 +130,9 @@ func main() {
 				LlamaCppConfig:       llamaCppConfig,
 				IncludeMLX:           true,
 				MLXPath:              mlxServerPath,
+				IncludeVLLM:          includeVLLM,
+				VLLMPath:             vllmServerPath,
+				VLLMMetalPath:        vllmMetalServerPath,
 			}),
 			routing.BackendDef{Name: sglang.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
 				return sglang.New(log, mm, log.WithFields(logrus.Fields{"component": sglang.Name}), nil, sglangServerPath)
@@ -137,13 +140,12 @@ func main() {
 			routing.BackendDef{Name: diffusers.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
 				return diffusers.New(log, mm, log.WithFields(logrus.Fields{"component": diffusers.Name}), nil, diffusersServerPath)
 			}},
-		), vllmBackendDefs(log, vllmServerPath)...),
+		),
 		OnBackendError: func(name string, err error) {
 			log.Fatalf("unable to initialize %s backend: %v", name, err)
 		},
-		DefaultBackendName:  llamacpp.Name,
-		VLLMMetalServerPath: vllmMetalServerPath,
-		HTTPClient:          http.DefaultClient,
+		DefaultBackendName: llamacpp.Name,
+		HTTPClient:         http.DefaultClient,
 		MetricsTracker: metrics.NewTracker(
 			http.DefaultClient,
 			log.WithField("component", "metrics"),

--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -1,4 +1,4 @@
-package vllmmetal
+package vllm
 
 import (
 	"context"
@@ -19,12 +19,9 @@ import (
 	"github.com/docker/model-runner/pkg/inference/platform"
 	"github.com/docker/model-runner/pkg/internal/dockerhub"
 	"github.com/docker/model-runner/pkg/logging"
-	"github.com/sirupsen/logrus"
 )
 
 const (
-	// Name is the backend name.
-	Name              = "vllm-metal"
 	defaultInstallDir = ".docker/model-runner/vllm-metal"
 	// vllmMetalVersion is the vllm-metal release tag to download from Docker Hub.
 	vllmMetalVersion = "v0.1.0-20260126-121650"
@@ -53,9 +50,9 @@ type vllmMetal struct {
 	status string
 }
 
-// New creates a new vllm-metal backend.
+// newMetal creates a new vllm-metal backend.
 // customPythonPath is an optional path to a custom python3 binary; if empty, the default installation is used.
-func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, customPythonPath string) (inference.Backend, error) {
+func newMetal(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, customPythonPath string) (inference.Backend, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user home directory: %w", err)
@@ -70,22 +67,6 @@ func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Log
 		installDir:       installDir,
 		status:           "not installed",
 	}, nil
-}
-
-// TryRegister initializes the vllm-metal backend if the platform supports it
-// and registers it in the provided backends map. It returns the backend names
-// whose installation should be deferred until explicitly requested.
-func TryRegister(log logging.Logger, modelManager *models.Manager, backends map[string]inference.Backend, serverPath string) []string {
-	if !platform.SupportsVLLMMetal() {
-		return nil
-	}
-	backend, err := New(log, modelManager, log.WithFields(logrus.Fields{"component": Name}), serverPath)
-	if err != nil {
-		log.Warnf("Failed to initialize vllm-metal backend: %v", err)
-		return nil
-	}
-	backends[Name] = backend
-	return []string{Name}
 }
 
 // Name implements inference.Backend.Name.

--- a/vllm_backend.go
+++ b/vllm_backend.go
@@ -2,19 +2,4 @@
 
 package main
 
-import (
-	"github.com/docker/model-runner/pkg/inference"
-	"github.com/docker/model-runner/pkg/inference/backends/vllm"
-	"github.com/docker/model-runner/pkg/inference/models"
-	"github.com/docker/model-runner/pkg/routing"
-	"github.com/sirupsen/logrus"
-)
-
-func vllmBackendDefs(log *logrus.Logger, customBinaryPath string) []routing.BackendDef {
-	return []routing.BackendDef{{
-		Name: vllm.Name,
-		Init: func(mm *models.Manager) (inference.Backend, error) {
-			return vllm.New(log, mm, log.WithFields(logrus.Fields{"component": vllm.Name}), nil, customBinaryPath)
-		},
-	}}
-}
+const includeVLLM = true

--- a/vllm_backend_stub.go
+++ b/vllm_backend_stub.go
@@ -2,11 +2,4 @@
 
 package main
 
-import (
-	"github.com/docker/model-runner/pkg/routing"
-	"github.com/sirupsen/logrus"
-)
-
-func vllmBackendDefs(_ *logrus.Logger, _ string) []routing.BackendDef {
-	return nil
-}
+const includeVLLM = false


### PR DESCRIPTION
Merge the vllm-metal backend into the vllm package so a single vllm backend dispatches to the correct platform implementation at runtime (Linux/macOS ARM64).

- macOS ARM64:
```
$ rm -rf ~/.docker/model-runner/vllm-metal/

$ MODEL_RUNNER_PORT=8080 make run
```

```
$ make install-cli
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C cmd/cli install
Building model-cli...
go build -ldflags="-s -w -X github.com/docker/model-runner/cmd/cli/desktop.Version=v1.0.24-25-g94efd18b" -o model-cli .
Using existing binary model-cli
Linking model-cli to Docker CLI plugins directory...
Link created: /Users/dorin/.docker/cli-plugins/docker-model

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model status | grep vllm
vllm: not installed

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model install-runner --backend vllm
Installing vllm backend...
vllm backend installed successfully

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run huggingface.co/mlx-community/llama-3.2-1b-instruct-4bit hi
Hi there! It's nice to meet you, User.

You might be wondering
```

- Linux (w/ CUDA)
```
$ make docker-run-vllm
```

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run smollm2-vllm hi
Hello there! I’m here to help with an interesting task. What can I assist you with?
```