### PR TITLE
refactor(backends): standardize status reporting across all backends

### DIFF
--- a/pkg/inference/backends/llamacpp/download_linux.go
+++ b/pkg/inference/backends/llamacpp/download_linux.go
@@ -2,7 +2,6 @@ package llamacpp
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path/filepath"
 
@@ -12,7 +11,6 @@ import (
 func (l *llamaCpp) ensureLatestLlamaCpp(_ context.Context, log logging.Logger, _ *http.Client,
 	_, vendoredServerStoragePath string,
 ) error {
-	l.status = fmt.Sprintf("running llama.cpp version: %s",
-		getLlamaCppVersion(log, filepath.Join(vendoredServerStoragePath, "com.docker.llama-server")))
+	l.setRunningStatus(log, filepath.Join(vendoredServerStoragePath, "com.docker.llama-server"), "", "")
 	return errLlamaCppUpdateDisabled
 }

--- a/pkg/inference/backends/llamacpp/download_windows.go
+++ b/pkg/inference/backends/llamacpp/download_windows.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/logging"
 )
 
@@ -23,13 +24,13 @@ func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger,
 		case "amd64":
 			canUseCUDA11, err = hasCUDA11CapableGPU(ctx, nvGPUInfoBin)
 			if err != nil {
-				l.status = fmt.Sprintf("failed to check CUDA 11 capability: %v", err)
+				l.status = inference.FormatError(fmt.Sprintf("failed to check CUDA 11 capability: %v", err))
 				return fmt.Errorf("failed to check CUDA 11 capability: %w", err)
 			}
 		case "arm64":
 			canUseOpenCL, err = hasOpenCL()
 			if err != nil {
-				l.status = fmt.Sprintf("failed to check OpenCL capability: %v", err)
+				l.status = inference.FormatError(fmt.Sprintf("failed to check OpenCL capability: %v", err))
 				return fmt.Errorf("failed to check OpenCL capability: %w", err)
 			}
 		}
@@ -41,7 +42,7 @@ func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger,
 	} else if canUseOpenCL {
 		desiredVariant = "opencl"
 	}
-	l.status = fmt.Sprintf("looking for updates for %s variant", desiredVariant)
+	l.status = inference.FormatInstalling(fmt.Sprintf("%s llama.cpp %s", inference.DetailCheckingForUpdates, desiredVariant))
 	return l.downloadLatestLlamaCpp(ctx, log, httpClient, llamaCppPath, vendoredServerStoragePath, desiredVersion,
 		desiredVariant)
 }

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -109,8 +109,6 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 		llamaServerBin = "com.docker.llama-server.exe"
 	}
 
-	l.status = "installing"
-
 	// Temporary workaround for dynamically downloading llama.cpp from Docker Hub.
 	// Internet access and an available docker/docker-model-backend-llamacpp:latest on Docker Hub are required.
 	// Even if docker/docker-model-backend-llamacpp:latest has been downloaded before, we still require its
@@ -119,7 +117,7 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 	if err := l.ensureLatestLlamaCpp(ctx, l.log, httpClient, llamaCppPath, l.vendoredServerStoragePath); err != nil {
 		l.log.Infof("failed to ensure latest llama.cpp: %v\n", err)
 		if !errors.Is(err, errLlamaCppUpToDate) && !errors.Is(err, errLlamaCppUpdateDisabled) {
-			l.status = fmt.Sprintf("failed to install llama.cpp: %v", err)
+			l.status = inference.FormatError(fmt.Sprintf("failed to install llama.cpp: %v", err))
 		}
 		if errors.Is(err, context.Canceled) {
 			return err

--- a/pkg/inference/backends/mlx/mlx.go
+++ b/pkg/inference/backends/mlx/mlx.go
@@ -53,7 +53,7 @@ func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Log
 		modelManager:     modelManager,
 		serverLog:        serverLog,
 		config:           conf,
-		status:           "not installed",
+		status:           inference.FormatNotInstalled(""),
 		customPythonPath: customPythonPath,
 	}, nil
 }
@@ -77,6 +77,7 @@ func (m *mlx) UsesTCP() bool {
 // Install implements inference.Backend.Install.
 func (m *mlx) Install(ctx context.Context, httpClient *http.Client) error {
 	if !platform.SupportsMLX() {
+		m.status = inference.FormatNotInstalled(inference.DetailOnlyAppleSilicon)
 		return errors.New("MLX is only available on macOS ARM64")
 	}
 
@@ -90,7 +91,7 @@ func (m *mlx) Install(ctx context.Context, httpClient *http.Client) error {
 		var err error
 		pythonPath, err = exec.LookPath("python3")
 		if err != nil {
-			m.status = ErrStatusNotFound.Error()
+			m.status = inference.FormatError(inference.DetailPythonNotFound)
 			return ErrStatusNotFound
 		}
 	}
@@ -101,7 +102,7 @@ func (m *mlx) Install(ctx context.Context, httpClient *http.Client) error {
 	// Check if mlx-lm package is installed by attempting to import it
 	cmd := exec.CommandContext(ctx, pythonPath, "-c", "import mlx_lm")
 	if runErr := cmd.Run(); runErr != nil {
-		m.status = "mlx-lm package not installed"
+		m.status = inference.FormatNotInstalled(inference.DetailPackageNotInstalled)
 		m.log.Warnf("mlx-lm package not found. Install with: uv pip install mlx-lm")
 		return fmt.Errorf("mlx-lm package not installed: %w", runErr)
 	}
@@ -111,9 +112,9 @@ func (m *mlx) Install(ctx context.Context, httpClient *http.Client) error {
 	output, outputErr := cmd.Output()
 	if outputErr != nil {
 		m.log.Warnf("could not get MLX version: %v", outputErr)
-		m.status = "running MLX version: unknown"
+		m.status = inference.FormatRunning(inference.DetailVersionUnknown)
 	} else {
-		m.status = fmt.Sprintf("running MLX version: %s", strings.TrimSpace(string(output)))
+		m.status = inference.FormatRunning(fmt.Sprintf("MLX %s", strings.TrimSpace(string(output))))
 	}
 
 	return nil


### PR DESCRIPTION
Prettify `docker model status`.

⚠️ This new CLI will show all statuses from older backends as "Error".

```
MODEL_RUNNER_PORT=8080 make run
```

E.g.,

- macOS
```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model status
Docker Model Runner is running

BACKEND    STATUS         DETAILS
llama.cpp  Running        llama.cpp latest-metal (sha256:13574106bd745302e63cf7b1978483eb47f32c128c40b1271364c937d850fdcb) c55bce4
vllm       Running        vllm-metal v0.1.0-20260126-121650
diffusers  Not Installed  only supported on Linux
mlx        Not Installed  package not installed
sglang     Not Installed  only supported on Linux
```

- Linux
```
$ docker model status
Docker Model Runner is running

BACKEND    STATUS         DETAILS
llama.cpp  Running        llama.cpp c55bce4
vllm       Running        vllm 0.12.0
diffusers  Not Installed  package not installed
mlx        Not Installed  only supported on Apple Silicon
sglang     Not Installed  package not installed
```