### PR TITLE
Clean up codebase

### DIFF
--- a/pkg/routing/router.go
+++ b/pkg/routing/router.go
@@ -35,11 +35,6 @@ type RouterConfig struct {
 	// layer, registering it under /responses, /v1/responses, and
 	// /engines/responses prefixes. Requires SchedulerHTTP to be set.
 	IncludeResponsesAPI bool
-
-	// ExtraRoutes is called after standard routes are registered,
-	// allowing callers to add custom routes (root handler, metrics, etc.).
-	// It may be nil.
-	ExtraRoutes func(*NormalizedServeMux)
 }
 
 // NewRouter builds a NormalizedServeMux with the standard model-runner
@@ -83,11 +78,6 @@ func NewRouter(cfg RouterConfig) *NormalizedServeMux {
 		router.Handle("/v1"+responses.APIPrefix, responsesHandler)
 		router.Handle(inference.InferencePrefix+responses.APIPrefix+"/", responsesHandler)
 		router.Handle(inference.InferencePrefix+responses.APIPrefix, responsesHandler)
-	}
-
-	// Caller-specific routes (root handler, metrics, etc.).
-	if cfg.ExtraRoutes != nil {
-		cfg.ExtraRoutes(router)
 	}
 
 	return router


### PR DESCRIPTION
- Return (config.BackendConfig, error) from createLlamaCppConfigFromEnv instead of calling exitFunc directly; let the caller handle the error.

- Remove testLog and Log package-level globals. testLog was a workaround for the old exitFunc-calling design; Log was exported but unused outside the package.

- Replace fmt.Sprintf wrappers inside structured log calls with native slog arguments (slog handles slices and values natively).

- Update main_test.go to check returned errors instead of overriding exitFunc and inspecting exit codes.

- Remove dead RouterConfig.ExtraRoutes field. NewRouter is only called from NewService, which handles extra routes via ServiceConfig.ExtraRoutes. Having a second ExtraRoutes on RouterConfig was unused dead code.