### PR TITLE
Add Gemini code review configuration

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,4 @@
+code_review:
+  comment_severity_threshold: HIGH
+  pull_request_opened:
+    summary: false


### PR DESCRIPTION
So we only get review comments that are high or critical.