### PR TITLE
feat: add ErrorTransformer for llama.cpp

### DIFF
--- a/pkg/inference/backends/llamacpp/errors.go
+++ b/pkg/inference/backends/llamacpp/errors.go
@@ -1,0 +1,32 @@
+package llamacpp
+
+import "regexp"
+
+// llamaCppErrorPatterns contains regex patterns to extract meaningful error messages
+// from llama.cpp stderr output. The patterns are tried in order, and the first match wins.
+var llamaCppErrorPatterns = []struct {
+	pattern *regexp.Regexp
+	message string
+}{
+	// Metal buffer allocation failure
+	// https://github.com/ggml-org/llama.cpp/blob/ecd99d6a9acbc436bad085783bcd5d0b9ae9e9e9/ggml/src/ggml-metal/ggml-metal-device.m#L1498
+	{regexp.MustCompile(`failed to allocate buffer, size = .*MiB`), "not enough GPU memory to load the model (Metal)"},
+	// CUDA out of memory
+	// https://github.com/ggml-org/llama.cpp/blob/ecd99d6a9acbc436bad085783bcd5d0b9ae9e9e9/ggml/src/ggml-cuda/ggml-cuda.cu#L710
+	{regexp.MustCompile(`cudaMalloc failed: out of memory`), "not enough GPU memory to load the model (CUDA)"},
+	// Generic model loading failure
+	// https://github.com/ggml-org/llama.cpp/blob/ecd99d6a9acbc436bad085783bcd5d0b9ae9e9e9/tools/server/server.cpp#L254
+	{regexp.MustCompile(`exiting due to model loading error`), "failed to load model"},
+}
+
+// ExtractLlamaCppError attempts to extract a meaningful error message from llama.cpp output.
+// It looks for common error patterns and returns a cleaner, more user-friendly message.
+// If no recognizable pattern is found, it returns the full output.
+func ExtractLlamaCppError(output string) string {
+	for _, entry := range llamaCppErrorPatterns {
+		if entry.pattern.MatchString(output) {
+			return entry.message
+		}
+	}
+	return output
+}

--- a/pkg/inference/backends/llamacpp/errors_test.go
+++ b/pkg/inference/backends/llamacpp/errors_test.go
@@ -1,0 +1,39 @@
+package llamacpp
+
+import (
+	"testing"
+)
+
+func TestExtractLlamaCppError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Metal buffer allocation failure",
+			input:    "ggml_metal_buffer_init: error: failed to allocate buffer, size = 2048.00 MiB",
+			expected: "not enough GPU memory to load the model (Metal)",
+		},
+		{
+			name:     "cudaMalloc OOM",
+			input:    "ggml_backend_cuda_buffer_type_alloc_buffer: allocating 12.50 MiB on device 1: cudaMalloc failed: out of memory",
+			expected: "not enough GPU memory to load the model (CUDA)",
+		},
+		{
+			name: "loading error",
+			input: `common_init_from_params: failed to load model '/models/model.gguf'
+main: exiting due to model loading error`,
+			expected: "failed to load model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractLlamaCppError(tt.input)
+			if result != tt.expected {
+				t.Errorf("ExtractLlamaCppError() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -171,14 +171,15 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, _ string, mode
 	}
 
 	return backends.RunBackend(ctx, backends.RunnerConfig{
-		BackendName:     "llama.cpp",
-		Socket:          socket,
-		BinaryPath:      filepath.Join(binPath, "com.docker.llama-server"),
-		SandboxPath:     binPath,
-		SandboxConfig:   sandbox.ConfigurationLlamaCpp,
-		Args:            args,
-		Logger:          l.log,
-		ServerLogWriter: logging.NewWriter(l.serverLog),
+		BackendName:      "llama.cpp",
+		Socket:           socket,
+		BinaryPath:       filepath.Join(binPath, "com.docker.llama-server"),
+		SandboxPath:      binPath,
+		SandboxConfig:    sandbox.ConfigurationLlamaCpp,
+		Args:             args,
+		Logger:           l.log,
+		ServerLogWriter:  logging.NewWriter(l.serverLog),
+		ErrorTransformer: ExtractLlamaCppError,
 	})
 }
 


### PR DESCRIPTION
Add `ErrorTransformer` for `llama.cpp` to surface friendly error messages.

E.g.,
```
$ MODEL_RUNNER_HOST=http://localhost:8080/ docker model run gpt-oss hi
Failed to generate a response: error response: status=500 body=unable to load runner: error waiting for runner to be ready: llama.cpp terminated unexpectedly: llama.cpp failed: not enough GPU memory to load the model (CUDA)
```
Logs:
```
time=2026-03-03T21:33:19.366Z level=INFO msg="load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)"
time=2026-03-03T21:36:19.179Z level=INFO msg="ggml_backend_cuda_buffer_type_alloc_buffer: allocating 10723.15 MiB on device 0: cudaMalloc failed: out of memory"
time=2026-03-03T21:36:19.181Z level=INFO msg="alloc_tensor_range: failed to allocate CUDA0 buffer of size 11244037120"
time=2026-03-03T21:36:20.133Z level=INFO msg="llama_model_load: error loading model: unable to allocate CUDA0 buffer"
time=2026-03-03T21:36:20.133Z level=INFO msg="llama_model_load_from_file_impl: failed to load model"
time=2026-03-03T21:36:21.070Z level=INFO msg="common_init_from_params: failed to load model '/models/bundles/sha256/9398339cb0d3b150931212377c16d2a105ddce053ec187e4397ba6e10f3ea112/model/model.gguf'"
time=2026-03-03T21:36:21.070Z level=INFO msg="srv    load_model: failed to load model, '/models/bundles/sha256/9398339cb0d3b150931212377c16d2a105ddce053ec187e4397ba6e10f3ea112/model/model.gguf'"
time=2026-03-03T21:36:21.070Z level=INFO msg="srv    operator(): operator(): cleaning up before exit..."
time=2026-03-03T21:36:21.077Z level=INFO msg="main: exiting due to model loading error"
time=2026-03-03T21:36:21.933Z level=WARN msg="Backend running model exited with error" backend=llama.cpp model=gpt-oss error="llama.cpp terminated unexpectedly: llama.cpp failed: not enough GPU memory to load the model (CUDA)"
time=2026-03-03T21:36:22.342Z level=INFO msg="getting model by reference" component=model-manager reference=sha256:9398339cb0d3b150931212377c16d2a105ddce053ec187e4397ba6e10f3ea112
time=2026-03-03T21:36:22.343Z level=INFO msg="Listing available models" component=model-manager
time=2026-03-03T21:36:22.362Z level=INFO msg="successfully listed models" component=model-manager count=1
time=2026-03-03T21:36:22.371Z level=INFO msg="Removed records for model" component=openai-recorder model=sha256:9398339cb0d3b150931212377c16d2a105ddce053ec187e4397ba6e10f3ea112
time=2026-03-03T21:36:22.371Z level=WARN msg="Backend runner initialization failed" backend=llama.cpp model=sha256:9398339cb0d3b150931212377c16d2a105ddce053ec187e4397ba6e10f3ea112 mode=completion error="llama.cpp terminated unexpectedly: llama.cpp failed: not enough GPU memory to load the model (CUDA)"
```

Improves UX for https://github.com/docker/model-runner/issues/709.