### PR TITLE
refactor: remove models-store in favor of default ~/.docker/models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 model-runner
 model-runner.sock
 docker-model
-# Default MODELS_PATH in Makefile
-models-store/
 # Directory where we store the updated llama.cpp
 updated-inference/
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ DOCKER_IMAGE_SGLANG := docker/model-runner:latest-sglang
 DOCKER_IMAGE_DIFFUSERS := docker/model-runner:latest-diffusers
 DOCKER_TARGET ?= final-llamacpp
 PORT := 8080
-MODELS_PATH := $(shell pwd)/models-store
 LLAMA_ARGS ?=
 DOCKER_BUILD_ARGS := \
 	--load \
@@ -63,7 +62,6 @@ run: build
 clean:
 	rm -f $(APP_NAME)
 	rm -f model-runner.sock
-	rm -rf $(MODELS_PATH)
 
 # Run tests
 test:
@@ -164,12 +162,11 @@ docker-run-diffusers: docker-build-diffusers
 # Common implementation for running Docker container
 docker-run-impl:
 	@echo ""
-	@echo "Starting service on port $(PORT) with model storage at $(MODELS_PATH)..."
+	@echo "Starting service on port $(PORT)..."
 	@echo "Service will be available at: http://localhost:$(PORT)"
 	@echo "Example usage: curl http://localhost:$(PORT)/models"
 	@echo ""
 	PORT="$(PORT)" \
-	MODELS_PATH="$(MODELS_PATH)" \
 	DOCKER_IMAGE="$(DOCKER_IMAGE)" \
 	LLAMA_ARGS="$(LLAMA_ARGS)" \
 	DMR_ORIGINS="$(DMR_ORIGINS)" \

--- a/cmd/cli/Dockerfile
+++ b/cmd/cli/Dockerfile
@@ -22,7 +22,7 @@ ARG DOCS_FORMATS
 RUN --mount=target=/context \
     --mount=target=.,type=tmpfs <<EOT
   set -e
-  rsync -a --exclude='models-store' /context/. .
+  rsync -a /context/. .
   docsgen --formats "$DOCS_FORMATS" --source "cmd/cli/docs/reference"
   mkdir /out
   cp -r cmd/cli/docs/reference/* /out/
@@ -35,7 +35,7 @@ FROM docs-build AS docs-validate
 RUN --mount=target=/context \
     --mount=target=.,type=tmpfs <<EOT
   set -e
-  rsync -a --exclude='models-store' /context/. .
+  rsync -a /context/. .
   git add -A
   rm -rf cmd/cli/docs/reference/*
   cp -rf /out/* ./cmd/cli/docs/reference/

--- a/demos/embeddings/indexer.js
+++ b/demos/embeddings/indexer.js
@@ -29,7 +29,7 @@ class CodebaseIndexer {
       const ig = ignore().add(content);
       
       // Always ignore these
-      ig.add(['node_modules', '.git', 'embeddings-index.json', 'models-store', 'model-store']);
+      ig.add(['node_modules', '.git', 'embeddings-index.json']);
       
       return ig;
     } catch (error) {

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -33,9 +33,7 @@ add_optional_args() {
     args+=(-p "$PORT:$PORT" -e "MODEL_RUNNER_PORT=$PORT")
   fi
 
-  if [ -n "${MODELS_PATH-}" ]; then
-    args+=(-v "$MODELS_PATH:/models" -e MODELS_PATH=/models)
-  fi
+  args+=(-v "$models_path:/models" -e MODELS_PATH=/models)
 
   for i in /usr/local/dcmi /usr/local/bin/npu-smi /usr/local/Ascend/driver/lib64/ /usr/local/Ascend/driver/version.info /etc/ascend_install.info; do
     if [ -e "$i" ]; then
@@ -65,14 +63,11 @@ add_optional_args() {
 main() {
   set -eux -o pipefail
 
+  local models_path="${MODELS_PATH:-$HOME/.docker/models}"
   local args=(docker run --rm -e LLAMA_SERVER_PATH=/app/bin)
   add_optional_args
-
-  # Ensure model path exists only if provided
-  if [ -n "${MODELS_PATH-}" ]; then
-    mkdir -p "$MODELS_PATH"
-    chmod a+rwx "$MODELS_PATH"
-  fi
+  mkdir -p "$models_path"
+  chmod a+rwx "$models_path"
 
   if [ -z "${DOCKER_IMAGE-}" ]; then
     echo "DOCKER_IMAGE is required" >&2


### PR DESCRIPTION
The Go code already defaults MODELS_PATH to ~/.docker/models, so the Makefile override to a local models-store/ directory was unnecessary. This shares the model store with Docker Desktop's Model Runner.