### PR TITLE
feat(ci): add imagesOnly input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: false
+      imagesOnly:
+        description: "Only build and push Docker images (skip CLI releases, pinata bump, and CE packaging)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -414,6 +419,7 @@ jobs:
   # Release CLI for Docker Desktop — build, sign & push CLI + Desktop module image
   # ---------------------------------------------------------------------------
   release-cli-desktop:
+    if: ${{ !inputs.imagesOnly }}
     needs: [prepare, test]
     runs-on: ubuntu-latest
     permissions:
@@ -468,6 +474,7 @@ jobs:
   # Bump docker-model version in pinata and open a PR
   # ---------------------------------------------------------------------------
   bump-pinata:
+    if: ${{ !inputs.imagesOnly }}
     needs: [prepare, release-cli-desktop]
     runs-on: ubuntu-latest
     permissions:
@@ -520,7 +527,7 @@ jobs:
   # deploy completed successfully.
   # ---------------------------------------------------------------------------
   release-cli-docker-ce-trigger:
-    if: ${{ !inputs.skipPackaging }}
+    if: ${{ !inputs.imagesOnly }}
     needs: [prepare, release-cli-desktop]
     runs-on: ubuntu-latest
     permissions:
@@ -609,6 +616,7 @@ jobs:
   # server versions match the release tag.
   # ---------------------------------------------------------------------------
   verify-docker-ce:
+    if: ${{ !inputs.imagesOnly }}
     needs: [prepare, release-cli-docker-ce-trigger, build]
     runs-on: ubuntu-latest
     environment: release-repo-deploy


### PR DESCRIPTION
Allow releasing just Docker images without triggering CLI desktop release, pinata bump, or CE packaging jobs. Also removes the unused input reference. This is useful for releasing a new image with an updated llama.cpp.

For https://github.com/docker/model-runner/issues/731.