### PR TITLE
feat: make llama.cpp a deferred backend on macOS/Windows

### DIFF
--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -231,18 +231,19 @@ func getStandaloneRunner(ctx context.Context) (*standaloneRunner, error) {
 
 // runnerOptions holds common configuration for install/start/reinstall commands
 type runnerOptions struct {
-	port            uint16
-	host            string
-	gpuMode         string
-	backend         string
-	doNotTrack      bool
-	pullImage       bool
-	pruneContainers bool
-	proxyCert       string
-	tls             bool
-	tlsPort         uint16
-	tlsCert         string
-	tlsKey          string
+	port               uint16
+	host               string
+	gpuMode            string
+	backend            string
+	llamaServerVersion string
+	doNotTrack         bool
+	pullImage          bool
+	pruneContainers    bool
+	proxyCert          string
+	tls                bool
+	tlsPort            uint16
+	tlsCert            string
+	tlsKey             string
 }
 
 func commandFlagChanged(cmd *cobra.Command, name string) bool {
@@ -284,7 +285,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 	// (on-demand via the running model runner), not as a standalone container.
 	if opts.backend == vllm.Name && platform.SupportsVLLMMetal() {
 		cmd.Println("Installing vllm backend...")
-		if err := desktopClient.InstallBackend(vllm.Name); err != nil {
+		if err := desktopClient.InstallBackend(vllm.Name, ""); err != nil {
 			return fmt.Errorf("failed to install vllm backend: %w", err)
 		}
 		cmd.Println("vllm backend installed successfully")
@@ -296,7 +297,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 	// the running model runner, the same way vllm-metal is handled above.
 	if opts.backend == llamacpp.Name && llamacpp.NeedsDeferredInstall() {
 		cmd.Println("Installing llama.cpp backend...")
-		if err := desktopClient.InstallBackend(llamacpp.Name); err != nil {
+		if err := desktopClient.InstallBackend(llamacpp.Name, opts.llamaServerVersion); err != nil {
 			return fmt.Errorf("failed to install llama.cpp backend: %w", err)
 		}
 		cmd.Println("llama.cpp backend installed successfully")
@@ -318,7 +319,7 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 		}
 
 		cmd.Println("Installing diffusers backend...")
-		if err := desktopClient.InstallBackend(diffusers.Name); err != nil {
+		if err := desktopClient.InstallBackend(diffusers.Name, ""); err != nil {
 			return fmt.Errorf("failed to install diffusers backend: %w", err)
 		}
 		cmd.Println("diffusers backend installed successfully")
@@ -469,6 +470,7 @@ func newInstallRunner() *cobra.Command {
 	var host string
 	var gpuMode string
 	var backend string
+	var llamaServerVersion string
 	var doNotTrack bool
 	var debug bool
 	var proxyCert string
@@ -481,34 +483,36 @@ func newInstallRunner() *cobra.Command {
 		Short: "Install Docker Model Runner (Docker Engine only)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstallOrStart(cmd, runnerOptions{
-				port:            port,
-				host:            host,
-				gpuMode:         gpuMode,
-				backend:         backend,
-				doNotTrack:      doNotTrack,
-				pullImage:       true,
-				pruneContainers: false,
-				proxyCert:       proxyCert,
-				tls:             tlsEnabled,
-				tlsPort:         tlsPort,
-				tlsCert:         tlsCert,
-				tlsKey:          tlsKey,
+				port:               port,
+				host:               host,
+				gpuMode:            gpuMode,
+				backend:            backend,
+				llamaServerVersion: llamaServerVersion,
+				doNotTrack:         doNotTrack,
+				pullImage:          true,
+				pruneContainers:    false,
+				proxyCert:          proxyCert,
+				tls:                tlsEnabled,
+				tlsPort:            tlsPort,
+				tlsCert:            tlsCert,
+				tlsKey:             tlsKey,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
 	addRunnerFlags(c, runnerFlagOptions{
-		Port:       &port,
-		Host:       &host,
-		GpuMode:    &gpuMode,
-		Backend:    &backend,
-		DoNotTrack: &doNotTrack,
-		Debug:      &debug,
-		ProxyCert:  &proxyCert,
-		TLS:        &tlsEnabled,
-		TLSPort:    &tlsPort,
-		TLSCert:    &tlsCert,
-		TLSKey:     &tlsKey,
+		Port:               &port,
+		Host:               &host,
+		GpuMode:            &gpuMode,
+		Backend:            &backend,
+		LlamaServerVersion: &llamaServerVersion,
+		DoNotTrack:         &doNotTrack,
+		Debug:              &debug,
+		ProxyCert:          &proxyCert,
+		TLS:                &tlsEnabled,
+		TLSPort:            &tlsPort,
+		TLSCert:            &tlsCert,
+		TLSKey:             &tlsKey,
 	})
 	return c
 }

--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -291,6 +291,18 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 		return nil
 	}
 
+	// On macOS/Windows the llama.cpp backend is installed on demand: its binary
+	// is downloaded rather than bundled at build time. Trigger installation via
+	// the running model runner, the same way vllm-metal is handled above.
+	if opts.backend == llamacpp.Name && llamacpp.NeedsDeferredInstall() {
+		cmd.Println("Installing llama.cpp backend...")
+		if err := desktopClient.InstallBackend(llamacpp.Name); err != nil {
+			return fmt.Errorf("failed to install llama.cpp backend: %w", err)
+		}
+		cmd.Println("llama.cpp backend installed successfully")
+		return nil
+	}
+
 	// The diffusers backend uses deferred installation: it pulls a Docker
 	// image, extracts a self-contained Python environment, and installs it
 	// to a well-known local folder. Trigger installation via the running

--- a/cmd/cli/commands/reinstall-runner.go
+++ b/cmd/cli/commands/reinstall-runner.go
@@ -10,6 +10,7 @@ func newReinstallRunner() *cobra.Command {
 	var host string
 	var gpuMode string
 	var backend string
+	var llamaServerVersion string
 	var doNotTrack bool
 	var debug bool
 	var proxyCert string
@@ -22,34 +23,36 @@ func newReinstallRunner() *cobra.Command {
 		Short: "Reinstall Docker Model Runner (Docker Engine only)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstallOrStart(cmd, runnerOptions{
-				port:            port,
-				host:            host,
-				gpuMode:         gpuMode,
-				backend:         backend,
-				doNotTrack:      doNotTrack,
-				pullImage:       true,
-				pruneContainers: true,
-				proxyCert:       proxyCert,
-				tls:             tlsEnabled,
-				tlsPort:         tlsPort,
-				tlsCert:         tlsCert,
-				tlsKey:          tlsKey,
+				port:               port,
+				host:               host,
+				gpuMode:            gpuMode,
+				backend:            backend,
+				llamaServerVersion: llamaServerVersion,
+				doNotTrack:         doNotTrack,
+				pullImage:          true,
+				pruneContainers:    true,
+				proxyCert:          proxyCert,
+				tls:                tlsEnabled,
+				tlsPort:            tlsPort,
+				tlsCert:            tlsCert,
+				tlsKey:             tlsKey,
 			}, debug)
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
 	addRunnerFlags(c, runnerFlagOptions{
-		Port:       &port,
-		Host:       &host,
-		GpuMode:    &gpuMode,
-		Backend:    &backend,
-		DoNotTrack: &doNotTrack,
-		Debug:      &debug,
-		ProxyCert:  &proxyCert,
-		TLS:        &tlsEnabled,
-		TLSPort:    &tlsPort,
-		TLSCert:    &tlsCert,
-		TLSKey:     &tlsKey,
+		Port:               &port,
+		Host:               &host,
+		GpuMode:            &gpuMode,
+		Backend:            &backend,
+		LlamaServerVersion: &llamaServerVersion,
+		DoNotTrack:         &doNotTrack,
+		Debug:              &debug,
+		ProxyCert:          &proxyCert,
+		TLS:                &tlsEnabled,
+		TLSPort:            &tlsPort,
+		TLSCert:            &tlsCert,
+		TLSKey:             &tlsKey,
 	})
 	return c
 }

--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -197,17 +197,18 @@ func requireMinArgs(n int, cmdName string, usageArgs string) cobra.PositionalArg
 
 // runnerFlagOptions holds common runner configuration options
 type runnerFlagOptions struct {
-	Port       *uint16
-	Host       *string
-	GpuMode    *string
-	Backend    *string
-	DoNotTrack *bool
-	Debug      *bool
-	ProxyCert  *string
-	TLS        *bool
-	TLSPort    *uint16
-	TLSCert    *string
-	TLSKey     *string
+	Port               *uint16
+	Host               *string
+	GpuMode            *string
+	Backend            *string
+	LlamaServerVersion *string
+	DoNotTrack         *bool
+	Debug              *bool
+	ProxyCert          *string
+	TLS                *bool
+	TLSPort            *uint16
+	TLSCert            *string
+	TLSKey             *string
 }
 
 // addRunnerFlags adds common runner flags to a command
@@ -224,6 +225,10 @@ func addRunnerFlags(cmd *cobra.Command, opts runnerFlagOptions) {
 	}
 	if opts.Backend != nil {
 		cmd.Flags().StringVar(opts.Backend, "backend", "", backendUsage)
+	}
+	if opts.LlamaServerVersion != nil {
+		cmd.Flags().StringVar(opts.LlamaServerVersion, "llama-server-version", "",
+			`Override the llama.cpp version to install on macOS/Windows (e.g. "latest" or "v0.0.34"); defaults to the version pinned to this release`)
 	}
 	if opts.DoNotTrack != nil {
 		cmd.Flags().BoolVar(opts.DoNotTrack, "do-not-track", false, "Do not track models usage in Docker Model Runner")

--- a/cmd/cli/desktop/desktop.go
+++ b/cmd/cli/desktop/desktop.go
@@ -1076,11 +1076,12 @@ func (c *Client) ShowConfigs(modelFilter string) ([]scheduling.ModelConfigEntry,
 }
 
 // InstallBackend triggers on-demand installation of a deferred backend
-func (c *Client) InstallBackend(backend string) error {
+func (c *Client) InstallBackend(backend, version string) error {
 	installPath := inference.InferencePrefix + "/install-backend"
 	jsonData, err := json.Marshal(struct {
 		Backend string `json:"backend"`
-	}{Backend: backend})
+		Version string `json:"version,omitempty"`
+	}{Backend: backend, Version: version})
 	if err != nil {
 		return fmt.Errorf("error marshaling request: %w", err)
 	}

--- a/cmd/cli/docs/reference/docker_model_install-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_install-runner.yaml
@@ -55,6 +55,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: llama-server-version
+      value_type: string
+      description: |
+        Override the llama.cpp version to install on macOS/Windows (e.g. "latest" or "v0.0.34"); defaults to the version pinned to this release
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: port
       value_type: uint16
       default_value: "0"

--- a/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
+++ b/cmd/cli/docs/reference/docker_model_reinstall-runner.yaml
@@ -55,6 +55,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: llama-server-version
+      value_type: string
+      description: |
+        Override the llama.cpp version to install on macOS/Windows (e.g. "latest" or "v0.0.34"); defaults to the version pinned to this release
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: port
       value_type: uint16
       default_value: "0"

--- a/cmd/cli/docs/reference/model_install-runner.md
+++ b/cmd/cli/docs/reference/model_install-runner.md
@@ -5,19 +5,20 @@ Install Docker Model Runner (Docker Engine only)
 
 ### Options
 
-| Name             | Type     | Default     | Description                                                                                            |
-|:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
-| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                       |
-| `--debug`        | `bool`   |             | Enable debug logging                                                                                   |
-| `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
-| `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
-| `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
-| `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
-| `--proxy-cert`   | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                 |
-| `--tls`          | `bool`   |             | Enable TLS/HTTPS for Docker Model Runner API                                                           |
-| `--tls-cert`     | `string` |             | Path to TLS certificate file (auto-generated if not provided)                                          |
-| `--tls-key`      | `string` |             | Path to TLS private key file (auto-generated if not provided)                                          |
-| `--tls-port`     | `uint16` | `0`         | TLS port for Docker Model Runner (default: 12444 for Docker Engine, 12445 for Cloud mode)              |
+| Name                     | Type     | Default     | Description                                                                                                                             |
+|:-------------------------|:---------|:------------|:----------------------------------------------------------------------------------------------------------------------------------------|
+| `--backend`              | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                                                        |
+| `--debug`                | `bool`   |             | Enable debug logging                                                                                                                    |
+| `--do-not-track`         | `bool`   |             | Do not track models usage in Docker Model Runner                                                                                        |
+| `--gpu`                  | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                                                                |
+| `--host`                 | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                                                                |
+| `--llama-server-version` | `string` |             | Override the llama.cpp version to install on macOS/Windows (e.g. "latest" or "v0.0.34"); defaults to the version pinned to this release |
+| `--port`                 | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)                                  |
+| `--proxy-cert`           | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                                                  |
+| `--tls`                  | `bool`   |             | Enable TLS/HTTPS for Docker Model Runner API                                                                                            |
+| `--tls-cert`             | `string` |             | Path to TLS certificate file (auto-generated if not provided)                                                                           |
+| `--tls-key`              | `string` |             | Path to TLS private key file (auto-generated if not provided)                                                                           |
+| `--tls-port`             | `uint16` | `0`         | TLS port for Docker Model Runner (default: 12444 for Docker Engine, 12445 for Cloud mode)                                               |
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_reinstall-runner.md
+++ b/cmd/cli/docs/reference/model_reinstall-runner.md
@@ -5,19 +5,20 @@ Reinstall Docker Model Runner (Docker Engine only)
 
 ### Options
 
-| Name             | Type     | Default     | Description                                                                                            |
-|:-----------------|:---------|:------------|:-------------------------------------------------------------------------------------------------------|
-| `--backend`      | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                       |
-| `--debug`        | `bool`   |             | Enable debug logging                                                                                   |
-| `--do-not-track` | `bool`   |             | Do not track models usage in Docker Model Runner                                                       |
-| `--gpu`          | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                               |
-| `--host`         | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                               |
-| `--port`         | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode) |
-| `--proxy-cert`   | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                 |
-| `--tls`          | `bool`   |             | Enable TLS/HTTPS for Docker Model Runner API                                                           |
-| `--tls-cert`     | `string` |             | Path to TLS certificate file (auto-generated if not provided)                                          |
-| `--tls-key`      | `string` |             | Path to TLS private key file (auto-generated if not provided)                                          |
-| `--tls-port`     | `uint16` | `0`         | TLS port for Docker Model Runner (default: 12444 for Docker Engine, 12445 for Cloud mode)              |
+| Name                     | Type     | Default     | Description                                                                                                                             |
+|:-------------------------|:---------|:------------|:----------------------------------------------------------------------------------------------------------------------------------------|
+| `--backend`              | `string` |             | Specify backend (llama.cpp\|vllm\|diffusers). Default: llama.cpp                                                                        |
+| `--debug`                | `bool`   |             | Enable debug logging                                                                                                                    |
+| `--do-not-track`         | `bool`   |             | Do not track models usage in Docker Model Runner                                                                                        |
+| `--gpu`                  | `string` | `auto`      | Specify GPU support (none\|auto\|cuda\|rocm\|musa\|cann)                                                                                |
+| `--host`                 | `string` | `127.0.0.1` | Host address to bind Docker Model Runner                                                                                                |
+| `--llama-server-version` | `string` |             | Override the llama.cpp version to install on macOS/Windows (e.g. "latest" or "v0.0.34"); defaults to the version pinned to this release |
+| `--port`                 | `uint16` | `0`         | Docker container port for Docker Model Runner (default: 12434 for Docker Engine, 12435 for Cloud mode)                                  |
+| `--proxy-cert`           | `string` |             | Path to a CA certificate file for proxy SSL inspection                                                                                  |
+| `--tls`                  | `bool`   |             | Enable TLS/HTTPS for Docker Model Runner API                                                                                            |
+| `--tls-cert`             | `string` |             | Path to TLS certificate file (auto-generated if not provided)                                                                           |
+| `--tls-key`              | `string` |             | Path to TLS private key file (auto-generated if not provided)                                                                           |
+| `--tls-port`             | `uint16` | `0`         | TLS port for Docker Model Runner (default: 12444 for Docker Engine, 12445 for Cloud mode)                                               |
 
 
 <!---MARKER_GEN_END-->

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -99,20 +98,13 @@ func TCPPort() string {
 	return Var("MODEL_RUNNER_PORT")
 }
 
-// LlamaServerPath returns the path to the llama.cpp server binary.
-// Configured via LLAMA_SERVER_PATH. On macOS this defaults to the Docker
-// Desktop bundle location as a last-resort lookup (Desktop vendors its own
-// copy there); on every other platform there is no meaningful default path
-// to check, and the daemon falls back to downloading the pinned llama.cpp
-// release on demand.
+// LlamaServerPath returns the directory that holds the llama.cpp server binary.
+// Configured via LLAMA_SERVER_PATH. On Linux the container image sets this to
+// the bundled binary's location. When it is unset (macOS/Windows), an empty
+// string is returned and the llama.cpp backend falls back to a writable
+// per-user directory into which it downloads the pinned release on demand.
 func LlamaServerPath() string {
-	if s := Var("LLAMA_SERVER_PATH"); s != "" {
-		return s
-	}
-	if runtime.GOOS == "darwin" {
-		return "/Applications/Docker.app/Contents/Resources/model-runner/bin"
-	}
-	return ""
+	return Var("LLAMA_SERVER_PATH")
 }
 
 // LlamaArgs returns custom arguments to pass to the llama.cpp server.

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -1,7 +1,6 @@
 package envconfig_test
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/docker/model-runner/pkg/envconfig"
@@ -15,16 +14,13 @@ func TestLlamaServerPath(t *testing.T) {
 		}
 	})
 
-	t.Run("default depends on platform", func(t *testing.T) {
+	t.Run("empty when unset", func(t *testing.T) {
 		t.Setenv("LLAMA_SERVER_PATH", "")
-		got := envconfig.LlamaServerPath()
-		if runtime.GOOS == "darwin" {
-			want := "/Applications/Docker.app/Contents/Resources/model-runner/bin"
-			if got != want {
-				t.Fatalf("LlamaServerPath() = %q, want %q", got, want)
-			}
-		} else if got != "" {
-			t.Fatalf("LlamaServerPath() = %q, want empty string on %s", got, runtime.GOOS)
+		// When unset there is no meaningful default here: the llama.cpp backend
+		// falls back to a writable per-user directory (macOS/Windows) or the
+		// image sets LLAMA_SERVER_PATH explicitly (Linux).
+		if got := envconfig.LlamaServerPath(); got != "" {
+			t.Fatalf("LlamaServerPath() = %q, want empty string", got)
 		}
 	})
 }

--- a/pkg/inference/backend.go
+++ b/pkg/inference/backend.go
@@ -323,3 +323,13 @@ type Backend interface {
 	// GetDiskUsage returns the disk usage of the backend.
 	GetDiskUsage() (int64, error)
 }
+
+// BackendVersionSelector is an optional interface implemented by backends whose
+// install version can be overridden at install time (e.g. to pull a specific
+// build or the latest one on demand instead of the version pinned to this
+// model-runner release). The override takes effect on the next Install.
+type BackendVersionSelector interface {
+	// SetInstallVersion sets the version the backend should install. An empty
+	// string leaves the current selection unchanged.
+	SetInstallVersion(version string)
+}

--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -2,6 +2,7 @@ package llamacpp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -21,6 +22,18 @@ import (
 const (
 	hubNamespace = "docker"
 	hubRepo      = "docker-model-backend-llamacpp"
+
+	// LatestServerVersion is the sentinel that opts into tracking the mutable
+	// "latest" tag rather than a pinned release.
+	LatestServerVersion = "latest"
+
+	// pinnedServerVersion is the default llama.cpp version this model-runner
+	// build downloads on macOS/Windows. It is a tag of the
+	// docker/docker-model-backend-llamacpp image and must be bumped together
+	// with the Linux bundle (Dockerfile LLAMA_SERVER_VERSION) whenever llama.cpp
+	// is upgraded, so all platforms ship a consistent, tested build. Users can
+	// override it via LLAMA_SERVER_VERSION or `--llama-server-version`.
+	pinnedServerVersion = "v0.0.34"
 )
 
 var (
@@ -28,9 +41,9 @@ var (
 	ShouldUseGPUVariantLock   sync.Mutex
 	ShouldUpdateServer        = true
 	ShouldUpdateServerLock    sync.Mutex
-	DesiredServerVersion      = "latest"
+	DesiredServerVersion      = pinnedServerVersion
 	DesiredServerVersionLock  sync.Mutex
-	errLlamaCppUpToDate       = errors.New("bundled llama.cpp version is up to date, no need to update")
+	errLlamaCppUpToDate       = errors.New("llama.cpp version is up to date, no need to update")
 	errLlamaCppUpdateDisabled = errors.New("llama.cpp auto-updated is disabled")
 )
 
@@ -50,19 +63,35 @@ func SetDesiredServerVersion(version string) {
 func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logger,
 	desiredVersion, desiredVariant string,
 ) error {
+	llamaCppPath := filepath.Join(l.installDir, l.downloadBinaryName())
+	desiredTag := desiredVersion + "-" + desiredVariant
+	binaryPresent := false
+	if _, statErr := os.Stat(llamaCppPath); statErr == nil {
+		binaryPresent = true
+	}
+	rec := l.readInstalledVersion()
+
 	ShouldUpdateServerLock.Lock()
 	shouldUpdateServer := ShouldUpdateServer
 	ShouldUpdateServerLock.Unlock()
 	if !shouldUpdateServer {
 		log.Info("downloadLatestLlamaCpp: update disabled")
+		if binaryPresent {
+			l.setRunningStatus(log, llamaCppPath, desiredTag, rec.Digest)
+		}
 		return errLlamaCppUpdateDisabled
 	}
 
-	llamaCppPath := filepath.Join(l.installDir, l.downloadBinaryName())
-	versionFile := filepath.Join(l.installDir, ".llamacpp_version")
-
 	log.Info("downloadLatestLlamaCpp", "desiredVersion", desiredVersion, "desiredVariant", desiredVariant, "installDir", l.installDir)
-	desiredTag := desiredVersion + "-" + desiredVariant
+
+	// Fast path: a pinned (immutable) version tag that is already installed
+	// needs no registry round-trip at all, so startup works offline. Only the
+	// mutable "latest" tag must always be re-resolved to pick up new pushes.
+	if binaryPresent && desiredVersion != LatestServerVersion && rec.Tag == desiredTag {
+		log.Info("pinned llama.cpp version already installed, skipping update check", "tag", desiredTag)
+		l.setRunningStatus(log, llamaCppPath, desiredTag, rec.Digest)
+		return errLlamaCppUpToDate
+	}
 
 	// Resolve the desired tag to a digest via the Registry HTTP API v2. This
 	// honors l.registryMirrors (typically a corporate Artifactory / Nexus /
@@ -80,17 +109,13 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 	// If we have already downloaded this exact digest and the binary is still
 	// present, there is nothing to do. Unlike the previous Docker Desktop
 	// bundled model, there is no vendored binary to compare against here.
-	if data, readErr := os.ReadFile(versionFile); readErr == nil {
-		if strings.TrimSpace(string(data)) == latest {
-			if _, statErr := os.Stat(llamaCppPath); statErr == nil {
-				log.Info("current llama.cpp version is already up to date")
-				l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
-				return errLlamaCppUpToDate
-			}
-			log.Info("llama.cpp binary missing despite version match, proceeding to download")
-		} else {
-			log.Info("current llama.cpp version is outdated, proceeding to update", "current", strings.TrimSpace(string(data)), "latest", latest)
-		}
+	if binaryPresent && rec.Digest == latest {
+		log.Info("current llama.cpp version is already up to date")
+		l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
+		return errLlamaCppUpToDate
+	}
+	if rec.Digest != "" && rec.Digest != latest {
+		log.Info("current llama.cpp version is outdated, proceeding to update", "current", rec.Digest, "latest", latest)
 	}
 
 	image := fmt.Sprintf("registry-1.docker.io/%s/%s@%s", hubNamespace, hubRepo, latest)
@@ -140,11 +165,53 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 	l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
 	log.Info(l.status)
 
-	if err := os.WriteFile(versionFile, []byte(latest), 0o644); err != nil {
-		log.Warn("failed to save llama.cpp version", "error", err)
-	}
+	l.writeInstalledVersion(log, installedVersion{Tag: desiredTag, Digest: latest})
 
 	return nil
+}
+
+// installedVersion records which llama.cpp image tag and digest are currently
+// installed in installDir. Tracking the tag (not just the digest) lets us skip
+// the registry round-trip for immutable pinned versions.
+//
+//nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
+type installedVersion struct {
+	Tag    string `json:"tag"`
+	Digest string `json:"digest"`
+}
+
+//nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
+func (l *llamaCpp) versionFilePath() string {
+	return filepath.Join(l.installDir, ".llamacpp_version")
+}
+
+// readInstalledVersion reads the recorded install metadata, tolerating the
+// legacy format where the file held only the raw digest.
+//
+//nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
+func (l *llamaCpp) readInstalledVersion() installedVersion {
+	data, err := os.ReadFile(l.versionFilePath())
+	if err != nil {
+		return installedVersion{}
+	}
+	var rec installedVersion
+	if json.Unmarshal(data, &rec) == nil && rec.Digest != "" {
+		return rec
+	}
+	// Legacy format: the file previously held only the digest string.
+	return installedVersion{Digest: strings.TrimSpace(string(data))}
+}
+
+//nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
+func (l *llamaCpp) writeInstalledVersion(log logging.Logger, rec installedVersion) {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		log.Warn("failed to marshal llama.cpp version", "error", err)
+		return
+	}
+	if err := os.WriteFile(l.versionFilePath(), data, 0o644); err != nil {
+		log.Warn("failed to save llama.cpp version", "error", err)
+	}
 }
 
 //nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)

--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -48,7 +48,7 @@ func SetDesiredServerVersion(version string) {
 
 //nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
 func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logger,
-	llamaCppPath, vendoredServerStoragePath, desiredVersion, desiredVariant string,
+	desiredVersion, desiredVariant string,
 ) error {
 	ShouldUpdateServerLock.Lock()
 	shouldUpdateServer := ShouldUpdateServer
@@ -58,7 +58,10 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 		return errLlamaCppUpdateDisabled
 	}
 
-	log.Info("downloadLatestLlamaCpp", "desiredVersion", desiredVersion, "desiredVariant", desiredVariant, "vendoredServerStoragePath", vendoredServerStoragePath, "llamaCppPath", llamaCppPath)
+	llamaCppPath := filepath.Join(l.installDir, l.downloadBinaryName())
+	versionFile := filepath.Join(l.installDir, ".llamacpp_version")
+
+	log.Info("downloadLatestLlamaCpp", "desiredVersion", desiredVersion, "desiredVariant", desiredVariant, "installDir", l.installDir)
 	desiredTag := desiredVersion + "-" + desiredVariant
 
 	// Resolve the desired tag to a digest via the Registry HTTP API v2. This
@@ -74,30 +77,20 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 		return fmt.Errorf("could not resolve the %s tag: %w", desiredTag, err)
 	}
 
-	bundledVersionFile := filepath.Join(vendoredServerStoragePath, "com.docker.llama-server.digest")
-	currentVersionFile := filepath.Join(filepath.Dir(llamaCppPath), ".llamacpp_version")
-
-	data, err := os.ReadFile(bundledVersionFile)
-	if err != nil {
-		return fmt.Errorf("failed to read bundled llama.cpp version: %w", err)
-	} else if strings.TrimSpace(string(data)) == latest {
-		l.setRunningStatus(log, filepath.Join(vendoredServerStoragePath, "com.docker.llama-server"), desiredTag, latest)
-		return errLlamaCppUpToDate
-	}
-
-	data, err = os.ReadFile(currentVersionFile)
-	if err != nil {
-		log.Warn("failed to read current llama.cpp version", "error", err)
-		log.Warn("proceeding to update llama.cpp binary")
-	} else if strings.TrimSpace(string(data)) == latest {
-		log.Info("current llama.cpp version is already up to date")
-		if _, statErr := os.Stat(llamaCppPath); statErr == nil {
-			l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
-			return nil
+	// If we have already downloaded this exact digest and the binary is still
+	// present, there is nothing to do. Unlike the previous Docker Desktop
+	// bundled model, there is no vendored binary to compare against here.
+	if data, readErr := os.ReadFile(versionFile); readErr == nil {
+		if strings.TrimSpace(string(data)) == latest {
+			if _, statErr := os.Stat(llamaCppPath); statErr == nil {
+				log.Info("current llama.cpp version is already up to date")
+				l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
+				return errLlamaCppUpToDate
+			}
+			log.Info("llama.cpp binary missing despite version match, proceeding to download")
+		} else {
+			log.Info("current llama.cpp version is outdated, proceeding to update", "current", strings.TrimSpace(string(data)), "latest", latest)
 		}
-		log.Info("llama.cpp binary must be updated, proceeding to update it")
-	} else {
-		log.Info("current llama.cpp version is outdated, proceeding to update it", "current", strings.TrimSpace(string(data)), "latest", latest)
 	}
 
 	image := fmt.Sprintf("registry-1.docker.io/%s/%s@%s", hubNamespace, hubRepo, latest)
@@ -112,32 +105,33 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 		return fmt.Errorf("could not extract image: %w", extractErr)
 	}
 
-	if err := os.RemoveAll(filepath.Dir(llamaCppPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
+	libDir := filepath.Join(filepath.Dir(l.installDir), "lib")
+	if err := os.RemoveAll(l.installDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to clear inference binary dir: %w", err)
 	}
-	if err := os.RemoveAll(filepath.Join(filepath.Dir(filepath.Dir(llamaCppPath)), "lib")); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := os.RemoveAll(libDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to clear inference library dir: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(filepath.Dir(llamaCppPath)), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(l.installDir), 0o755); err != nil {
 		return fmt.Errorf("could not create directory for llama.cpp artifacts: %w", err)
 	}
 
 	rootDir := fmt.Sprintf("com.docker.llama-server.native.%s.%s.%s", runtime.GOOS, desiredVariant, runtime.GOARCH)
-	if err := os.Rename(filepath.Join(downloadDir, rootDir, "bin"), filepath.Dir(llamaCppPath)); err != nil {
+	if err := os.Rename(filepath.Join(downloadDir, rootDir, "bin"), l.installDir); err != nil {
 		return fmt.Errorf("could not move llama.cpp binary: %w", err)
 	}
 	if err := os.Chmod(llamaCppPath, 0o755); err != nil {
 		return fmt.Errorf("could not chmod llama.cpp binary: %w", err)
 	}
 
-	libDir := filepath.Join(downloadDir, rootDir, "lib")
-	fi, err := os.Stat(libDir)
+	srcLibDir := filepath.Join(downloadDir, rootDir, "lib")
+	fi, err := os.Stat(srcLibDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to stat llama.cpp lib dir: %w", err)
 	}
 	if err == nil && fi.IsDir() {
-		if err := os.Rename(libDir, filepath.Join(filepath.Dir(filepath.Dir(llamaCppPath)), "lib")); err != nil {
+		if err := os.Rename(srcLibDir, libDir); err != nil {
 			return fmt.Errorf("could not move llama.cpp libs: %w", err)
 		}
 	}
@@ -146,7 +140,7 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 	l.setRunningStatus(log, llamaCppPath, desiredTag, latest)
 	log.Info(l.status)
 
-	if err := os.WriteFile(currentVersionFile, []byte(latest), 0o644); err != nil {
+	if err := os.WriteFile(versionFile, []byte(latest), 0o644); err != nil {
 		log.Warn("failed to save llama.cpp version", "error", err)
 	}
 

--- a/pkg/inference/backends/llamacpp/download_darwin.go
+++ b/pkg/inference/backends/llamacpp/download_darwin.go
@@ -7,11 +7,8 @@ import (
 	"github.com/docker/model-runner/pkg/logging"
 )
 
-func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, _ *http.Client,
-	llamaCppPath, vendoredServerStoragePath string,
-) error {
+func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, _ *http.Client) error {
 	desiredVersion := GetDesiredServerVersion()
 	desiredVariant := "metal"
-	return l.downloadLatestLlamaCpp(ctx, log, llamaCppPath, vendoredServerStoragePath, desiredVersion,
-		desiredVariant)
+	return l.downloadLatestLlamaCpp(ctx, log, desiredVersion, desiredVariant)
 }

--- a/pkg/inference/backends/llamacpp/download_linux.go
+++ b/pkg/inference/backends/llamacpp/download_linux.go
@@ -8,9 +8,9 @@ import (
 	"github.com/docker/model-runner/pkg/logging"
 )
 
-func (l *llamaCpp) ensureLatestLlamaCpp(_ context.Context, log logging.Logger, _ *http.Client,
-	_, vendoredServerStoragePath string,
-) error {
-	l.setRunningStatus(log, filepath.Join(vendoredServerStoragePath, resolveLlamaServerBin(vendoredServerStoragePath)), "", "")
+func (l *llamaCpp) ensureLatestLlamaCpp(_ context.Context, log logging.Logger, _ *http.Client) error {
+	// On Linux the binary is bundled into the container image at installDir;
+	// there is no on-demand download.
+	l.setRunningStatus(log, filepath.Join(l.installDir, resolveLlamaServerBin(l.installDir)), "", "")
 	return errLlamaCppUpdateDisabled
 }

--- a/pkg/inference/backends/llamacpp/download_windows.go
+++ b/pkg/inference/backends/llamacpp/download_windows.go
@@ -11,10 +11,8 @@ import (
 	"github.com/docker/model-runner/pkg/logging"
 )
 
-func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, _ *http.Client,
-	llamaCppPath, vendoredServerStoragePath string,
-) error {
-	nvGPUInfoBin := filepath.Join(vendoredServerStoragePath, "com.docker.nv-gpu-info.exe")
+func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger, _ *http.Client) error {
+	nvGPUInfoBin := filepath.Join(l.installDir, "com.docker.nv-gpu-info.exe")
 	var canUseCUDA11, canUseOpenCL bool
 	var err error
 	ShouldUseGPUVariantLock.Lock()
@@ -43,6 +41,5 @@ func (l *llamaCpp) ensureLatestLlamaCpp(ctx context.Context, log logging.Logger,
 		desiredVariant = "opencl"
 	}
 	l.status = inference.FormatInstalling(fmt.Sprintf("%s llama.cpp %s", inference.DetailCheckingForUpdates, desiredVariant))
-	return l.downloadLatestLlamaCpp(ctx, log, llamaCppPath, vendoredServerStoragePath, desiredVersion,
-		desiredVariant)
+	return l.downloadLatestLlamaCpp(ctx, log, desiredVersion, desiredVariant)
 }

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -39,13 +39,12 @@ type llamaCpp struct {
 	// modelManager is the shared model manager.
 	modelManager *models.Manager
 	// serverLog is the logger to use for the llama.cpp server process.
-	serverLog       logging.Logger
-	updatedLlamaCpp bool
-	// vendoredServerStoragePath is the parent path of the vendored version of com.docker.llama-server.
-	vendoredServerStoragePath string
-	// updatedServerStoragePath is the parent path of the updated version of com.docker.llama-server.
-	// It is also where updates will be stored when downloaded.
-	updatedServerStoragePath string
+	serverLog logging.Logger
+	// installDir is the directory that holds the llama.cpp server binary.
+	// On macOS/Windows it defaults to a writable location under the user's
+	// home directory and is populated on demand (deferred install). On Linux
+	// it points at the binary bundled into the container image.
+	installDir string
 	// status is the state in which the llama.cpp backend is in.
 	status string
 	// config is the configuration for the llama.cpp backend.
@@ -56,13 +55,14 @@ type llamaCpp struct {
 	registryMirrors []string
 }
 
-// New creates a new llama.cpp-based backend.
+// New creates a new llama.cpp-based backend. installDir is the directory that
+// holds (or, on macOS/Windows, will hold) the llama.cpp server binary. When it
+// is empty a default writable location under the user's home directory is used.
 func New(
 	log logging.Logger,
 	modelManager *models.Manager,
 	serverLog logging.Logger,
-	vendoredServerStoragePath string,
-	updatedServerStoragePath string,
+	installDir string,
 	conf config.BackendConfig,
 	registryMirrors []string,
 ) (inference.Backend, error) {
@@ -71,15 +71,30 @@ func New(
 		conf = NewDefaultLlamaCppConfig()
 	}
 
+	if installDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("could not determine home directory for llama.cpp install path: %w", err)
+		}
+		installDir = filepath.Join(home, ".docker", "model-runner", "llama.cpp", "bin")
+	}
+
 	return &llamaCpp{
-		log:                       log,
-		modelManager:              modelManager,
-		serverLog:                 serverLog,
-		vendoredServerStoragePath: vendoredServerStoragePath,
-		updatedServerStoragePath:  updatedServerStoragePath,
-		config:                    conf,
-		registryMirrors:           registryMirrors,
+		log:             log,
+		modelManager:    modelManager,
+		serverLog:       serverLog,
+		installDir:      installDir,
+		status:          inference.FormatNotInstalled(""),
+		config:          conf,
+		registryMirrors: registryMirrors,
 	}, nil
+}
+
+// NeedsDeferredInstall reports whether the llama.cpp backend downloads its
+// binary on demand on the current platform (macOS/Windows) rather than relying
+// on a binary bundled at build time (Linux container image).
+func NeedsDeferredInstall() bool {
+	return runtime.GOOS == "darwin" || runtime.GOOS == "windows"
 }
 
 // resolveLlamaServerBin returns the llama-server binary name to use.
@@ -103,6 +118,16 @@ func resolveLlamaServerBin(dir string) string {
 	return "llama-server"
 }
 
+// downloadBinaryName returns the name of the llama.cpp server binary shipped in
+// the docker-model-backend-llamacpp images used for on-demand downloads. These
+// images always use the Docker-convention name.
+func (l *llamaCpp) downloadBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "com.docker.llama-server.exe"
+	}
+	return "com.docker.llama-server"
+}
+
 // Name implements inference.Backend.Name.
 func (l *llamaCpp) Name() string {
 	return Name
@@ -121,8 +146,6 @@ func (l *llamaCpp) UsesTCP() bool {
 
 // Install implements inference.Backend.Install.
 func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
-	l.updatedLlamaCpp = false
-
 	// We don't currently support this backend on Windows. We'll likely
 	// never support it on Intel Macs.
 	if (runtime.GOOS == "darwin" && runtime.GOARCH == "amd64") ||
@@ -130,10 +153,11 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 		return errors.New("platform not supported")
 	}
 
-	llamaServerBin := resolveLlamaServerBin(l.vendoredServerStoragePath)
-
-	llamaCppPath := filepath.Join(l.updatedServerStoragePath, llamaServerBin)
-	if err := l.ensureLatestLlamaCpp(ctx, l.log, httpClient, llamaCppPath, l.vendoredServerStoragePath); err != nil {
+	// On macOS/Windows the binary is downloaded on demand into installDir; on
+	// Linux it is bundled into the image at installDir and ensureLatestLlamaCpp
+	// simply reports it as running. ensureLatestLlamaCpp is idempotent: if the
+	// binary is already present and up to date it returns errLlamaCppUpToDate.
+	if err := l.ensureLatestLlamaCpp(ctx, l.log, httpClient); err != nil {
 		l.log.Info("Failed to ensure latest llama.cpp", "error", err)
 		if !errors.Is(err, errLlamaCppUpToDate) && !errors.Is(err, errLlamaCppUpdateDisabled) {
 			l.status = inference.FormatError(fmt.Sprintf("failed to install llama.cpp: %v", err))
@@ -141,8 +165,6 @@ func (l *llamaCpp) Install(ctx context.Context, httpClient *http.Client) error {
 		if errors.Is(err, context.Canceled) {
 			return err
 		}
-	} else {
-		l.updatedLlamaCpp = true
 	}
 
 	l.gpuSupported = l.checkGPUSupport(ctx)
@@ -166,11 +188,6 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, _ string, mode
 		}
 	}
 
-	binPath := l.vendoredServerStoragePath
-	if l.updatedLlamaCpp {
-		binPath = l.updatedServerStoragePath
-	}
-
 	args, err := l.config.GetArgs(bundle, socket, mode, config)
 	if err != nil {
 		return fmt.Errorf("failed to get args for llama.cpp: %w", err)
@@ -192,8 +209,8 @@ func (l *llamaCpp) Run(ctx context.Context, socket, model string, _ string, mode
 	return backends.RunBackend(ctx, backends.RunnerConfig{
 		BackendName:      "llama.cpp",
 		Socket:           socket,
-		BinaryPath:       filepath.Join(binPath, resolveLlamaServerBin(binPath)),
-		SandboxPath:      binPath,
+		BinaryPath:       filepath.Join(l.installDir, resolveLlamaServerBin(l.installDir)),
+		SandboxPath:      l.installDir,
 		SandboxConfig:    sandbox.ConfigurationLlamaCpp,
 		Args:             args,
 		Logger:           l.log,
@@ -212,7 +229,7 @@ func (l *llamaCpp) Status() string {
 }
 
 func (l *llamaCpp) GetDiskUsage() (int64, error) {
-	size, err := diskusage.Size(l.updatedServerStoragePath)
+	size, err := diskusage.Size(l.installDir)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting store size: %w", err)
 	}
@@ -357,10 +374,7 @@ func getGGUFLayers(layers []oci.Layer) []oci.Layer {
 }
 
 func (l *llamaCpp) checkGPUSupport(ctx context.Context) bool {
-	binPath := l.vendoredServerStoragePath
-	if l.updatedLlamaCpp {
-		binPath = l.updatedServerStoragePath
-	}
+	binPath := l.installDir
 	var output bytes.Buffer
 	llamaCppSandbox, err := sandbox.Create(
 		ctx,

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -97,6 +97,16 @@ func NeedsDeferredInstall() bool {
 	return runtime.GOOS == "darwin" || runtime.GOOS == "windows"
 }
 
+// SetInstallVersion implements inference.BackendVersionSelector. It selects the
+// llama.cpp image version installed on the next Install (e.g. "latest" or a
+// specific "vX.Y.Z" tag), overriding the version pinned to this release.
+func (l *llamaCpp) SetInstallVersion(version string) {
+	if version == "" {
+		return
+	}
+	SetDesiredServerVersion(version)
+}
+
 // resolveLlamaServerBin returns the llama-server binary name to use.
 // It prefers the upstream name (llama-server) shipped by the official
 // ghcr.io/ggml-org/llama.cpp images used on Linux.  When that binary
@@ -121,6 +131,8 @@ func resolveLlamaServerBin(dir string) string {
 // downloadBinaryName returns the name of the llama.cpp server binary shipped in
 // the docker-model-backend-llamacpp images used for on-demand downloads. These
 // images always use the Docker-convention name.
+//
+//nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
 func (l *llamaCpp) downloadBinaryName() string {
 	if runtime.GOOS == "windows" {
 		return "com.docker.llama-server.exe"

--- a/pkg/inference/scheduling/http_handler.go
+++ b/pkg/inference/scheduling/http_handler.go
@@ -378,6 +378,10 @@ func (h *HTTPHandler) Unload(w http.ResponseWriter, r *http.Request) {
 // installBackendRequest is the JSON body for the install-backend endpoint.
 type installBackendRequest struct {
 	Backend string `json:"backend"`
+	// Version optionally overrides the backend version to install (e.g.
+	// "latest" or a specific "vX.Y.Z"). Empty means use the version pinned to
+	// this model-runner release. Only honored by backends that support it.
+	Version string `json:"version,omitempty"`
 }
 
 // InstallBackend handles POST <inference-prefix>/install-backend requests.
@@ -394,7 +398,7 @@ func (h *HTTPHandler) InstallBackend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.scheduler.InstallBackend(r.Context(), req.Backend); err != nil {
+	if err := h.scheduler.InstallBackend(r.Context(), req.Backend, req.Version); err != nil {
 		if errors.Is(err, ErrBackendNotFound) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {

--- a/pkg/inference/scheduling/scheduler.go
+++ b/pkg/inference/scheduling/scheduler.go
@@ -214,8 +214,16 @@ func (s *Scheduler) ResetInstaller(httpClient *http.Client) {
 	s.installer = newInstaller(s.log, s.backends, httpClient, s.deferredBackends)
 }
 
-// InstallBackend triggers on-demand installation of a deferred backend.
-func (s *Scheduler) InstallBackend(ctx context.Context, name string) error {
+// InstallBackend triggers on-demand installation of a deferred backend. When
+// version is non-empty and the backend supports version selection, it installs
+// that version (e.g. "latest" or a specific "vX.Y.Z") instead of the version
+// pinned to this release.
+func (s *Scheduler) InstallBackend(ctx context.Context, name, version string) error {
+	if version != "" {
+		if vs, ok := s.backends[name].(inference.BackendVersionSelector); ok {
+			vs.SetInstallVersion(version)
+		}
+	}
 	return s.installer.installBackend(ctx, name)
 }
 

--- a/pkg/routing/backends.go
+++ b/pkg/routing/backends.go
@@ -21,9 +21,8 @@ type BackendsConfig struct {
 	ServerLogFactory func(backendName string) logging.Logger
 
 	// LlamaCpp settings (always included).
-	LlamaCppVendoredPath string
-	LlamaCppUpdatedPath  string
-	LlamaCppConfig       config.BackendConfig
+	LlamaCppPath   string
+	LlamaCppConfig config.BackendConfig
 
 	// Optional backends and their custom server paths.
 	IncludeMLX bool
@@ -54,8 +53,8 @@ func DefaultBackendDefs(cfg BackendsConfig) []BackendDef {
 	}
 
 	defs := []BackendDef{
-		{Name: llamacpp.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
-			return llamacpp.New(cfg.Log, mm, sl(llamacpp.Name), cfg.LlamaCppVendoredPath, cfg.LlamaCppUpdatedPath, cfg.LlamaCppConfig, cfg.RegistryMirrors)
+		{Name: llamacpp.Name, Deferred: llamacpp.NeedsDeferredInstall(), Init: func(mm *models.Manager) (inference.Backend, error) {
+			return llamacpp.New(cfg.Log, mm, sl(llamacpp.Name), cfg.LlamaCppPath, cfg.LlamaCppConfig, cfg.RegistryMirrors)
 		}},
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -146,13 +146,6 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("invalid LLAMA_ARGS: %w", err)
 	}
 
-	updatedServerPath := func() string {
-		wd, _ := os.Getwd()
-		d := filepath.Join(wd, "updated-inference", "bin")
-		_ = os.MkdirAll(d, 0o755)
-		return d
-	}()
-
 	svc, err := routing.NewService(routing.ServiceConfig{
 		Log: log,
 		ClientConfig: models.ClientConfig{
@@ -174,17 +167,16 @@ func Run(ctx context.Context, cfg Config) error {
 						&slog.HandlerOptions{Level: envconfig.LogLevel()},
 					))
 				},
-				LlamaCppVendoredPath: llamaServerPath,
-				LlamaCppUpdatedPath:  updatedServerPath,
-				LlamaCppConfig:       llamaCppConfig,
-				IncludeMLX:           true,
-				MLXPath:              mlxServerPath,
-				IncludeVLLM:          includeVLLM,
-				VLLMPath:             vllmServerPath,
-				VLLMMetalPath:        vllmMetalServerPath,
-				IncludeDiffusers:     true,
-				DiffusersPath:        diffusersServerPath,
-				RegistryMirrors:      envconfig.RegistryMirrors(),
+				LlamaCppPath:     llamaServerPath,
+				LlamaCppConfig:   llamaCppConfig,
+				IncludeMLX:       true,
+				MLXPath:          mlxServerPath,
+				IncludeVLLM:      includeVLLM,
+				VLLMPath:         vllmServerPath,
+				VLLMMetalPath:    vllmMetalServerPath,
+				IncludeDiffusers: true,
+				DiffusersPath:    diffusersServerPath,
+				RegistryMirrors:  envconfig.RegistryMirrors(),
 			}),
 			routing.BackendDef{Name: sglang.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
 				return sglang.New(log, mm, log.With("component", sglang.Name), nil, sglangServerPath)


### PR DESCRIPTION
```
$ make build-dmr
CGO_ENABLED=0 go build -ldflags="-s -w -X main.Version=v0.1.0-4-gf8b8e764 -X github.com/docker/model-runner/cmd/cli/desktop.Version=v0.1.0-4-gf8b8e764" -o dmr ./cmd/dmr
```

```
$ ./dmr serve smollm2
```

```
$ ./dmr run smollm2 hi
Installing llama.cpp backend...
llama.cpp backend installed successfully
Hi, I'm SmolLM, your AI assistant. How can I help you today?
```

```
$ ./dmr status
Docker Model Runner is running

BACKEND    STATUS         DETAILS
llama.cpp  Running        llama.cpp v0.0.34-metal (sha256:aa3e239c5737a7fa56f3908a865eb75dfae214b9cfec2cdd929e4d5353c2d714) ac4cdde
diffusers  Not Installed
mlx        Not Installed  package not installed
sglang     Not Installed  only supported on Linux
vllm       Not Installed
```