### PR TITLE
fix: update diffusers status messages for improved clarity and formatting

### DIFF
--- a/pkg/inference/backends/diffusers/diffusers.go
+++ b/pkg/inference/backends/diffusers/diffusers.go
@@ -122,7 +122,7 @@ func (d *diffusers) Install(ctx context.Context, httpClient *http.Client) error 
 		}
 	}
 
-	d.status = "installing"
+	d.status = inference.FormatInstalling(fmt.Sprintf("%s diffusers %s", inference.DetailDownloading, diffusersVersion))
 	if err := d.downloadAndExtract(ctx); err != nil {
 		return fmt.Errorf("failed to install diffusers: %w", err)
 	}
@@ -194,17 +194,17 @@ func (d *diffusers) downloadAndExtract(ctx context.Context) error {
 func (d *diffusers) verifyInstallation(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, d.pythonPath, "-c", "import diffusers") //nolint:gosec // pythonPath is set internally by Install, not user input
 	if err := cmd.Run(); err != nil {
-		d.status = "import failed"
+		d.status = inference.FormatError(inference.DetailImportFailed)
 		return fmt.Errorf("diffusers import failed: %w", err)
 	}
 
 	versionFile := filepath.Join(d.installDir, ".diffusers-version")
 	versionBytes, err := os.ReadFile(versionFile)
 	if err != nil {
-		d.status = "running diffusers"
+		d.status = inference.FormatRunning(inference.DetailVersionUnknown)
 		return nil
 	}
-	d.status = fmt.Sprintf("running diffusers %s", strings.TrimSpace(string(versionBytes)))
+	d.status = inference.FormatRunning(fmt.Sprintf("diffusers %s", strings.TrimSpace(string(versionBytes))))
 	return nil
 }
 


### PR DESCRIPTION
Fixed the `diffusers` backend status reporting to match the `vllm-metal` pattern. The core issue was that raw lowercase strings (e.g. `"running diffusers v0.1.0-20260216-000000"`) were being used instead of the proper `inference.Format*()` helpers, causing `ParseStatus()` to misclassify the healthy backend as "Error".