### PR TITLE
downgrade Go version from 1.26.0 to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: 1.26.0
+          go-version: 1.25.8
           cache: true
 
       - name: Install golangci-lint
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: 1.26.0
+          go-version: 1.25.8
           cache: true
 
       - name: Check go mod tidy

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: 1.26.0
+          go-version: 1.25.8
           cache: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: 1.26.0
+          go-version: 1.25.8
           cache: true
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26
+ARG GO_VERSION=1.25
 ARG LLAMA_SERVER_VERSION=latest
 ARG LLAMA_SERVER_VARIANT=cpu
 ARG LLAMA_BINARY_PATH=/com.docker.llama-server.native.linux.${LLAMA_SERVER_VARIANT}.${TARGETARCH}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Project variables
 APP_NAME := model-runner
-GO_VERSION := 1.26.0
+GO_VERSION := 1.25.8
 LLAMA_SERVER_VERSION := latest
 LLAMA_SERVER_VARIANT := cpu
 BASE_IMAGE := ubuntu:24.04

--- a/cmd/cli/Dockerfile
+++ b/cmd/cli/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26
+ARG GO_VERSION=1.25
 ARG ALPINE_VERSION=3.23
 
 ARG DOCS_FORMATS="md,yaml"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/model-runner
 
-go 1.26.0
+go 1.25.8
 
 require (
 	github.com/charmbracelet/glamour v1.0.0


### PR DESCRIPTION
required to bump DMR in DD to latest version