### PR TITLE
cmd/cli/commands: use local fork of hooks.PrintNextSteps

### DIFF
--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
@@ -63,7 +62,7 @@ func textStatus(cmd *cobra.Command, status desktop.Status, backendStatus map[str
 		cmd.Print(backendStatusTable(backendStatus))
 	} else {
 		cmd.Println("Docker Model Runner is not running")
-		hooks.PrintNextSteps(cmd.OutOrStdout(), []string{enableViaCLI, enableViaGUI})
+		printNextSteps(cmd.OutOrStdout(), []string{enableViaCLI, enableViaGUI})
 		osExit(1)
 	}
 }

--- a/cmd/cli/commands/status_test.go
+++ b/cmd/cli/commands/status_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	mockdesktop "github.com/docker/model-runner/cmd/cli/mocks"
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
@@ -51,7 +50,7 @@ func TestStatus(t *testing.T) {
 			expectedOutput: func() string {
 				buf := new(bytes.Buffer)
 				fmt.Fprintln(buf, "Docker Model Runner is not running")
-				hooks.PrintNextSteps(buf, []string{enableViaCLI, enableViaGUI})
+				printNextSteps(buf, []string{enableViaCLI, enableViaGUI})
 				return buf.String()
 			}(),
 		},

--- a/cmd/cli/commands/utils.go
+++ b/cmd/cli/commands/utils.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-runner/cmd/cli/desktop"
 	"github.com/docker/model-runner/cmd/cli/pkg/standalone"
 	"github.com/docker/model-runner/pkg/distribution/oci/reference"
@@ -47,12 +46,12 @@ func handleClientError(err error, message string) error {
 	if errors.Is(err, desktop.ErrServiceUnavailable) {
 		err = errNotRunning
 		var buf bytes.Buffer
-		hooks.PrintNextSteps(&buf, []string{enableViaCLI, enableViaGUI})
+		printNextSteps(&buf, []string{enableViaCLI, enableViaGUI})
 		return fmt.Errorf("%w\n%s", err, strings.TrimRight(buf.String(), "\n"))
 	} else if strings.Contains(err.Error(), vllm.ErrorNotFound.Error()) {
 		// Handle `run` error.
 		var buf bytes.Buffer
-		hooks.PrintNextSteps(&buf, []string{enableVLLM})
+		printNextSteps(&buf, []string{enableVLLM})
 		return fmt.Errorf("%w\n%s", err, strings.TrimRight(buf.String(), "\n"))
 	}
 	return fmt.Errorf("%s: %w", message, err)
@@ -269,4 +268,18 @@ func newTable(w io.Writer) *tablewriter.Table {
 			},
 		}),
 	)
+}
+
+func printNextSteps(out io.Writer, messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(out, bold("\nWhat's next:"))
+	for _, n := range messages {
+		_, _ = fmt.Fprintln(out, "   ", n)
+	}
+}
+
+func bold(s string) string {
+	return "\033[1m" + s + "\033[0m"
 }


### PR DESCRIPTION
We're refactoring code in the CLI for better separation of plugin-manager and plugin code; add a local fork of this utility instead of depending on the utility in the CLI.