### PR TITLE
vllm: macOS: update to vLLM 0.17.1 and use native server entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ docker-run-impl:
 
 # vllm-metal (macOS ARM64 only)
 # The tarball is self-contained: includes a standalone Python 3.12 + all packages.
-VLLM_METAL_RELEASE ?= v0.1.0-20260126-121650
+VLLM_METAL_RELEASE ?= v0.1.0-20260320-122309
 VLLM_METAL_INSTALL_DIR := $(HOME)/.docker/model-runner/vllm-metal
 VLLM_METAL_TARBALL := vllm-metal-macos-arm64-$(VLLM_METAL_RELEASE).tar.gz
 
@@ -231,14 +231,15 @@ vllm-metal-dev:
 	rm -rf "$(VLLM_METAL_INSTALL_DIR)"; \
 	$$PYTHON_BIN -m venv "$(VLLM_METAL_INSTALL_DIR)"; \
 	. "$(VLLM_METAL_INSTALL_DIR)/bin/activate" && \
-		VLLM_UPSTREAM_VERSION="0.13.0" && \
+		VLLM_UPSTREAM_VERSION="0.17.1" && \
 		WORK_DIR=$$(mktemp -d) && \
 		curl -fsSL -o "$$WORK_DIR/vllm.tar.gz" "https://github.com/vllm-project/vllm/releases/download/v$$VLLM_UPSTREAM_VERSION/vllm-$$VLLM_UPSTREAM_VERSION.tar.gz" && \
 		tar -xzf "$$WORK_DIR/vllm.tar.gz" -C "$$WORK_DIR" && \
 		pip install -r "$$WORK_DIR/vllm-$$VLLM_UPSTREAM_VERSION/requirements/cpu.txt" && \
-		pip install -e "$(VLLM_METAL_PATH)" && \
+		pip install "$$WORK_DIR/vllm-$$VLLM_UPSTREAM_VERSION" && \
 		pip install -r "$$WORK_DIR/vllm-$$VLLM_UPSTREAM_VERSION/requirements/common.txt" && \
 		rm -rf "$$WORK_DIR" && \
+		pip install -e "$(VLLM_METAL_PATH)" && \
 		echo "dev" > "$(VLLM_METAL_INSTALL_DIR)/.vllm-metal-version"; \
 	echo "vllm-metal dev installed from $(VLLM_METAL_PATH)"
 

--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultInstallDir = ".docker/model-runner/vllm-metal"
 	// vllmMetalVersion is the vllm-metal release tag to download from Docker Hub.
-	vllmMetalVersion = "v0.1.0-20260126-121650"
+	vllmMetalVersion = "v0.1.0-20260320-122309"
 )
 
 var (
@@ -207,7 +207,7 @@ func (v *vllmMetal) Run(ctx context.Context, socket, model string, modelRef stri
 		return fmt.Errorf("failed to get model: %w", err)
 	}
 
-	args, err := v.buildArgs(bundle, socket, mode, config)
+	args, err := v.buildArgs(bundle, socket, model, modelRef, mode, config)
 	if err != nil {
 		return fmt.Errorf("failed to build vllm-metal arguments: %w", err)
 	}
@@ -225,7 +225,9 @@ func (v *vllmMetal) Run(ctx context.Context, socket, model string, modelRef stri
 }
 
 // buildArgs builds the command line arguments for vllm-metal server.
-func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, socket string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
+// vllm-metal is a vLLM platform plugin, so we launch vLLM's OpenAI-compatible
+// API server directly; the Metal plugin is auto-discovered via entry points.
+func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, socket, model, modelRef string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
 	// Parse host:port from socket (vllm-metal uses TCP)
 	host, port, err := net.SplitHostPort(socket)
 	if err != nil {
@@ -240,7 +242,7 @@ func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, sock
 	modelPath := filepath.Dir(safetensorsPath)
 
 	args := []string{
-		"-m", "vllm_metal.server",
+		"-m", "vllm.entrypoints.openai.api_server",
 		"--model", modelPath,
 		"--host", host,
 		"--port", port,
@@ -257,6 +259,10 @@ func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, sock
 	case inference.BackendModeImageGeneration:
 		return nil, fmt.Errorf("image generation mode not supported by vllm-metal backend")
 	}
+
+	// Register model aliases so the model-runner can address the model by its
+	// digest (model) and its human-readable reference (modelRef).
+	args = append(args, "--served-model-name", model, modelRef)
 
 	// Add context size if specified
 	if config != nil && config.ContextSize != nil {

--- a/scripts/build-vllm-metal-tarball.sh
+++ b/scripts/build-vllm-metal-tarball.sh
@@ -20,7 +20,7 @@ WORK_DIR=$(mktemp -d)
 # Convert tarball path to absolute before we cd elsewhere
 TARBALL="$(cd "$(dirname "$TARBALL_ARG")" && pwd)/$(basename "$TARBALL_ARG")"
 
-VLLM_VERSION="0.13.0"
+VLLM_VERSION="0.17.1"
 # Extract wheel version from release tag (e.g., v0.1.0-20260126-121650 -> 0.1.0)
 VLLM_METAL_WHEEL_VERSION=$(echo "$VLLM_METAL_RELEASE" | sed 's/^v//' | cut -d'-' -f1)
 VLLM_METAL_WHEEL_URL="https://github.com/vllm-project/vllm-metal/releases/download/${VLLM_METAL_RELEASE}/vllm_metal-${VLLM_METAL_WHEEL_VERSION}-cp312-cp312-macosx_11_0_arm64.whl"
@@ -89,4 +89,4 @@ SIZE=$(du -h "$TARBALL" | cut -f1)
 echo "Created: $TARBALL ($SIZE)"
 echo ""
 echo "This tarball is fully self-contained (includes Python 3.12 + all packages)."
-echo "To use: extract to a directory and run bin/python3 -m vllm_metal.server"
+echo "To use: extract to a directory and run bin/python3 -m vllm.entrypoints.openai.api_server --model <path>"


### PR DESCRIPTION
1. Pushed new [docker/model-runner:vllm-metal-v0.1.0-20260320-122309](https://hub.docker.com/layers/docker/model-runner/vllm-metal-v0.1.0-20260320-122309/images/sha256-c63ad88ef0176fbfdb0cae435918f26986d3683d57cbaf03b53a100d8f627e97) image.
2. Launch DMR and install vLLM.
```
MODEL_RUNNER_PORT=8080 make run
```
FYI w/o step 1, you can develop on vllm-metal using:
```
$ make help 2>/dev/null | awk '/^vllm-metal/{found=1} found{if(/^$/) exit; print}'
vllm-metal (macOS ARM64 only):
  1. Auto-pull from Docker Hub (clean dev installs first: make vllm-metal-clean):
     make run
  2. Build and install from tarball:
     make vllm-metal-build && make vllm-metal-install && make run
  4. Install from local source (for development, requires Python 3.12):
     make vllm-metal-dev VLLM_METAL_PATH=../vllm-metal && make run
```
3. Run.
```
MODEL_RUNNER_HOST=http://localhost:8080 docker model run hf.co/mlx-community/Qwen3.5-4B-MLX-4bit hi
```

Implements https://github.com/docker/model-runner/issues/767.