### PR TITLE
fix(vllm-metal): enable tool calling support in backend args

### DIFF
--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -246,6 +246,7 @@ func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, sock
 		"--model", modelPath,
 		"--host", host,
 		"--port", port,
+		"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
 	}
 
 	// Add mode-specific arguments


### PR DESCRIPTION
Fixes
```
$ ldm run huggingface.co/mlx-community/SmolLM2-135M-Instruct hi
Failed to generate a response: error response: status=400 body={"error":{"message":"\"auto\" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set","type":"BadRequestError","param":null,"code":400}}
```
after https://github.com/docker/model-runner/pull/771.