### PR TITLE
test(e2e): add multi-backend, API compat, and concurrency tests

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -1,0 +1,106 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/model-runner/cmd/cli/desktop"
+)
+
+func TestE2E_APIErrors(t *testing.T) {
+	t.Run("InvalidModel", func(t *testing.T) {
+		status, body := doJSON(t, http.MethodPost, serverURL+"/engines/v1/chat/completions",
+			desktop.OpenAIChatRequest{
+				Model:    "nonexistent/model:latest",
+				Messages: []desktop.OpenAIChatMessage{{Role: "user", Content: "hi"}},
+			})
+		if status == http.StatusOK {
+			t.Fatalf("expected error for invalid model, got 200: %s", body)
+		}
+		t.Logf("invalid model: status=%d", status)
+	})
+
+	t.Run("MalformedJSON", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost,
+			serverURL+"/engines/v1/chat/completions",
+			strings.NewReader(`{bad json`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatal("expected error for malformed JSON")
+		}
+		t.Logf("malformed JSON: status=%d", resp.StatusCode)
+	})
+
+	t.Run("EmptyMessages", func(t *testing.T) {
+		status, body := doJSON(t, http.MethodPost, serverURL+"/engines/v1/chat/completions",
+			desktop.OpenAIChatRequest{
+				Model:    ggufModel,
+				Messages: []desktop.OpenAIChatMessage{},
+			})
+		// Some backends accept empty messages, some don't — just verify no 500.
+		if status == http.StatusInternalServerError {
+			t.Fatalf("unexpected 500 for empty messages: %s", body)
+		}
+		t.Logf("empty messages: status=%d", status)
+	})
+}
+
+func TestE2E_ModelLifecycle(t *testing.T) {
+	model := ggufModel
+
+	t.Run("PullIdempotent", func(t *testing.T) {
+		pullModel(t, model)
+		output := pullModel(t, model)
+		if !strings.Contains(output, "Using cached model") {
+			t.Errorf("expected 'Using cached model' in second pull, got: %s", output)
+		}
+	})
+
+	t.Run("InspectModel", func(t *testing.T) {
+		status, body := doJSON(t, http.MethodGet,
+			serverURL+"/engines/v1/models/"+model, nil)
+		if status != http.StatusOK {
+			t.Fatalf("inspect: status=%d body=%s", status, body)
+		}
+		var m struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if m.ID == "" {
+			t.Fatal("empty model ID in inspect response")
+		}
+		t.Logf("inspect: id=%s", m.ID)
+	})
+
+	t.Run("OllamaShow", func(t *testing.T) {
+		status, body := doJSON(t, http.MethodPost, serverURL+"/api/show",
+			map[string]string{"name": model})
+		if status != http.StatusOK {
+			t.Fatalf("show: status=%d body=%s", status, body)
+		}
+		var show struct {
+			Details struct {
+				Format string `json:"format"`
+			} `json:"details"`
+		}
+		if err := json.Unmarshal(body, &show); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		t.Logf("format: %s", show.Details.Format)
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		removeModel(t, model)
+	})
+}

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -7,46 +7,45 @@ import (
 	"testing"
 )
 
-// TestE2E_CLI runs all CLI tests sequentially as subtests to ensure
-// correct ordering (pull → list → run → remove).
 func TestE2E_CLI(t *testing.T) {
-	t.Run("Pull", func(t *testing.T) {
-		out, err := runCLI(t, "pull", testModel)
-		if err != nil {
-			t.Fatalf("cli pull failed: %v\noutput: %s", err, out)
-		}
-		t.Logf("pull output: %s", out)
-	})
+	for _, bc := range backends {
+		bc := bc
+		t.Run(bc.name, func(t *testing.T) {
+			t.Run("Pull", func(t *testing.T) {
+				out, err := runCLI(t, "pull", bc.model)
+				if err != nil {
+					t.Fatalf("cli pull failed: %v\noutput: %s", err, out)
+				}
+				t.Logf("pull output: %s", out)
+			})
 
-	t.Run("List", func(t *testing.T) {
-		out, err := runCLI(t, "ls")
-		if err != nil {
-			t.Fatalf("cli ls failed: %v\noutput: %s", err, out)
-		}
+			t.Run("List", func(t *testing.T) {
+				out, err := runCLI(t, "ls")
+				if err != nil {
+					t.Fatalf("cli ls failed: %v\noutput: %s", err, out)
+				}
+				if !strings.Contains(out, "smollm2") {
+					t.Errorf("expected smollm2 in list output, got:\n%s", out)
+				}
+			})
 
-		if !strings.Contains(out, "smollm2") {
-			t.Errorf("expected smollm2 in list output, got:\n%s", out)
-		}
-		t.Logf("ls output:\n%s", out)
-	})
+			t.Run("Run", func(t *testing.T) {
+				out, err := runCLI(t, "run", bc.model, "Say hi in one word.")
+				if err != nil {
+					t.Fatalf("cli run failed: %v\noutput: %s", err, out)
+				}
+				if strings.TrimSpace(out) == "" {
+					t.Fatal("cli run produced empty output")
+				}
+				t.Logf("run output: %s", out)
+			})
 
-	t.Run("Run", func(t *testing.T) {
-		out, err := runCLI(t, "run", testModel, "Say hi in one word.")
-		if err != nil {
-			t.Fatalf("cli run failed: %v\noutput: %s", err, out)
-		}
-
-		if strings.TrimSpace(out) == "" {
-			t.Fatal("cli run produced empty output")
-		}
-		t.Logf("run output: %s", out)
-	})
-
-	t.Run("Remove", func(t *testing.T) {
-		out, err := runCLI(t, "rm", "-f", testModel)
-		if err != nil {
-			t.Fatalf("cli rm failed: %v\noutput: %s", err, out)
-		}
-		t.Logf("rm output: %s", out)
-	})
+			t.Run("Remove", func(t *testing.T) {
+				out, err := runCLI(t, "rm", "-f", bc.model)
+				if err != nil {
+					t.Fatalf("cli rm failed: %v\noutput: %s", err, out)
+				}
+			})
+		})
+	}
 }

--- a/e2e/concurrency_test.go
+++ b/e2e/concurrency_test.go
@@ -1,0 +1,28 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestE2E_ConcurrentRequests sends parallel chat completions to verify
+// the scheduler handles concurrent slot allocation correctly.
+func TestE2E_ConcurrentRequests(t *testing.T) {
+	model := ggufModel
+	pullModel(t, model)
+	t.Cleanup(func() {
+		removeModel(t, model)
+	})
+
+	for i := range 5 {
+		t.Run(fmt.Sprintf("request-%d", i), func(t *testing.T) {
+			t.Parallel()
+			resp := chatCompletion(t, model, "Say a single word.")
+			if len(resp.Choices) == 0 || resp.Choices[0].Message.Content == "" {
+				t.Fatal("empty response")
+			}
+		})
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,58 +3,57 @@
 // Package e2e contains end-to-end tests that build and run the full
 // model-runner stack (server + llama.cpp backend + CLI) from source.
 //
-// These tests require:
-//   - The llamacpp submodule to be initialised and built (make build-llamacpp)
-//   - A successful `make build` so that model-runner, model-cli, and dmr exist
-//
 // Run with:
 //
 //	go test -v -count=1 -tags=e2e -timeout=15m ./e2e/
 package e2e
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/pkg/ollama"
 )
 
 const (
-	// testModel is small enough to pull quickly in CI.
-	testModel = "ai/smollm2:135M-Q4_0"
+	// ggufModel is a small GGUF model for llama.cpp tests.
+	ggufModel = "ai/smollm2:135M-Q4_0"
+	// mlxModel is a small MLX-format model served by the vllm-metal backend.
+	mlxModel = "huggingface.co/mlx-community/SmolLM2-135M-Instruct"
 
 	serverStartTimeout = 60 * time.Second
 )
 
 var (
-	// serverURL is the base URL of the running model-runner instance.
 	serverURL string
-	// cliBin is the absolute path to the model-cli binary.
-	cliBin string
+	cliBin    string
 )
 
-// TestMain builds the binaries, starts the server (same pattern as dmr),
-// and tears it down after all tests complete.
 func TestMain(m *testing.M) {
-	code := run(m)
-	os.Exit(code)
+	os.Exit(run(m))
 }
 
 func run(m *testing.M) int {
-	// go test sets cwd to the package directory (e2e/), so the repo root is ../
 	root, err := filepath.Abs("..")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: %v\n", err)
 		return 1
 	}
 
-	// ── 1. Build binaries ──────────────────────────────────────────────
 	fmt.Fprintln(os.Stderr, "e2e: building server and CLI...")
 	if err := makeTarget(root, "build"); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: make build failed: %v\n", err)
@@ -72,7 +71,6 @@ func run(m *testing.M) int {
 		}
 	}
 
-	// ── 2. Start model-runner (same pattern as cmd/dmr) ────────────────
 	port, err := freePort()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: %v\n", err)
@@ -102,14 +100,12 @@ func run(m *testing.M) int {
 		_ = server.Wait()
 	}()
 
-	// ── 3. Wait for health ─────────────────────────────────────────────
 	if err := waitForServer(serverURL+"/models", serverStartTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: %v\n", err)
 		return 1
 	}
 	fmt.Fprintf(os.Stderr, "e2e: server ready at %s\n", serverURL)
 
-	// ── 4. Run tests ───────────────────────────────────────────────────
 	return m.Run()
 }
 
@@ -146,13 +142,202 @@ func waitForServer(url string, timeout time.Duration) error {
 	return fmt.Errorf("server not ready after %s", timeout)
 }
 
-// runCLI executes the model-cli binary with the given arguments and
-// MODEL_RUNNER_HOST pointing to the test server. The subprocess is
-// cancelled if the test's context expires.
 func runCLI(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), cliBin, args...)
 	cmd.Env = append(os.Environ(), "MODEL_RUNNER_HOST="+serverURL)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func pullModel(t *testing.T, model string) string {
+	t.Helper()
+	status, body := doJSON(t, http.MethodPost, serverURL+"/models/create",
+		map[string]string{"from": model})
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("pull %s failed: status=%d body=%s", model, status, body)
+	}
+	return string(body)
+}
+
+// removeModel removes a model via API. Does not fail if the model doesn't exist.
+func removeModel(t *testing.T, model string) {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodDelete,
+		fmt.Sprintf("%s/models/%s", serverURL, model), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+// doJSON sends a JSON request and returns the response body.
+func doJSON(t *testing.T, method, url string, body any) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), method, url, reader)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request %s %s failed: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response body for %s %s: %v", method, url, err)
+	}
+	return resp.StatusCode, respBody
+}
+
+// readSSE reads an SSE stream and returns accumulated content and chunk count.
+func readSSE(t *testing.T, resp *http.Response) (content string, chunks int, gotDone bool) {
+	t.Helper()
+	var accumulated strings.Builder
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			t.Fatalf("unexpected SSE line: %q", line)
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			gotDone = true
+			break
+		}
+		var chunk desktop.OpenAIChatResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			t.Fatalf("parsing SSE chunk: %v (data=%q)", err, data)
+		}
+		chunks++
+		if len(chunk.Choices) > 0 {
+			accumulated.WriteString(chunk.Choices[0].Delta.Content)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	return accumulated.String(), chunks, gotDone
+}
+
+// chatCompletion sends a non-streaming chat request and returns the response.
+func chatCompletion(t *testing.T, model, prompt string) desktop.OpenAIChatResponse {
+	t.Helper()
+	status, body := doJSON(t, http.MethodPost, serverURL+"/engines/v1/chat/completions",
+		desktop.OpenAIChatRequest{
+			Model:    model,
+			Messages: []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
+			Stream:   false,
+		})
+	if status != http.StatusOK {
+		t.Fatalf("chat completion failed: status=%d body=%s", status, body)
+	}
+	var resp desktop.OpenAIChatResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decoding response: %v (body=%s)", err, body)
+	}
+	return resp
+}
+
+// streamingChatCompletion sends a streaming chat request and validates the SSE response.
+func streamingChatCompletion(t *testing.T, model, prompt string) string {
+	t.Helper()
+	data, err := json.Marshal(desktop.OpenAIChatRequest{
+		Model:    model,
+		Messages: []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
+		Stream:   true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		serverURL+"/engines/v1/chat/completions", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			t.Fatalf("streaming failed: status=%d (could not read body: %v)", resp.StatusCode, readErr)
+		}
+		t.Fatalf("streaming failed: status=%d body=%s", resp.StatusCode, body)
+	}
+
+	content, chunks, gotDone := readSSE(t, resp)
+	if !gotDone {
+		t.Error("stream did not end with [DONE]")
+	}
+	if chunks == 0 {
+		t.Error("received no SSE chunks")
+	}
+	if content == "" {
+		t.Error("accumulated content is empty")
+	}
+	return content
+}
+
+// ollamaChat sends an Ollama-compatible /api/chat request (non-streaming).
+func ollamaChat(t *testing.T, model, prompt string) ollama.ChatResponse {
+	t.Helper()
+	stream := false
+	status, body := doJSON(t, http.MethodPost, serverURL+"/api/chat",
+		ollama.ChatRequest{
+			Model:    model,
+			Messages: []ollama.Message{{Role: "user", Content: prompt}},
+			Stream:   &stream,
+		})
+	if status != http.StatusOK {
+		t.Fatalf("ollama chat failed: status=%d body=%s", status, body)
+	}
+	var resp ollama.ChatResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decoding ollama response: %v (body=%s)", err, body)
+	}
+	return resp
+}
+
+// ollamaGenerate sends an Ollama-compatible /api/generate request (non-streaming).
+func ollamaGenerate(t *testing.T, model, prompt string) ollama.GenerateResponse {
+	t.Helper()
+	stream := false
+	status, body := doJSON(t, http.MethodPost, serverURL+"/api/generate",
+		ollama.GenerateRequest{
+			Model:  model,
+			Prompt: prompt,
+			Stream: &stream,
+		})
+	if status != http.StatusOK {
+		t.Fatalf("ollama generate failed: status=%d body=%s", status, body)
+	}
+	var resp ollama.GenerateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decoding ollama response: %v (body=%s)", err, body)
+	}
+	return resp
 }

--- a/e2e/inference_test.go
+++ b/e2e/inference_test.go
@@ -3,233 +3,169 @@
 package e2e
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
-
-	"github.com/docker/model-runner/cmd/cli/desktop"
 )
 
-// TestE2E_Inference runs all inference API tests sequentially as subtests
-// to ensure correct ordering (pull → list → chat → streaming → remove).
+type backendTestCase struct {
+	name  string
+	model string
+}
+
+var backends = []backendTestCase{
+	{"llama.cpp", ggufModel},
+	{"vllm-metal", mlxModel},
+}
+
 func TestE2E_Inference(t *testing.T) {
-	t.Run("PullModel", func(t *testing.T) {
-		t.Logf("pulling model %s via API...", testModel)
+	for _, bc := range backends {
+		bc := bc
+		t.Run(bc.name, func(t *testing.T) {
+			t.Run("Pull", func(t *testing.T) {
+				pullModel(t, bc.model)
+				t.Logf("pulled %s", bc.model)
+			})
 
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, serverURL+"/models/create", strings.NewReader(`{"from":"`+testModel+`"}`))
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("pull request failed: %v", err)
-		}
-		defer resp.Body.Close()
-
-		body, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-			t.Fatalf("pull failed: status=%d body=%s", resp.StatusCode, body)
-		}
-		t.Logf("pull completed (status %d)", resp.StatusCode)
-	})
-
-	t.Run("ListModels", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, serverURL+"/engines/v1/models", nil)
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("list models failed: %v", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("list models: status=%d body=%s", resp.StatusCode, body)
-		}
-
-		var result struct {
-			Data []struct {
-				ID string `json:"id"`
-			} `json:"data"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			t.Fatalf("decoding list response: %v", err)
-		}
-
-		found := false
-		for _, m := range result.Data {
-			t.Logf("  model: %s", m.ID)
-			if strings.Contains(m.ID, "smollm2") {
-				found = true
-			}
-		}
-		if !found {
-			t.Fatalf("expected %s in model list", testModel)
-		}
-	})
-
-	t.Run("ChatCompletionNonStreaming", func(t *testing.T) {
-		reqBody := desktop.OpenAIChatRequest{
-			Model: testModel,
-			Messages: []desktop.OpenAIChatMessage{
-				{Role: "user", Content: "Say hello in exactly one word."},
-			},
-			Stream: false,
-		}
-
-		body, err := json.Marshal(reqBody)
-		if err != nil {
-			t.Fatalf("marshal: %v", err)
-		}
-
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, serverURL+"/engines/v1/chat/completions", bytes.NewReader(body))
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request failed: %v", err)
-		}
-		defer resp.Body.Close()
-
-		respBody, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("chat completion failed: status=%d body=%s", resp.StatusCode, respBody)
-		}
-
-		var chatResp desktop.OpenAIChatResponse
-		if err := json.Unmarshal(respBody, &chatResp); err != nil {
-			t.Fatalf("decoding response: %v (body=%s)", err, respBody)
-		}
-
-		if len(chatResp.Choices) == 0 {
-			t.Fatal("no choices in response")
-		}
-
-		content := chatResp.Choices[0].Message.Content
-		t.Logf("model response: %q", content)
-
-		if content == "" {
-			t.Fatal("empty response content")
-		}
-		if chatResp.Choices[0].Message.Role != "assistant" {
-			t.Errorf("expected role=assistant, got %q", chatResp.Choices[0].Message.Role)
-		}
-	})
-
-	t.Run("ChatCompletionStreaming", func(t *testing.T) {
-		reqBody := desktop.OpenAIChatRequest{
-			Model: testModel,
-			Messages: []desktop.OpenAIChatMessage{
-				{Role: "user", Content: "Count from 1 to 3."},
-			},
-			Stream: true,
-		}
-
-		body, err := json.Marshal(reqBody)
-		if err != nil {
-			t.Fatalf("marshal: %v", err)
-		}
-
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, serverURL+"/engines/v1/chat/completions", bytes.NewReader(body))
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request failed: %v", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			respBody, _ := io.ReadAll(resp.Body)
-			t.Fatalf("streaming request failed: status=%d body=%s", resp.StatusCode, respBody)
-		}
-
-		var accumulated strings.Builder
-		var chunkCount int
-		gotDone := false
-
-		scanner := bufio.NewScanner(resp.Body)
-		for scanner.Scan() {
-			line := scanner.Text()
-
-			if line == "" {
-				continue
-			}
-
-			if !strings.HasPrefix(line, "data: ") {
-				if strings.HasPrefix(line, ":") {
-					continue
+			t.Run("ListModels", func(t *testing.T) {
+				status, body := doJSON(t, http.MethodGet, serverURL+"/engines/v1/models", nil)
+				if status != http.StatusOK {
+					t.Fatalf("list: status=%d body=%s", status, body)
 				}
-				t.Fatalf("unexpected SSE line: %q", line)
-			}
+				var result struct {
+					Data []struct {
+						ID string `json:"id"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(body, &result); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				found := false
+				for _, m := range result.Data {
+					if strings.Contains(m.ID, "smollm2") {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("model %s not in list", bc.model)
+				}
+			})
 
-			data := strings.TrimPrefix(line, "data: ")
+			t.Run("ChatCompletion", func(t *testing.T) {
+				resp := chatCompletion(t, bc.model, "Say hello in one word.")
+				if len(resp.Choices) == 0 {
+					t.Fatal("no choices")
+				}
+				t.Logf("response: %q", resp.Choices[0].Message.Content)
+				if resp.Choices[0].Message.Content == "" {
+					t.Fatal("empty content")
+				}
+				if resp.Choices[0].Message.Role != "assistant" {
+					t.Errorf("expected role=assistant, got %q", resp.Choices[0].Message.Role)
+				}
+			})
 
-			if data == "[DONE]" {
-				gotDone = true
-				break
-			}
+			t.Run("ChatCompletionStreaming", func(t *testing.T) {
+				content := streamingChatCompletion(t, bc.model, "Count from 1 to 3.")
+				t.Logf("streamed: %q", content)
+			})
 
-			var chunk desktop.OpenAIChatResponse
-			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-				t.Fatalf("parsing SSE chunk: %v (data=%q)", err, data)
-			}
+			t.Run("ResponsesAPI", func(t *testing.T) {
+				status, body := doJSON(t, http.MethodPost, serverURL+"/responses",
+					map[string]any{
+						"model": bc.model,
+						"input": "Say hi in one word.",
+					})
+				if status != http.StatusOK {
+					t.Fatalf("responses API: status=%d body=%s", status, body)
+				}
+				var resp struct {
+					ID         string `json:"id"`
+					Status     string `json:"status"`
+					OutputText string `json:"output_text"`
+				}
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("decode: %v (body=%s)", err, body)
+				}
+				if resp.Status != "completed" {
+					t.Errorf("expected status=completed, got %q", resp.Status)
+				}
+				if resp.OutputText == "" {
+					t.Fatal("empty output_text")
+				}
+				t.Logf("responses API: %q", resp.OutputText)
+			})
 
-			chunkCount++
-			if len(chunk.Choices) > 0 {
-				accumulated.WriteString(chunk.Choices[0].Delta.Content)
-			}
-		}
+			t.Run("AnthropicMessages", func(t *testing.T) {
+				status, body := doJSON(t, http.MethodPost, serverURL+"/anthropic/v1/messages",
+					map[string]any{
+						"model":      bc.model,
+						"max_tokens": 32,
+						"messages":   []map[string]string{{"role": "user", "content": "Say hi."}},
+					})
+				if status != http.StatusOK {
+					t.Fatalf("anthropic messages: status=%d body=%s", status, body)
+				}
+				var resp struct {
+					Content []struct {
+						Text string `json:"text"`
+					} `json:"content"`
+				}
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("decode: %v (body=%s)", err, body)
+				}
+				if len(resp.Content) == 0 || resp.Content[0].Text == "" {
+					t.Fatal("empty anthropic response")
+				}
+				t.Logf("anthropic: %q", resp.Content[0].Text)
+			})
 
-		if err := scanner.Err(); err != nil {
-			t.Fatalf("reading stream: %v", err)
-		}
+			t.Run("OllamaChat", func(t *testing.T) {
+				resp := ollamaChat(t, bc.model, "Say hi.")
+				if resp.Message.Content == "" {
+					t.Fatal("empty ollama chat response")
+				}
+				if !resp.Done {
+					t.Error("ollama chat response not done")
+				}
+				t.Logf("ollama chat: %q", resp.Message.Content)
+			})
 
-		t.Logf("received %d chunks, accumulated: %q", chunkCount, accumulated.String())
+			t.Run("OllamaGenerate", func(t *testing.T) {
+				resp := ollamaGenerate(t, bc.model, "Say hi.")
+				if resp.Response == "" {
+					t.Fatal("empty ollama generate response")
+				}
+				if !resp.Done {
+					t.Error("ollama generate response not done")
+				}
+				t.Logf("ollama generate: %q", resp.Response)
+			})
 
-		if !gotDone {
-			t.Error("stream did not end with [DONE]")
-		}
-		if chunkCount == 0 {
-			t.Error("received no SSE chunks")
-		}
-		if accumulated.Len() == 0 {
-			t.Error("accumulated content is empty")
-		}
-	})
+			t.Run("OllamaTags", func(t *testing.T) {
+				status, body := doJSON(t, http.MethodGet, serverURL+"/api/tags", nil)
+				if status != http.StatusOK {
+					t.Fatalf("tags: status=%d body=%s", status, body)
+				}
+				var list struct {
+					Models []struct {
+						Name string `json:"name"`
+					} `json:"models"`
+				}
+				if err := json.Unmarshal(body, &list); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if len(list.Models) == 0 {
+					t.Fatal("no models in /api/tags")
+				}
+				t.Logf("tags returned %d models", len(list.Models))
+			})
 
-	t.Run("RemoveModel", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, fmt.Sprintf("%s/models/%s", serverURL, testModel), nil)
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("delete request failed: %v", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("delete failed: status=%d body=%s", resp.StatusCode, body)
-		}
-		t.Logf("model %s removed", testModel)
-	})
+			t.Run("Remove", func(t *testing.T) {
+				removeModel(t, bc.model)
+				t.Logf("removed %s", bc.model)
+			})
+		})
+	}
 }


### PR DESCRIPTION
The inference and CLI tests are now table-driven, running the same test suite against both llama.cpp (GGUF) and vllm-metal (MLX-format model). Each backend goes through pull, list, chat completion (streaming and non-streaming), OpenAI Responses API, Anthropic Messages API, Ollama chat, generate, and tags endpoints, then cleanup.

```
$ make e2e 2>&1 | grep -E '^\s*(--- (PASS|FAIL|SKIP)|ok\s|FAIL\s)'
--- PASS: TestE2E_APIErrors (0.00s)
    --- PASS: TestE2E_APIErrors/InvalidModel (0.00s)
    --- PASS: TestE2E_APIErrors/MalformedJSON (0.00s)
    --- PASS: TestE2E_APIErrors/EmptyMessages (0.00s)
--- PASS: TestE2E_ModelLifecycle (5.94s)
    --- PASS: TestE2E_ModelLifecycle/PullIdempotent (5.93s)
    --- PASS: TestE2E_ModelLifecycle/InspectModel (0.00s)
    --- PASS: TestE2E_ModelLifecycle/OllamaShow (0.00s)
    --- PASS: TestE2E_ModelLifecycle/Remove (0.01s)
--- PASS: TestE2E_CLI (12.71s)
    --- PASS: TestE2E_CLI/llama.cpp (4.90s)
        --- PASS: TestE2E_CLI/llama.cpp/Pull (4.72s)
        --- PASS: TestE2E_CLI/llama.cpp/List (0.06s)
        --- PASS: TestE2E_CLI/llama.cpp/Run (0.09s)
        --- PASS: TestE2E_CLI/llama.cpp/Remove (0.03s)
    --- PASS: TestE2E_CLI/vllm-metal (7.81s)
        --- PASS: TestE2E_CLI/vllm-metal/Pull (7.65s)
        --- PASS: TestE2E_CLI/vllm-metal/List (0.03s)
        --- PASS: TestE2E_CLI/vllm-metal/Run (0.09s)
        --- PASS: TestE2E_CLI/vllm-metal/Remove (0.04s)
--- PASS: TestE2E_ConcurrentRequests (4.44s)
    --- PASS: TestE2E_ConcurrentRequests/request-0 (0.71s)
    --- PASS: TestE2E_ConcurrentRequests/request-4 (0.77s)
    --- PASS: TestE2E_ConcurrentRequests/request-1 (0.81s)
    --- PASS: TestE2E_ConcurrentRequests/request-2 (0.83s)
    --- PASS: TestE2E_ConcurrentRequests/request-3 (0.90s)
--- PASS: TestE2E_Inference (10.99s)
    --- PASS: TestE2E_Inference/llama.cpp (1.93s)
        --- PASS: TestE2E_Inference/llama.cpp/Pull (1.49s)
        --- PASS: TestE2E_Inference/llama.cpp/ListModels (0.02s)
        --- PASS: TestE2E_Inference/llama.cpp/ChatCompletion (0.06s)
        --- PASS: TestE2E_Inference/llama.cpp/ChatCompletionStreaming (0.06s)
        --- PASS: TestE2E_Inference/llama.cpp/ResponsesAPI (0.04s)
        --- PASS: TestE2E_Inference/llama.cpp/AnthropicMessages (0.05s)
        --- PASS: TestE2E_Inference/llama.cpp/OllamaChat (0.05s)
        --- PASS: TestE2E_Inference/llama.cpp/OllamaGenerate (0.13s)
        --- PASS: TestE2E_Inference/llama.cpp/OllamaTags (0.01s)
        --- PASS: TestE2E_Inference/llama.cpp/Remove (0.01s)
    --- PASS: TestE2E_Inference/vllm-metal (9.06s)
        --- PASS: TestE2E_Inference/vllm-metal/Pull (7.47s)
        --- PASS: TestE2E_Inference/vllm-metal/ListModels (0.01s)
        --- PASS: TestE2E_Inference/vllm-metal/ChatCompletion (0.20s)
        --- PASS: TestE2E_Inference/vllm-metal/ChatCompletionStreaming (0.07s)
        --- PASS: TestE2E_Inference/vllm-metal/ResponsesAPI (0.64s)
        --- PASS: TestE2E_Inference/vllm-metal/AnthropicMessages (0.16s)
        --- PASS: TestE2E_Inference/vllm-metal/OllamaChat (0.39s)
        --- PASS: TestE2E_Inference/vllm-metal/OllamaGenerate (0.10s)
        --- PASS: TestE2E_Inference/vllm-metal/OllamaTags (0.01s)
        --- PASS: TestE2E_Inference/vllm-metal/Remove (0.02s)
ok  	github.com/docker/model-runner/e2e	37.230s
```