### PR TITLE
fix(e2e): send SIGINT on teardown to prevent orphan processes

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -83,6 +83,11 @@ func run(m *testing.M) int {
 	defer cancel()
 
 	server := exec.CommandContext(ctx, serverBin)
+	// TODO: os.Interrupt is not supported on Windows. When Windows e2e
+	// tests are added, use a platform-specific shutdown mechanism.
+	server.Cancel = func() error {
+		return server.Process.Signal(os.Interrupt)
+	}
 	server.Dir = root
 	server.Env = append(os.Environ(),
 		"MODEL_RUNNER_PORT="+strconv.Itoa(port),


### PR DESCRIPTION
The e2e test teardown was using exec.CommandContext which sends SIGKILL when the context is cancelled. This kills the model-runner server instantly without giving it a chance to shut down its child processes (llama.cpp, vllm-metal), leaving orphan processes running on their ports. Setting Cmd.Cancel to send os.Interrupt instead triggers the same graceful shutdown path as Ctrl+C, which properly cleans up all backend processes.

Note that os.Interrupt is not supported on Windows , so a platform-specific mechanism will be needed when Windows e2e tests are added.