### PR TITLE
ci(release): skip docs PR when CLI reference is unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -569,6 +569,9 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
         run: |
           VENDOR_MODULE=github.com/docker/model-runner@${RELEASE_TAG} make vendor
+          # Remove the second require block added by `go get` — the docs repo
+          # only needs the direct dependency in the first require block.
+          awk '/^require \(/{n++} n==2{if(/^\)/) n=3; next} n!=2' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
 
       - name: Create pull request
         if: steps.check-docs.outputs.changed == 'true'


### PR DESCRIPTION
The update-docs job now checks whether any files under cmd/cli/docs/reference/ changed between the previous and current release tags before opening a PR in docker/docs. If no CLI reference docs changed, all subsequent steps are skipped.

When the PR is created, the second require block that go get adds to go.mod (containing all transitive dependencies of model-runner) is stripped after vendoring, so the PR only contains the model-runner version bump in the existing require block.

Test run for unchanged files: https://github.com/docker/model-runner/actions/runs/23498364715/job/68385961940.