### PR TITLE
ci(e2e): increase workflow timeout to 30 minutes

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   e2e-test:
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Safer after https://github.com/docker/model-runner/pull/784, considering runs like https://github.com/docker/model-runner/actions/runs/23498356595/attempts/1.