### PR TITLE
fix: extend digest verification to sha512 and set sandbox paths

### DIFF
--- a/pkg/distribution/internal/store/blobs.go
+++ b/pkg/distribution/internal/store/blobs.go
@@ -3,9 +3,11 @@ package store
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -276,14 +278,20 @@ func (s *LocalStore) WriteBlobWithResume(diffID oci.Hash, r io.Reader, digestStr
 	// We hash the whole file rather than the streamed bytes so that resumed
 	// downloads (which append to an existing partial file) are verified
 	// correctly over their entire contents.
-	if diffID.Algorithm == "sha256" {
+	var hasher hash.Hash
+	switch diffID.Algorithm {
+	case "sha256":
+		hasher = sha256.New()
+	case "sha512":
+		hasher = sha512.New()
+	}
+	if hasher != nil {
 		completedFile, openErr := os.Open(incompletePath)
 		if openErr != nil {
 			_ = os.Remove(incompletePath)
 			return fmt.Errorf("open completed blob file for verification: %w", openErr)
 		}
 
-		hasher := sha256.New()
 		if _, copyErr := io.Copy(hasher, completedFile); copyErr != nil {
 			completedFile.Close()
 			_ = os.Remove(incompletePath)
@@ -294,8 +302,8 @@ func (s *LocalStore) WriteBlobWithResume(diffID oci.Hash, r io.Reader, digestStr
 		computed := hex.EncodeToString(hasher.Sum(nil))
 		if computed != diffID.Hex {
 			_ = os.Remove(incompletePath)
-			return fmt.Errorf("blob digest mismatch for %q: expected sha256:%s, got sha256:%s",
-				diffID.String(), diffID.Hex, computed)
+			return fmt.Errorf("blob digest mismatch for %q: expected %s:%s, got %s:%s",
+				diffID.String(), diffID.Algorithm, diffID.Hex, diffID.Algorithm, computed)
 		}
 	}
 

--- a/pkg/inference/backends/diffusers/diffusers.go
+++ b/pkg/inference/backends/diffusers/diffusers.go
@@ -255,7 +255,7 @@ func (d *diffusers) Run(ctx context.Context, socket, model string, modelRef stri
 		BackendName:      "Diffusers",
 		Socket:           socket,
 		BinaryPath:       d.pythonPath,
-		SandboxPath:      "",
+		SandboxPath:      filepath.Dir(d.pythonPath),
 		SandboxConfig:    sandbox.ConfigurationPython,
 		Args:             args,
 		Logger:           d.log,

--- a/pkg/inference/backends/mlx/mlx.go
+++ b/pkg/inference/backends/mlx/mlx.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/model-runner/pkg/inference"
@@ -140,7 +141,7 @@ func (m *mlx) Run(ctx context.Context, socket, model string, modelRef string, mo
 		BackendName:     "MLX",
 		Socket:          socket,
 		BinaryPath:      m.pythonPath,
-		SandboxPath:     "",
+		SandboxPath:     filepath.Dir(m.pythonPath),
 		SandboxConfig:   sandbox.ConfigurationPython,
 		Args:            args,
 		Logger:          m.log,

--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -217,7 +217,7 @@ func (v *vllmMetal) Run(ctx context.Context, socket, model string, modelRef stri
 		BackendName:     "vllm-metal",
 		Socket:          socket,
 		BinaryPath:      v.pythonPath,
-		SandboxPath:     v.installDir,
+		SandboxPath:     filepath.Join(v.installDir, "bin"),
 		SandboxConfig:   sandbox.ConfigurationPython,
 		Args:            args,
 		Logger:          v.log,


### PR DESCRIPTION
Extend blob digest verification to cover sha512 in addition to sha256, closing a bypass where sha512-addressed blobs were stored without any integrity check. Set correct SandboxPath for Python backends (diffusers, mlx, vllm-metal) so the Darwin sandbox profile resolves UPDATEDLIBPATH to the sibling lib/ directory of the Python bin/ directory.