### PR TITLE
Extract context size

### DIFF
--- a/pkg/distribution/format/gguf.go
+++ b/pkg/distribution/format/gguf.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 
@@ -54,14 +55,21 @@ func (g *GGUFFormat) ExtractConfig(paths []string) (types.Config, error) {
 		return types.Config{Format: types.FormatGGUF}, nil
 	}
 
-	return types.Config{
+	cfg := types.Config{
 		Format:       types.FormatGGUF,
 		Parameters:   normalizeUnitString(gguf.Metadata().Parameters.String()),
 		Architecture: strings.TrimSpace(gguf.Metadata().Architecture),
 		Quantization: strings.TrimSpace(gguf.Metadata().FileType.String()),
 		Size:         normalizeUnitString(gguf.Metadata().Size.String()),
 		GGUF:         extractGGUFMetadata(&gguf.Header),
-	}, nil
+	}
+
+	if ctx := gguf.Architecture().MaximumContextLength; ctx > 0 && ctx <= math.MaxInt32 {
+		ctxSize := int32(ctx)
+		cfg.ContextSize = &ctxSize
+	}
+
+	return cfg, nil
 }
 
 var (

--- a/pkg/distribution/format/safetensors.go
+++ b/pkg/distribution/format/safetensors.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -115,14 +116,62 @@ func (s *SafetensorsFormat) ExtractConfig(paths []string) (types.Config, error) 
 		architecture = fmt.Sprintf("%v", arch)
 	}
 
-	return types.Config{
+	cfg := types.Config{
 		Format:       types.FormatSafetensors,
 		Parameters:   formatParameters(params),
 		Quantization: header.getQuantization(),
 		Size:         formatSize(totalSize),
 		Architecture: architecture,
 		Safetensors:  header.extractMetadata(),
-	}, nil
+	}
+
+	if ctx := readContextSizeFromConfigJSON(filepath.Dir(paths[0])); ctx != nil {
+		cfg.ContextSize = ctx
+	}
+
+	return cfg, nil
+}
+
+// contextSizeConfigKeys lists the HuggingFace config.json keys that may hold
+// the model's maximum context length, in priority order. This mirrors
+// llama.cpp's convert_hf_to_gguf.py (TextModel.set_gguf_parameters), which is
+// the canonical HuggingFace-to-GGUF converter.
+var contextSizeConfigKeys = []string{
+	"max_position_embeddings",
+	"n_ctx",
+	"n_positions",
+	"max_length",
+	"max_sequence_length",
+	"model_max_length",
+}
+
+func readContextSizeFromConfigJSON(dir string) *int32 {
+	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		return nil
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+
+	for _, key := range contextSizeConfigKeys {
+		v, ok := raw[key]
+		if !ok {
+			continue
+		}
+		var n int64
+		if err := json.Unmarshal(v, &n); err != nil {
+			continue
+		}
+		if n <= 0 || n > math.MaxInt32 {
+			continue
+		}
+		ctx := int32(n)
+		return &ctx
+	}
+	return nil
 }
 
 const (

--- a/pkg/distribution/format/safetensors.go
+++ b/pkg/distribution/format/safetensors.go
@@ -3,8 +3,10 @@ package format
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -15,6 +17,9 @@ import (
 	"github.com/docker/model-runner/pkg/distribution/oci"
 	"github.com/docker/model-runner/pkg/distribution/types"
 )
+
+// maxFormatJSONSize caps how many bytes are read from JSON metadata blobs (safetensors headers, HuggingFace config.json)
+const maxFormatJSONSize = 100 * 1024 * 1024
 
 // SafetensorsFormat implements the Format interface for Safetensors model files.
 type SafetensorsFormat struct{}
@@ -116,6 +121,11 @@ func (s *SafetensorsFormat) ExtractConfig(paths []string) (types.Config, error) 
 		architecture = fmt.Sprintf("%v", arch)
 	}
 
+	contextSize, err := readContextSizeConfig(paths)
+	if err != nil {
+		log.Printf("warning: read context size from config.json: %v", err)
+	}
+
 	cfg := types.Config{
 		Format:       types.FormatSafetensors,
 		Parameters:   formatParameters(params),
@@ -123,10 +133,7 @@ func (s *SafetensorsFormat) ExtractConfig(paths []string) (types.Config, error) 
 		Size:         formatSize(totalSize),
 		Architecture: architecture,
 		Safetensors:  header.extractMetadata(),
-	}
-
-	if ctx := readContextSizeFromConfigJSON(filepath.Dir(paths[0])); ctx != nil {
-		cfg.ContextSize = ctx
+		ContextSize:  contextSize,
 	}
 
 	return cfg, nil
@@ -145,15 +152,24 @@ var contextSizeConfigKeys = []string{
 	"model_max_length",
 }
 
-func readContextSizeFromConfigJSON(dir string) *int32 {
-	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+func readContextSizeConfig(paths []string) (*int32, error) {
+	f, err := openSiblingConfigJSON(paths)
+	if err != nil || f == nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxFormatJSONSize+1))
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("read config.json: %w", err)
+	}
+	if len(data) > maxFormatJSONSize {
+		return nil, fmt.Errorf("config.json exceeds %d-byte limit", maxFormatJSONSize)
 	}
 
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil
+		return nil, fmt.Errorf("parse config.json: %w", err)
 	}
 
 	for _, key := range contextSizeConfigKeys {
@@ -169,9 +185,30 @@ func readContextSizeFromConfigJSON(dir string) *int32 {
 			continue
 		}
 		ctx := int32(n)
-		return &ctx
+		return &ctx, nil
 	}
-	return nil
+	return nil, nil
+}
+
+// openSiblingConfigJSON walks unique directories from paths and opens the
+// first config.json it finds. Returns (nil, nil) when none exists.
+func openSiblingConfigJSON(paths []string) (*os.File, error) {
+	seen := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		dir := filepath.Dir(p)
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		f, err := os.Open(filepath.Join(dir, "config.json"))
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("open config.json: %w", err)
+		}
+	}
+	return nil, nil
 }
 
 const (
@@ -206,8 +243,7 @@ func parseSafetensorsHeader(path string) (*safetensorsHeader, error) {
 		return nil, fmt.Errorf("read header length: %w", err)
 	}
 
-	// Sanity check: header shouldn't be larger than 100MB
-	if headerLen > 100*1024*1024 {
+	if headerLen > maxFormatJSONSize {
 		return nil, fmt.Errorf("header length too large: %d bytes", headerLen)
 	}
 

--- a/pkg/distribution/format/safetensors_test.go
+++ b/pkg/distribution/format/safetensors_test.go
@@ -34,3 +34,110 @@ func TestParseSafetensorsHeader_TruncatedFile(t *testing.T) {
 		t.Fatal("expected error for truncated safetensors header, got nil")
 	}
 }
+
+func TestReadContextSizeFromConfigJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		expected *int32
+	}{
+		{
+			name:     "max_position_embeddings",
+			contents: `{"max_position_embeddings": 4096}`,
+			expected: int32Ptr(4096),
+		},
+		{
+			name:     "n_ctx fallback",
+			contents: `{"n_ctx": 8192}`,
+			expected: int32Ptr(8192),
+		},
+		{
+			name:     "n_positions fallback",
+			contents: `{"n_positions": 2048}`,
+			expected: int32Ptr(2048),
+		},
+		{
+			name:     "max_length fallback",
+			contents: `{"max_length": 1024}`,
+			expected: int32Ptr(1024),
+		},
+		{
+			name:     "max_sequence_length fallback",
+			contents: `{"max_sequence_length": 512}`,
+			expected: int32Ptr(512),
+		},
+		{
+			name:     "model_max_length fallback",
+			contents: `{"model_max_length": 256}`,
+			expected: int32Ptr(256),
+		},
+		{
+			name:     "max_position_embeddings preferred over fallbacks",
+			contents: `{"max_position_embeddings": 4096, "n_positions": 2048, "n_ctx": 1024}`,
+			expected: int32Ptr(4096),
+		},
+		{
+			name:     "n_ctx preferred over n_positions",
+			contents: `{"n_ctx": 8192, "n_positions": 2048}`,
+			expected: int32Ptr(8192),
+		},
+		{
+			name:     "no recognized key",
+			contents: `{"hidden_size": 768}`,
+			expected: nil,
+		},
+		{
+			name:     "zero value ignored",
+			contents: `{"max_position_embeddings": 0}`,
+			expected: nil,
+		},
+		{
+			name:     "negative value ignored",
+			contents: `{"max_position_embeddings": -1}`,
+			expected: nil,
+		},
+		{
+			name:     "value exceeding int32 ignored",
+			contents: `{"max_position_embeddings": 9999999999}`,
+			expected: nil,
+		},
+		{
+			name:     "non-numeric value falls through",
+			contents: `{"max_position_embeddings": "not-a-number", "n_positions": 512}`,
+			expected: int32Ptr(512),
+		},
+		{
+			name:     "malformed json",
+			contents: `{not json}`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("failed to write config.json: %v", err)
+			}
+
+			got := readContextSizeFromConfigJSON(tmpDir)
+			if (got == nil) != (tt.expected == nil) {
+				t.Fatalf("expected nil=%v, got nil=%v (got value: %v)", tt.expected == nil, got == nil, got)
+			}
+			if got != nil && *got != *tt.expected {
+				t.Errorf("expected %d, got %d", *tt.expected, *got)
+			}
+		})
+	}
+}
+
+func TestReadContextSizeFromConfigJSON_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	if got := readContextSizeFromConfigJSON(tmpDir); got != nil {
+		t.Errorf("expected nil for missing config.json, got %d", *got)
+	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/pkg/distribution/format/safetensors_test.go
+++ b/pkg/distribution/format/safetensors_test.go
@@ -35,11 +35,12 @@ func TestParseSafetensorsHeader_TruncatedFile(t *testing.T) {
 	}
 }
 
-func TestReadContextSizeFromConfigJSON(t *testing.T) {
+func TestReadContextSizeConfig(t *testing.T) {
 	tests := []struct {
-		name     string
-		contents string
-		expected *int32
+		name      string
+		contents  string
+		expected  *int32
+		expectErr bool
 	}{
 		{
 			name:     "max_position_embeddings",
@@ -107,9 +108,10 @@ func TestReadContextSizeFromConfigJSON(t *testing.T) {
 			expected: int32Ptr(512),
 		},
 		{
-			name:     "malformed json",
-			contents: `{not json}`,
-			expected: nil,
+			name:      "malformed json surfaces error",
+			contents:  `{not json}`,
+			expected:  nil,
+			expectErr: true,
 		},
 	}
 
@@ -120,7 +122,17 @@ func TestReadContextSizeFromConfigJSON(t *testing.T) {
 				t.Fatalf("failed to write config.json: %v", err)
 			}
 
-			got := readContextSizeFromConfigJSON(tmpDir)
+			paths := []string{filepath.Join(tmpDir, "model.safetensors")}
+			got, err := readContextSizeConfig(paths)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if (got == nil) != (tt.expected == nil) {
 				t.Fatalf("expected nil=%v, got nil=%v (got value: %v)", tt.expected == nil, got == nil, got)
 			}
@@ -131,10 +143,35 @@ func TestReadContextSizeFromConfigJSON(t *testing.T) {
 	}
 }
 
-func TestReadContextSizeFromConfigJSON_MissingFile(t *testing.T) {
+func TestReadContextSizeConfig_MissingFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	if got := readContextSizeFromConfigJSON(tmpDir); got != nil {
+	paths := []string{filepath.Join(tmpDir, "model.safetensors")}
+	got, err := readContextSizeConfig(paths)
+	if err != nil {
+		t.Fatalf("expected no error for missing config.json, got %v", err)
+	}
+	if got != nil {
 		t.Errorf("expected nil for missing config.json, got %d", *got)
+	}
+}
+
+func TestReadContextSizeConfig_SearchesAllDirs(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirB, "config.json"), []byte(`{"n_ctx": 4096}`), 0o644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	paths := []string{
+		filepath.Join(dirA, "shard-00001.safetensors"),
+		filepath.Join(dirB, "shard-00002.safetensors"),
+	}
+	got, err := readContextSizeConfig(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || *got != 4096 {
+		t.Errorf("expected 4096, got %v", got)
 	}
 }
 

--- a/pkg/distribution/format/safetensors_test.go
+++ b/pkg/distribution/format/safetensors_test.go
@@ -39,78 +39,73 @@ func TestReadContextSizeConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		contents  string
-		expected  *int32
+		expected  int32
 		expectErr bool
 	}{
 		{
 			name:     "max_position_embeddings",
 			contents: `{"max_position_embeddings": 4096}`,
-			expected: int32Ptr(4096),
+			expected: 4096,
 		},
 		{
 			name:     "n_ctx fallback",
 			contents: `{"n_ctx": 8192}`,
-			expected: int32Ptr(8192),
+			expected: 8192,
 		},
 		{
 			name:     "n_positions fallback",
 			contents: `{"n_positions": 2048}`,
-			expected: int32Ptr(2048),
+			expected: 2048,
 		},
 		{
 			name:     "max_length fallback",
 			contents: `{"max_length": 1024}`,
-			expected: int32Ptr(1024),
+			expected: 1024,
 		},
 		{
 			name:     "max_sequence_length fallback",
 			contents: `{"max_sequence_length": 512}`,
-			expected: int32Ptr(512),
+			expected: 512,
 		},
 		{
 			name:     "model_max_length fallback",
 			contents: `{"model_max_length": 256}`,
-			expected: int32Ptr(256),
+			expected: 256,
 		},
 		{
 			name:     "max_position_embeddings preferred over fallbacks",
 			contents: `{"max_position_embeddings": 4096, "n_positions": 2048, "n_ctx": 1024}`,
-			expected: int32Ptr(4096),
+			expected: 4096,
 		},
 		{
 			name:     "n_ctx preferred over n_positions",
 			contents: `{"n_ctx": 8192, "n_positions": 2048}`,
-			expected: int32Ptr(8192),
+			expected: 8192,
 		},
 		{
 			name:     "no recognized key",
 			contents: `{"hidden_size": 768}`,
-			expected: nil,
 		},
 		{
 			name:     "zero value ignored",
 			contents: `{"max_position_embeddings": 0}`,
-			expected: nil,
 		},
 		{
 			name:     "negative value ignored",
 			contents: `{"max_position_embeddings": -1}`,
-			expected: nil,
 		},
 		{
 			name:     "value exceeding int32 ignored",
 			contents: `{"max_position_embeddings": 9999999999}`,
-			expected: nil,
 		},
 		{
 			name:     "non-numeric value falls through",
 			contents: `{"max_position_embeddings": "not-a-number", "n_positions": 512}`,
-			expected: int32Ptr(512),
+			expected: 512,
 		},
 		{
 			name:      "malformed json surfaces error",
 			contents:  `{not json}`,
-			expected:  nil,
 			expectErr: true,
 		},
 	}
@@ -133,11 +128,17 @@ func TestReadContextSizeConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if (got == nil) != (tt.expected == nil) {
-				t.Fatalf("expected nil=%v, got nil=%v (got value: %v)", tt.expected == nil, got == nil, got)
+			if tt.expected == 0 {
+				if got != nil {
+					t.Errorf("expected nil, got %d", *got)
+				}
+				return
 			}
-			if got != nil && *got != *tt.expected {
-				t.Errorf("expected %d, got %d", *tt.expected, *got)
+			if got == nil {
+				t.Fatalf("expected %d, got nil", tt.expected)
+			}
+			if *got != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, *got)
 			}
 		})
 	}
@@ -175,6 +176,40 @@ func TestReadContextSizeConfig_SearchesAllDirs(t *testing.T) {
 	}
 }
 
-func int32Ptr(v int32) *int32 {
-	return &v
+func TestReadContextSizeConfig_SizeLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	f, err := os.Create(configPath)
+	if err != nil {
+		t.Fatalf("create config.json: %v", err)
+	}
+	if _, err := f.WriteString(`{"max_position_embeddings": 4096, "padding": "`); err != nil {
+		f.Close()
+		t.Fatalf("write prefix: %v", err)
+	}
+	chunk := make([]byte, 1024*1024)
+	for i := range chunk {
+		chunk[i] = 'x'
+	}
+	for written := 0; written <= maxFormatJSONSize; written += len(chunk) {
+		if _, err := f.Write(chunk); err != nil {
+			f.Close()
+			t.Fatalf("pad: %v", err)
+		}
+	}
+	if _, err := f.WriteString(`"}`); err != nil {
+		f.Close()
+		t.Fatalf("write suffix: %v", err)
+	}
+	f.Close()
+
+	paths := []string{filepath.Join(tmpDir, "model.safetensors")}
+	got, err := readContextSizeConfig(paths)
+	if err == nil {
+		t.Fatalf("expected size-limit error, got nil (value: %v)", got)
+	}
+	if got != nil {
+		t.Errorf("expected nil value on size error, got %d", *got)
+	}
 }


### PR DESCRIPTION
##summary
- Populates `Config.ContextSize` during ExtractConfig for GGUF and safetensors models, so context size is baked into the OCI artifact at package time.

Fixes #398