### PR TITLE
Fix Linux CPU build: add `spirv-headers` dependency

### DIFF
--- a/llamacpp/native/install-vulkan.sh
+++ b/llamacpp/native/install-vulkan.sh
@@ -3,7 +3,7 @@
 main() {
   set -eux -o pipefail
 
-  apt-get install -y glslc libvulkan-dev
+  apt-get install -y glslc libvulkan-dev spirv-headers
 }
 
 main "$@"


### PR DESCRIPTION
The `build_native_linux_cpu` job is failing with:

```
fatal error: spirv/unified1/spirv.hpp: No such file or directory
```

This is caused by llama.cpp [PR #21572](https://github.com/ggml-org/llama.cpp/pull/21572) which added a dependency on `spirv-headers` for the Vulkan backend. The llama.cpp CI was already updated in [PR #22109](https://github.com/ggml-org/llama.cpp/pull/22109) to install this package.

This PR adds `spirv-headers` to `install-vulkan.sh` to fix the build.

Fixes: https://github.com/docker/inference-engine-llama.cpp/actions/runs/24664691885/job/72119213249

---