### PR TITLE
fix: install llama-common DLL on Windows shared builds

### DIFF
--- a/llamacpp/native/CMakeLists.txt
+++ b/llamacpp/native/CMakeLists.txt
@@ -26,6 +26,15 @@ if (DDLLAMA_BUILD_SERVER)
     endif()
     add_subdirectory(vendor/llama.cpp)
 
+    # Ensure shared library DLLs are installed on Windows.
+    # Upstream install rules use LIBRARY which doesn't install RUNTIME (DLL) artifacts on DLL platforms.
+    if (BUILD_SHARED_LIBS)
+        install(TARGETS llama RUNTIME DESTINATION bin)
+        if (TARGET llama-common)
+            install(TARGETS llama-common RUNTIME DESTINATION bin)
+        endif()
+    endif()
+
     # Create custom target to copy llama-server to com.docker.llama-server
     if (WIN32)
         set(LLAMA_SERVER_DST "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/com.docker.llama-server.exe")


### PR DESCRIPTION
The llama.cpp b8851 bump changed the 'common' library from always-STATIC to following BUILD_SHARED_LIBS (renamed to 'llama-common'). When building with -DBUILD_SHARED_LIBS=ON (used by the Windows CPU/CUDA builds), this now produces a llama-common.dll that com.docker.llama-server.exe depends on at runtime.

The upstream install rule uses LIBRARY which on DLL platforms does not install the RUNTIME (.dll) artifact, causing STATUS_DLL_NOT_FOUND (0xc0000135) at startup.

Add explicit RUNTIME install rules for llama and llama-common shared library targets to ensure DLLs are installed to the bin/ directory.

upstream fix: https://github.com/ggml-org/llama.cpp/pull/22225