### PR TITLE
fix: pass chat template to vllm-metal backend

### DIFF
--- a/pkg/inference/backends/vllm/vllm_config.go
+++ b/pkg/inference/backends/vllm/vllm_config.go
@@ -40,6 +40,13 @@ func (c *Config) GetArgs(bundle types.ModelBundle, socket string, mode inference
 	// Add socket arguments
 	args = append(args, "--uds", socket)
 
+	// Add chat template if available in the model bundle.
+	// Since transformers v4.44, vLLM no longer provides a default chat
+	// template so we must supply one when the tokenizer omits it.
+	if path := bundle.ChatTemplatePath(); path != "" {
+		args = append(args, "--chat-template", path)
+	}
+
 	// Add mode-specific arguments
 	switch mode {
 	case inference.BackendModeCompletion:

--- a/pkg/inference/backends/vllm/vllm_config_test.go
+++ b/pkg/inference/backends/vllm/vllm_config_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 type mockModelBundle struct {
-	safetensorsPath string
-	runtimeConfig   *types.Config
+	safetensorsPath  string
+	chatTemplatePath string
+	runtimeConfig    *types.Config
 }
 
 func (m *mockModelBundle) GGUFPath() string {
@@ -21,7 +22,7 @@ func (m *mockModelBundle) SafetensorsPath() string {
 }
 
 func (m *mockModelBundle) ChatTemplatePath() string {
-	return ""
+	return m.chatTemplatePath
 }
 
 func (m *mockModelBundle) MMPROJPath() string {
@@ -65,6 +66,36 @@ func TestGetArgs(t *testing.T) {
 			name: "basic args without context size",
 			bundle: &mockModelBundle{
 				safetensorsPath: "/path/to/model",
+			},
+			config: nil,
+			expected: []string{
+				"serve",
+				"/path/to",
+				"--uds",
+				"/tmp/socket",
+			},
+		},
+		{
+			name: "with chat template",
+			bundle: &mockModelBundle{
+				safetensorsPath:  "/path/to/model",
+				chatTemplatePath: "/path/to/bundle/template.jinja",
+			},
+			config: nil,
+			expected: []string{
+				"serve",
+				"/path/to",
+				"--uds",
+				"/tmp/socket",
+				"--chat-template",
+				"/path/to/bundle/template.jinja",
+			},
+		},
+		{
+			name: "without chat template omits flag",
+			bundle: &mockModelBundle{
+				safetensorsPath:  "/path/to/model",
+				chatTemplatePath: "",
 			},
 			config: nil,
 			expected: []string{
@@ -494,6 +525,158 @@ func TestGetMaxModelLen(t *testing.T) {
 				t.Errorf("expected nil=%v, got nil=%v", tt.expectedValue == nil, result == nil)
 			} else if result != nil && *result != *tt.expectedValue {
 				t.Errorf("expected %d, got %d", *tt.expectedValue, *result)
+			}
+		})
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		bundle      *mockModelBundle
+		socket      string
+		model       string
+		modelRef    string
+		mode        inference.BackendMode
+		config      *inference.BackendConfiguration
+		expected    []string
+		expectError bool
+	}{
+		{
+			name: "basic completion mode",
+			bundle: &mockModelBundle{
+				safetensorsPath: "/models/bundle/model/safetensors",
+			},
+			socket:   "127.0.0.1:30000",
+			model:    "sha256:abc123",
+			modelRef: "ai/test-model:latest",
+			mode:     inference.BackendModeCompletion,
+			expected: []string{
+				"-m", "vllm.entrypoints.openai.api_server",
+				"--model", "/models/bundle/model",
+				"--host", "127.0.0.1",
+				"--port", "30000",
+				"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+				"--served-model-name", "sha256:abc123", "ai/test-model:latest",
+			},
+		},
+		{
+			name: "with chat template",
+			bundle: &mockModelBundle{
+				safetensorsPath:  "/models/bundle/model/safetensors",
+				chatTemplatePath: "/models/bundle/template.jinja",
+			},
+			socket:   "127.0.0.1:30000",
+			model:    "sha256:abc123",
+			modelRef: "ai/test-model:latest",
+			mode:     inference.BackendModeCompletion,
+			expected: []string{
+				"-m", "vllm.entrypoints.openai.api_server",
+				"--model", "/models/bundle/model",
+				"--host", "127.0.0.1",
+				"--port", "30000",
+				"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+				"--chat-template", "/models/bundle/template.jinja",
+				"--served-model-name", "sha256:abc123", "ai/test-model:latest",
+			},
+		},
+		{
+			name: "without chat template",
+			bundle: &mockModelBundle{
+				safetensorsPath:  "/models/bundle/model/safetensors",
+				chatTemplatePath: "",
+			},
+			socket:   "127.0.0.1:30000",
+			model:    "sha256:abc123",
+			modelRef: "ai/test-model:latest",
+			mode:     inference.BackendModeCompletion,
+			expected: []string{
+				"-m", "vllm.entrypoints.openai.api_server",
+				"--model", "/models/bundle/model",
+				"--host", "127.0.0.1",
+				"--port", "30000",
+				"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+				"--served-model-name", "sha256:abc123", "ai/test-model:latest",
+			},
+		},
+		{
+			name: "empty safetensors path should error",
+			bundle: &mockModelBundle{
+				safetensorsPath: "",
+			},
+			socket:      "127.0.0.1:30000",
+			model:       "sha256:abc123",
+			modelRef:    "ai/test-model:latest",
+			mode:        inference.BackendModeCompletion,
+			expectError: true,
+		},
+		{
+			name: "embedding mode",
+			bundle: &mockModelBundle{
+				safetensorsPath: "/models/bundle/model/safetensors",
+			},
+			socket:   "127.0.0.1:30000",
+			model:    "sha256:abc123",
+			modelRef: "ai/test-model:latest",
+			mode:     inference.BackendModeEmbedding,
+			expected: []string{
+				"-m", "vllm.entrypoints.openai.api_server",
+				"--model", "/models/bundle/model",
+				"--host", "127.0.0.1",
+				"--port", "30000",
+				"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+				"--runner", "pooling",
+				"--served-model-name", "sha256:abc123", "ai/test-model:latest",
+			},
+		},
+		{
+			name: "with context size",
+			bundle: &mockModelBundle{
+				safetensorsPath: "/models/bundle/model/safetensors",
+			},
+			socket:   "127.0.0.1:30000",
+			model:    "sha256:abc123",
+			modelRef: "ai/test-model:latest",
+			mode:     inference.BackendModeCompletion,
+			config: &inference.BackendConfiguration{
+				ContextSize: int32ptr(4096),
+			},
+			expected: []string{
+				"-m", "vllm.entrypoints.openai.api_server",
+				"--model", "/models/bundle/model",
+				"--host", "127.0.0.1",
+				"--port", "30000",
+				"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+				"--served-model-name", "sha256:abc123", "ai/test-model:latest",
+				"--max-model-len", "4096",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &vllmMetal{}
+			args, err := v.buildArgs(tt.bundle, tt.socket, tt.model, tt.modelRef, tt.mode, tt.config)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(args) != len(tt.expected) {
+				t.Fatalf("expected %d args, got %d\nexpected: %v\ngot: %v", len(tt.expected), len(args), tt.expected, args)
+			}
+
+			for i, arg := range args {
+				if arg != tt.expected[i] {
+					t.Errorf("arg[%d]: expected %q, got %q", i, tt.expected[i], arg)
+				}
 			}
 		})
 	}

--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/model-runner/pkg/distribution/types"
 	"github.com/docker/model-runner/pkg/inference"
 	"github.com/docker/model-runner/pkg/inference/backends"
 	"github.com/docker/model-runner/pkg/inference/models"
@@ -252,7 +253,7 @@ func (v *vllmMetal) Run(ctx context.Context, socket, model string, modelRef stri
 // buildArgs builds the command line arguments for vllm-metal server.
 // vllm-metal is a vLLM platform plugin, so we launch vLLM's OpenAI-compatible
 // API server directly; the Metal plugin is auto-discovered via entry points.
-func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, socket, model, modelRef string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
+func (v *vllmMetal) buildArgs(bundle types.ModelBundle, socket, model, modelRef string, mode inference.BackendMode, config *inference.BackendConfiguration) ([]string, error) {
 	// Parse host:port from socket (vllm-metal uses TCP)
 	host, port, err := net.SplitHostPort(socket)
 	if err != nil {
@@ -272,6 +273,13 @@ func (v *vllmMetal) buildArgs(bundle interface{ SafetensorsPath() string }, sock
 		"--host", host,
 		"--port", port,
 		"--enable-auto-tool-choice", "--tool-call-parser", "hermes",
+	}
+
+	// Add chat template if available in the model bundle.
+	// Since transformers v4.44, vLLM no longer provides a default chat
+	// template so we must supply one when the tokenizer omits it.
+	if path := bundle.ChatTemplatePath(); path != "" {
+		args = append(args, "--chat-template", path)
 	}
 
 	// Add mode-specific arguments


### PR DESCRIPTION
### Problem

When using the vllm-metal backend with models whose tokenizer does not include a built-in chat template (e.g., `ai/gemma4-safetensors:4B`), chat completion requests fail with a **400 Bad Request**:

```
vllm.entrypoints.chat_utils.ChatTemplateResolutionError: As of transformers v4.44,
default chat template is no longer allowed, so you must provide a chat template if
the tokenizer does not define one.
```

The vLLM server starts and loads the model successfully, but the first `POST /v1/chat/completions` request fails because no chat template is provided.

### Root Cause

The **llama.cpp** backend already handles this correctly by reading `ChatTemplatePath()` from the model bundle and passing `--chat-template-file` to the server. However, the **vllm-metal** backend's `buildArgs()` method used a narrow interface (`interface{ SafetensorsPath() string }`) that did not expose the chat template, so it was never forwarded to the vLLM process.

### Fix

- Widened the `buildArgs()` bundle interface to include `ChatTemplatePath() string`
- Added `--chat-template <path>` to the vLLM server arguments when the model bundle provides a chat template
- Added `TestBuildArgs` tests covering chat template presence/absence and other `buildArgs` scenarios

