### PR TITLE
fix: update release workflow to prioritize GitHub Release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,15 @@ jobs:
           BUMP_TYPE: ${{ inputs.bumpType || 'patch' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --- Find the latest published GitHub Release tag ---          
-          LATEST_RELEASE_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          # --- Find the latest published GitHub Release tag ---
+          # Using gh release list instead of git tags ensures we reference the
+          # last *successfully published* release, not an orphan tag left behind
+          # by a failed release workflow run.
+          # - Filter to v* tags only (aligned with the git tag fallback)
+          # - Use jq's // operator to handle empty arrays (avoids literal "null")
+          LATEST_RELEASE_TAG=$(gh release list --limit 100 --json tagName \
+            --jq '[.[] | select(.tagName | startswith("v"))] | sort_by(.tagName) | last | .tagName // ""' \
+            2>/dev/null || echo "")
 
           if [ -n "$LATEST_RELEASE_TAG" ]; then
             LATEST_TAG="$LATEST_RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,19 @@ jobs:
         env:
           EXPLICIT_TAG: ${{ inputs.releaseTag }}
           BUMP_TYPE: ${{ inputs.bumpType || 'patch' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --- Find the latest existing v* tag ---
-          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          echo "Latest existing tag: ${LATEST_TAG:-<none>}"
+          # --- Find the latest published GitHub Release tag ---          
+          LATEST_RELEASE_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+
+          if [ -n "$LATEST_RELEASE_TAG" ]; then
+            LATEST_TAG="$LATEST_RELEASE_TAG"
+            echo "Latest published GitHub Release tag: $LATEST_TAG"
+          else
+            # Fallback to git tags when no GitHub Releases exist yet
+            LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+            echo "No GitHub Releases found, falling back to latest git tag: ${LATEST_TAG:-<none>}"
+          fi
 
           if [ -n "$EXPLICIT_TAG" ]; then
             # Validate explicit tag format


### PR DESCRIPTION
This pull request updates the release workflow to improve how the latest release tag is determined. The workflow now prioritizes the latest published GitHub Release tag, falling back to the latest git tag only if no GitHub Releases exist. 

This is to ensure release notes are built from latest published release.