### PR TITLE
fix: increase timeout for E2E tests to improve stability

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,6 +19,8 @@ jobs:
           - os: macos-latest
           - os: ubuntu-latest
     runs-on: ${{ matrix.os }}
+    # Must exceed the Go test timeout (E2E_TIMEOUT in the Makefile, currently
+    # 30 min) to allow for setup steps (checkout, Go/Rust toolchain, build).
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,7 +19,7 @@ jobs:
           - os: macos-latest
           - os: ubuntu-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ e2e:
 		echo "$$INVALID_TESTS" | sed 's/.*func \([^(]*\).*/\1/'; \
 		exit 1; \
 	fi
-	go test -v -count=1 -tags=e2e -run "^TestE2E" -timeout=15m ./e2e/
+	go test -v -count=1 -tags=e2e -run "^TestE2E" -timeout=30m ./e2e/
 	@echo "E2E tests completed!"
 
 test-docker-ce-installation:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DOCKER_IMAGE_SGLANG := docker/model-runner:latest-sglang
 DOCKER_TARGET ?= final-llamacpp
 PORT := 8080
 LLAMA_ARGS ?=
+E2E_TIMEOUT ?= 30m
 DOCKER_BUILD_ARGS := \
 	--load \
 	--platform linux/$(shell docker version --format '{{.Server.Arch}}') \
@@ -95,7 +96,7 @@ e2e:
 		echo "$$INVALID_TESTS" | sed 's/.*func \([^(]*\).*/\1/'; \
 		exit 1; \
 	fi
-	go test -v -count=1 -tags=e2e -run "^TestE2E" -timeout=30m ./e2e/
+	go test -v -count=1 -tags=e2e -run "^TestE2E" -timeout=$(E2E_TIMEOUT) ./e2e/
 	@echo "E2E tests completed!"
 
 test-docker-ce-installation:

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,7 +5,7 @@
 //
 // Run with:
 //
-//	go test -v -count=1 -tags=e2e -timeout=15m ./e2e/
+//	go test -v -count=1 -tags=e2e -timeout=30m ./e2e/
 package e2e
 
 import (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,7 +5,8 @@
 //
 // Run with:
 //
-//	go test -v -count=1 -tags=e2e -timeout=30m ./e2e/
+//	make e2e                          # uses E2E_TIMEOUT from Makefile (default 30m)
+//	make e2e E2E_TIMEOUT=45m          # override for slower machines
 package e2e
 
 import (


### PR DESCRIPTION
This pull request increases the timeouts for end-to-end (E2E) tests to allow for longer test execution. The updates affect both the GitHub Actions workflow and local test commands to ensure consistency and reduce the likelihood of premature test failures due to timeout.

**E2E test timeout increases:**

* Increased the E2E test timeout in the GitHub Actions workflow from 30 minutes to 45 minutes in `.github/workflows/e2e-test.yml`.
* Updated the E2E test timeout in the `Makefile` from 15 minutes to 30 minutes for the `e2e` target.
* Updated the documentation comment in `e2e/e2e_test.go` to reflect the new 30-minute timeout for running E2E tests.