### PR TITLE
fix: cap max_tokens in E2E chat helpers to prevent test timeouts

### DIFF
--- a/cmd/cli/desktop/api.go
+++ b/cmd/cli/desktop/api.go
@@ -47,10 +47,11 @@ type ImageURL struct {
 }
 
 type OpenAIChatRequest struct {
-	Model    string              `json:"model"`
-	Messages []OpenAIChatMessage `json:"messages"`
-	Stream   bool                `json:"stream"`
-	Tools    []Tool              `json:"tools,omitempty"`
+	Model     string              `json:"model"`
+	Messages  []OpenAIChatMessage `json:"messages"`
+	Stream    bool                `json:"stream"`
+	Tools     []Tool              `json:"tools,omitempty"`
+	MaxTokens *int                `json:"max_tokens,omitempty"`
 }
 
 type OpenAIChatResponse struct {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -316,13 +316,17 @@ func readSSE(t *testing.T, resp *http.Response) (content string, chunks int, got
 }
 
 // chatCompletion sends a non-streaming chat request and returns the response.
+// A small max_tokens cap is applied to prevent runaway generation from
+// causing test timeouts.
 func chatCompletion(t *testing.T, model, prompt string) desktop.OpenAIChatResponse {
 	t.Helper()
+	maxTokens := 64
 	status, body := doJSON(t, http.MethodPost, serverURL+"/engines/v1/chat/completions",
 		desktop.OpenAIChatRequest{
-			Model:    model,
-			Messages: []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
-			Stream:   false,
+			Model:     model,
+			Messages:  []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
+			Stream:    false,
+			MaxTokens: &maxTokens,
 		})
 	if status != http.StatusOK {
 		t.Fatalf("chat completion failed: status=%d body=%s", status, body)
@@ -335,12 +339,16 @@ func chatCompletion(t *testing.T, model, prompt string) desktop.OpenAIChatRespon
 }
 
 // streamingChatCompletion sends a streaming chat request and validates the SSE response.
+// A small max_tokens cap is applied to prevent runaway generation from
+// causing test timeouts.
 func streamingChatCompletion(t *testing.T, model, prompt string) string {
 	t.Helper()
+	maxTokens := 64
 	data, err := json.Marshal(desktop.OpenAIChatRequest{
-		Model:    model,
-		Messages: []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
-		Stream:   true,
+		Model:     model,
+		Messages:  []desktop.OpenAIChatMessage{{Role: "user", Content: prompt}},
+		Stream:    true,
+		MaxTokens: &maxTokens,
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)


### PR DESCRIPTION
## Summary

- The `TestE2E_ConcurrentRequests` E2E test was timing out after 33 minutes on the main branch because `chatCompletion` calls had no token limit, causing the model to generate up to 7,489 tokens per request
- Added `MaxTokens *int` field to `OpenAIChatRequest` so the limit can be passed through the API
- Applied a 64-token cap in the `chatCompletion` and `streamingChatCompletion` E2E test helpers to keep generation bounded and tests fast

## Root Cause

The failing CI run (run #25053510049) shows:
```
slot release: id 3 | task 12 | stop processing: n_tokens = 7489
*** Test killed with quit: ran too long (33m0s).
```

The concurrent test spawned 5 parallel `chatCompletion("Say a single word.")` calls. Without a `max_tokens` limit, the model ran until it hit the context window, causing each request to take several minutes.