### PR TITLE
ci: declare contents: read on ci, e2e-test, integration-test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main ]
   push:
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three CI workflows currently inherit the repo-default `GITHUB_TOKEN` scope:

- `ci.yml` (lint + tests matrix across linux/darwin/windows)
- `e2e-test.yml` (end-to-end run)
- `integration-test.yml` (integration run)

All three only do `actions/checkout` + setup + Go build/test. No git push, no GitHub API write. `contents: read` at the workflow level is the right floor.

`cli-validate.yml` in this repo already declares workflow-level `permissions: contents: read`; this brings the remaining three in line.