### PR TITLE
chore: update vllm install to use --torch-backend auto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,7 @@ USER modelrunner
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ~/.local/bin/uv venv --python 3.12 /opt/vllm-env \
     && . /opt/vllm-env/bin/activate \
-    && ~/.local/bin/uv pip install vllm \
-         --extra-index-url https://wheels.vllm.ai/${VLLM_VERSION}/cu130 \
-         --extra-index-url https://download.pytorch.org/whl/cu130 \
-         --index-strategy unsafe-best-match
+    && ~/.local/bin/uv pip install vllm --torch-backend auto
 
 RUN /opt/vllm-env/bin/python3.12 -c "import vllm; print(vllm.__version__)" > /opt/vllm-env/version
 


### PR DESCRIPTION
## Summary

- Replaces the explicit `cu130` extra index URLs with the simpler `--torch-backend auto` flag
- `--torch-backend auto` lets uv/vllm automatically select the appropriate CUDA 13 backend
- Reduces install complexity from 4 lines to 1