### PR TITLE
Add dmr sandbox config and launch command

### DIFF
--- a/cmd/cli/commands/config.go
+++ b/cmd/cli/commands/config.go
@@ -1,0 +1,14 @@
+package commands
+
+import "github.com/spf13/cobra"
+
+func newConfigCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "config",
+		Short: "Manage persistent model runner configuration",
+	}
+
+	c.AddCommand(newSandboxConfigCmd())
+
+	return c
+}

--- a/cmd/cli/commands/configure.go
+++ b/cmd/cli/commands/configure.go
@@ -11,10 +11,9 @@ func newConfigureCmd() *cobra.Command {
 	var flags ConfigureFlags
 
 	c := &cobra.Command{
-		Use:     "configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] [--keep-alive=<duration>] MODEL [-- <runtime-flags...>]",
-		Aliases: []string{"config"},
-		Short:   "Manage model runtime configurations",
-		Hidden:  true,
+		Use:    "configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] [--keep-alive=<duration>] MODEL [-- <runtime-flags...>]",
+		Short:  "Manage model runtime configurations",
+		Hidden: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			argsBeforeDash := cmd.ArgsLenAtDash()
 			if argsBeforeDash == -1 {

--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -196,30 +196,28 @@ Examples:
 }
 
 func launchSandboxedHostApp(cmd *cobra.Command, sandboxTool, app string, appArgs []string, dryRun bool) error {
-	if strings.ContainsAny(sandboxTool, "\x00\r\n") {
-		return fmt.Errorf("sandbox.tool contains invalid characters")
-	}
-
-	sandboxToolPath, err := exec.LookPath(sandboxTool)
-	if err != nil {
-		return fmt.Errorf("sandbox tool %q not found in PATH: %w", sandboxTool, err)
+	if err := validateSandboxTool(sandboxTool); err != nil {
+		return err
 	}
 
 	args := append([]string{app}, appArgs...)
 
-	if dryRun {
-		cmd.Printf("%s %s\n", sandboxToolPath, strings.Join(args, " "))
-		return nil
+	switch sandboxTool {
+	case "sbx":
+		if dryRun {
+			cmd.Printf("sbx %s\n", strings.Join(args, " "))
+			return nil
+		}
+
+		launchCmd := exec.Command("sbx", args...)
+		launchCmd.Stdin = os.Stdin
+		launchCmd.Stdout = os.Stdout
+		launchCmd.Stderr = os.Stderr
+
+		return launchCmd.Run()
+	default:
+		return fmt.Errorf("unsupported sandbox tool %q", sandboxTool)
 	}
-
-	// #nosec G204 -- sandboxToolPath is an explicit user-configured executable
-	// selected from allowedSandboxTools. exec.Command does not invoke a shell.
-	launchCmd := exec.Command(sandboxToolPath, args...)
-	launchCmd.Stdin = os.Stdin
-	launchCmd.Stdout = os.Stdout
-	launchCmd.Stderr = os.Stderr
-
-	return launchCmd.Run()
 }
 
 // listSupportedApps prints all supported apps with their descriptions and install status.

--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -147,15 +147,12 @@ Examples:
 			// resolving runner endpoints. This keeps sandbox launch independent of
 			// whether the host app binary itself is installed.
 			if _, ok := hostApps[app]; ok {
-				sandboxTool, err := readSandboxToolConfig()
+				sandboxTool, err := configuredSandboxTool()
 				if err != nil {
 					return err
 				}
 
 				if sandboxTool != "" {
-					if err := validateSandboxTool(sandboxTool); err != nil {
-						return err
-					}
 					return launchSandboxedHostApp(cmd, sandboxTool, app, appArgs, dryRun)
 				}
 			}
@@ -178,7 +175,6 @@ Examples:
 			if ca, ok := containerApps[app]; ok {
 				return launchContainerApp(cmd, ca, ep.container, image, port, detach, appArgs, dryRun)
 			}
-
 			if cli, ok := hostApps[app]; ok {
 				return launchHostApp(cmd, app, ep.host, cli, model, runner, appArgs, dryRun)
 			}
@@ -196,28 +192,9 @@ Examples:
 }
 
 func launchSandboxedHostApp(cmd *cobra.Command, sandboxTool, app string, appArgs []string, dryRun bool) error {
-	if err := validateSandboxTool(sandboxTool); err != nil {
-		return err
-	}
-
 	args := append([]string{app}, appArgs...)
 
-	switch sandboxTool {
-	case "sbx":
-		if dryRun {
-			cmd.Printf("sbx %s\n", strings.Join(args, " "))
-			return nil
-		}
-
-		launchCmd := exec.Command("sbx", args...)
-		launchCmd.Stdin = os.Stdin
-		launchCmd.Stdout = os.Stdout
-		launchCmd.Stderr = os.Stderr
-
-		return launchCmd.Run()
-	default:
-		return fmt.Errorf("unsupported sandbox tool %q", sandboxTool)
-	}
+	return runSandboxTool(cmd, sandboxTool, args, dryRun)
 }
 
 // listSupportedApps prints all supported apps with their descriptions and install status.

--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -166,12 +166,10 @@ Examples:
 			if err != nil {
 				return err
 			}
-
 			// --config: print configuration without launching
 			if configOnly {
 				return printAppConfig(cmd, app, ep, image, port)
 			}
-
 			if ca, ok := containerApps[app]; ok {
 				return launchContainerApp(cmd, ca, ep.container, image, port, detach, appArgs, dryRun)
 			}
@@ -349,7 +347,6 @@ func launchHostApp(cmd *cobra.Command, bin string, baseURL string, cli hostApp, 
 	if bin == "opencode" {
 		return launchOpenCode(cmd, baseURL, model, runner, appArgs, dryRun)
 	}
-
 	if !dryRun {
 		if _, err := exec.LookPath(bin); err != nil {
 			cmd.PrintErrf("%q executable not found in PATH.\n", bin)
@@ -362,11 +359,9 @@ func launchHostApp(cmd *cobra.Command, bin string, baseURL string, cli hostApp, 
 			return fmt.Errorf("%s not found; please install it and re-run", bin)
 		}
 	}
-
 	if cli.envFn == nil {
 		return launchUnconfigurableHostApp(cmd, bin, baseURL, cli, appArgs, dryRun)
 	}
-
 	env := cli.envFn(baseURL)
 	if dryRun {
 		cmd.Printf("Would run: %s %s\n", bin, strings.Join(appArgs, " "))

--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -143,6 +143,23 @@ Examples:
 				appArgs = args[dashIdx:]
 			}
 
+			// If a sandbox tool is configured, launch host apps through it before
+			// resolving runner endpoints. This keeps sandbox launch independent of
+			// whether the host app binary itself is installed.
+			if _, ok := hostApps[app]; ok {
+				sandboxTool, err := readSandboxToolConfig()
+				if err != nil {
+					return err
+				}
+
+				if sandboxTool != "" {
+					if err := validateSandboxTool(sandboxTool); err != nil {
+						return err
+					}
+					return launchSandboxedHostApp(cmd, sandboxTool, app, appArgs, dryRun)
+				}
+			}
+
 			runner, err := getStandaloneRunner(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("unable to determine standalone runner endpoint: %w", err)
@@ -161,9 +178,11 @@ Examples:
 			if ca, ok := containerApps[app]; ok {
 				return launchContainerApp(cmd, ca, ep.container, image, port, detach, appArgs, dryRun)
 			}
+
 			if cli, ok := hostApps[app]; ok {
 				return launchHostApp(cmd, app, ep.host, cli, model, runner, appArgs, dryRun)
 			}
+
 			return fmt.Errorf("unsupported app %q (supported: %s)", app, strings.Join(supportedApps, ", "))
 		},
 	}
@@ -174,6 +193,33 @@ Examples:
 	c.Flags().BoolVar(&configOnly, "config", false, "Print configuration without launching")
 	c.Flags().StringVar(&model, "model", "", "Model to use (for opencode)")
 	return c
+}
+
+func launchSandboxedHostApp(cmd *cobra.Command, sandboxTool, app string, appArgs []string, dryRun bool) error {
+	if strings.ContainsAny(sandboxTool, "\x00\r\n") {
+		return fmt.Errorf("sandbox.tool contains invalid characters")
+	}
+
+	sandboxToolPath, err := exec.LookPath(sandboxTool)
+	if err != nil {
+		return fmt.Errorf("sandbox tool %q not found in PATH: %w", sandboxTool, err)
+	}
+
+	args := append([]string{app}, appArgs...)
+
+	if dryRun {
+		cmd.Printf("%s %s\n", sandboxToolPath, strings.Join(args, " "))
+		return nil
+	}
+
+	// #nosec G204 -- sandboxToolPath is an explicit user-configured executable
+	// selected from allowedSandboxTools. exec.Command does not invoke a shell.
+	launchCmd := exec.Command(sandboxToolPath, args...)
+	launchCmd.Stdin = os.Stdin
+	launchCmd.Stdout = os.Stdout
+	launchCmd.Stderr = os.Stderr
+
+	return launchCmd.Run()
 }
 
 // listSupportedApps prints all supported apps with their descriptions and install status.

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -120,7 +120,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newShowCmd(),
 		newComposeCmd(),
 		newLaunchCmd(),
-		newSandboxConfigCmd(),
+		newConfigCmd(),
 		newTagCmd(),
 		newConfigureCmd(),
 		newPSCmd(),

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -120,6 +120,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newShowCmd(),
 		newComposeCmd(),
 		newLaunchCmd(),
+		newSandboxConfigCmd(),
 		newTagCmd(),
 		newConfigureCmd(),
 		newPSCmd(),

--- a/cmd/cli/commands/sandbox.go
+++ b/cmd/cli/commands/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -16,32 +17,26 @@ var allowedSandboxTools = map[string]struct{}{
 
 func newSandboxConfigCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "config <key> <value>",
-		Short: "Set model runner configuration values",
-		Args:  cobra.ExactArgs(2),
+		Use:   "sandbox.tool <tool>",
+		Short: "Set the sandbox tool",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			key := args[0]
-			value := args[1]
-
-			if key != "sandbox.tool" {
-				return fmt.Errorf("unsupported config key %q", key)
-			}
-
-			if err := validateSandboxTool(value); err != nil {
+			tool, err := validateSandboxTool(args[0])
+			if err != nil {
 				return err
 			}
 
-			return writeSandboxToolConfig(value)
+			return writeSandboxToolConfig(tool)
 		},
 	}
 }
 
-func validateSandboxTool(tool string) error {
+func validateSandboxTool(tool string) (string, error) {
 	if _, ok := allowedSandboxTools[tool]; !ok {
-		return fmt.Errorf("unsupported sandbox tool %q", tool)
+		return "", fmt.Errorf("unsupported sandbox tool %q", tool)
 	}
 
-	return nil
+	return tool, nil
 }
 
 func dmrConfigPath() (string, error) {
@@ -123,4 +118,39 @@ func readSandboxToolConfig() (string, error) {
 	}
 
 	return "", nil
+}
+func runSandboxTool(cmd *cobra.Command, sandboxTool string, args []string, dryRun bool) error {
+	validatedSandboxTool, err := validateSandboxTool(sandboxTool)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		cmd.Printf("%s %s\n", validatedSandboxTool, strings.Join(args, " "))
+		return nil
+	}
+
+	switch validatedSandboxTool {
+	case "sbx":
+		launchCmd := exec.Command("sbx", args...)
+		launchCmd.Stdin = os.Stdin
+		launchCmd.Stdout = os.Stdout
+		launchCmd.Stderr = os.Stderr
+
+		return launchCmd.Run()
+	default:
+		return fmt.Errorf("unsupported sandbox tool %q", validatedSandboxTool)
+	}
+}
+func configuredSandboxTool() (string, error) {
+	sandboxTool, err := readSandboxToolConfig()
+	if err != nil {
+		return "", err
+	}
+
+	if sandboxTool == "" {
+		return "", nil
+	}
+
+	return validateSandboxTool(sandboxTool)
 }

--- a/cmd/cli/commands/sandbox.go
+++ b/cmd/cli/commands/sandbox.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var allowedSandboxTools = map[string]struct{}{
+	"sbx": {},
+}
+
+func newSandboxConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config <key> <value>",
+		Short: "Set model runner configuration values",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			key := args[0]
+			value := args[1]
+
+			if key != "sandbox.tool" {
+				return fmt.Errorf("unsupported config key %q", key)
+			}
+
+			if err := validateSandboxTool(value); err != nil {
+				return err
+			}
+
+			return writeSandboxToolConfig(value)
+		},
+	}
+}
+
+func validateSandboxTool(tool string) error {
+	if _, ok := allowedSandboxTools[tool]; !ok {
+		return fmt.Errorf("unsupported sandbox tool %q", tool)
+	}
+
+	return nil
+}
+
+func dmrConfigPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine config directory: %w", err)
+	}
+
+	return filepath.Join(configDir, "dmr", "config.toml"), nil
+}
+
+func writeSandboxToolConfig(tool string) error {
+	path, err := dmrConfigPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("unable to create config directory: %w", err)
+	}
+
+	content := fmt.Sprintf("[sandbox]\ntool = %q\n", tool)
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("unable to write config: %w", err)
+	}
+
+	return nil
+}
+
+func readSandboxToolConfig() (string, error) {
+	path, err := dmrConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to read config: %w", err)
+	}
+	defer file.Close()
+
+	inSandboxSection := false
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inSandboxSection = line == "[sandbox]"
+			continue
+		}
+
+		if !inSandboxSection {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+
+		if strings.TrimSpace(key) != "tool" {
+			continue
+		}
+
+		return strings.Trim(strings.TrimSpace(value), `"`), nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("unable to parse config: %w", err)
+	}
+
+	return "", nil
+}

--- a/cmd/cli/commands/sandbox_test.go
+++ b/cmd/cli/commands/sandbox_test.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteAndReadSandboxToolConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := writeSandboxToolConfig("sbx"); err != nil {
+		t.Fatalf("writeSandboxToolConfig() error = %v", err)
+	}
+
+	got, err := readSandboxToolConfig()
+	if err != nil {
+		t.Fatalf("readSandboxToolConfig() error = %v", err)
+	}
+
+	if got != "sbx" {
+		t.Fatalf("readSandboxToolConfig() = %q, want %q", got, "sbx")
+	}
+
+	configPath, err := dmrConfigPath()
+	if err != nil {
+		t.Fatalf("dmrConfigPath() error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", configPath, err)
+	}
+
+	want := "[sandbox]\ntool = \"sbx\"\n"
+	if string(content) != want {
+		t.Fatalf("config content = %q, want %q", string(content), want)
+	}
+}
+
+func TestReadSandboxToolConfigMissingFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	got, err := readSandboxToolConfig()
+	if err != nil {
+		t.Fatalf("readSandboxToolConfig() error = %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("readSandboxToolConfig() = %q, want empty string", got)
+	}
+}
+
+func TestValidateSandboxToolAllowsSbx(t *testing.T) {
+	if err := validateSandboxTool("sbx"); err != nil {
+		t.Fatalf("validateSandboxTool() error = %v", err)
+	}
+}
+
+func TestValidateSandboxToolRejectsUnsupportedTool(t *testing.T) {
+	err := validateSandboxTool("firejail")
+	if err == nil {
+		t.Fatal("validateSandboxTool() error = nil, want error")
+	}
+}
+
+func TestSandboxConfigCommandRejectsUnsupportedKey(t *testing.T) {
+	cmd := newSandboxConfigCmd()
+	cmd.SetArgs([]string{"unsupported.key", "sbx"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("config command error = nil, want error")
+	}
+}
+
+func TestSandboxConfigCommandRejectsUnsupportedTool(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := newSandboxConfigCmd()
+	cmd.SetArgs([]string{"sandbox.tool", "firejail"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("config command error = nil, want error")
+	}
+}
+
+func TestSandboxConfigCommandWritesConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := newSandboxConfigCmd()
+	cmd.SetArgs([]string{"sandbox.tool", "sbx"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("config command error = %v", err)
+	}
+
+	got, err := readSandboxToolConfig()
+	if err != nil {
+		t.Fatalf("readSandboxToolConfig() error = %v", err)
+	}
+
+	if got != "sbx" {
+		t.Fatalf("readSandboxToolConfig() = %q, want %q", got, "sbx")
+	}
+}
+
+func TestLaunchCommandRequiresConfiguredSandboxTool(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := newLaunchCmd()
+	cmd.SetArgs([]string{"opencode"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("launch command error = nil, want error")
+	}
+}
+
+func TestLaunchCommandUsesConfiguredSandboxTool(t *testing.T) {
+	configDir := t.TempDir()
+	binDir := t.TempDir()
+	outputPath := filepath.Join(t.TempDir(), "output.txt")
+
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("TEST_OUTPUT", outputPath)
+
+	sbxPath := filepath.Join(binDir, "sbx")
+	sbxScript := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$TEST_OUTPUT\"\n"
+
+	if err := os.WriteFile(sbxPath, []byte(sbxScript), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", sbxPath, err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+
+	if err := writeSandboxToolConfig("sbx"); err != nil {
+		t.Fatalf("writeSandboxToolConfig() error = %v", err)
+	}
+
+	cmd := newLaunchCmd()
+	cmd.SetArgs([]string{"opencode", "--", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("launch command error = %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+	}
+
+	want := "opencode\n--help\n"
+	if string(content) != want {
+		t.Fatalf("sandbox output = %q, want %q", string(content), want)
+	}
+}

--- a/cmd/cli/commands/sandbox_test.go
+++ b/cmd/cli/commands/sandbox_test.go
@@ -52,20 +52,25 @@ func TestReadSandboxToolConfigMissingFile(t *testing.T) {
 }
 
 func TestValidateSandboxToolAllowsSbx(t *testing.T) {
-	if err := validateSandboxTool("sbx"); err != nil {
+	tool, err := validateSandboxTool("sbx")
+	if err != nil {
 		t.Fatalf("validateSandboxTool() error = %v", err)
+	}
+
+	if tool != "sbx" {
+		t.Fatalf("validateSandboxTool() = %q, want %q", tool, "sbx")
 	}
 }
 
 func TestValidateSandboxToolRejectsUnsupportedTool(t *testing.T) {
-	err := validateSandboxTool("firejail")
+	_, err := validateSandboxTool("firejail")
 	if err == nil {
 		t.Fatal("validateSandboxTool() error = nil, want error")
 	}
 }
 
-func TestSandboxConfigCommandRejectsUnsupportedKey(t *testing.T) {
-	cmd := newSandboxConfigCmd()
+func TestConfigCommandRejectsUnsupportedKey(t *testing.T) {
+	cmd := newConfigCmd()
 	cmd.SetArgs([]string{"unsupported.key", "sbx"})
 
 	if err := cmd.Execute(); err == nil {
@@ -73,10 +78,10 @@ func TestSandboxConfigCommandRejectsUnsupportedKey(t *testing.T) {
 	}
 }
 
-func TestSandboxConfigCommandRejectsUnsupportedTool(t *testing.T) {
+func TestConfigCommandRejectsUnsupportedTool(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cmd := newSandboxConfigCmd()
+	cmd := newConfigCmd()
 	cmd.SetArgs([]string{"sandbox.tool", "firejail"})
 
 	if err := cmd.Execute(); err == nil {
@@ -84,10 +89,10 @@ func TestSandboxConfigCommandRejectsUnsupportedTool(t *testing.T) {
 	}
 }
 
-func TestSandboxConfigCommandWritesConfig(t *testing.T) {
+func TestConfigCommandWritesSandboxToolConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cmd := newSandboxConfigCmd()
+	cmd := newConfigCmd()
 	cmd.SetArgs([]string{"sandbox.tool", "sbx"})
 
 	if err := cmd.Execute(); err != nil {
@@ -104,14 +109,16 @@ func TestSandboxConfigCommandWritesConfig(t *testing.T) {
 	}
 }
 
-func TestLaunchCommandRequiresConfiguredSandboxTool(t *testing.T) {
+func TestConfiguredSandboxToolMissingConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cmd := newLaunchCmd()
-	cmd.SetArgs([]string{"opencode"})
+	got, err := configuredSandboxTool()
+	if err != nil {
+		t.Fatalf("configuredSandboxTool() error = %v", err)
+	}
 
-	if err := cmd.Execute(); err == nil {
-		t.Fatal("launch command error = nil, want error")
+	if got != "" {
+		t.Fatalf("configuredSandboxTool() = %q, want empty string", got)
 	}
 }
 

--- a/cmd/cli/docs/reference/docker_model.yaml
+++ b/cmd/cli/docs/reference/docker_model.yaml
@@ -7,6 +7,7 @@ pname: docker
 plink: docker.yaml
 cname:
     - docker model bench
+    - docker model config
     - docker model context
     - docker model df
     - docker model gateway
@@ -37,6 +38,7 @@ cname:
     - docker model version
 clink:
     - docker_model_bench.yaml
+    - docker_model_config.yaml
     - docker_model_context.yaml
     - docker_model_df.yaml
     - docker_model_gateway.yaml

--- a/cmd/cli/docs/reference/docker_model_config.yaml
+++ b/cmd/cli/docs/reference/docker_model_config.yaml
@@ -1,9 +1,12 @@
 command: docker model config
-short: Set model runner configuration values
-long: Set model runner configuration values
-usage: docker model config <key> <value>
+short: Manage persistent model runner configuration
+long: Manage persistent model runner configuration
 pname: docker model
 plink: docker_model.yaml
+cname:
+    - docker model config sandbox.tool
+clink:
+    - docker_model_config_sandbox.tool.yaml
 deprecated: false
 hidden: false
 experimental: false

--- a/cmd/cli/docs/reference/docker_model_config.yaml
+++ b/cmd/cli/docs/reference/docker_model_config.yaml
@@ -1,0 +1,13 @@
+command: docker model config
+short: Set model runner configuration values
+long: Set model runner configuration values
+usage: docker model config <key> <value>
+pname: docker model
+plink: docker_model.yaml
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/cmd/cli/docs/reference/docker_model_config_sandbox.tool.yaml
+++ b/cmd/cli/docs/reference/docker_model_config_sandbox.tool.yaml
@@ -1,0 +1,13 @@
+command: docker model config sandbox.tool
+short: Set the sandbox tool
+long: Set the sandbox tool
+usage: docker model config sandbox.tool <tool>
+pname: docker model config
+plink: docker_model_config.yaml
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/cmd/cli/docs/reference/docker_model_configure.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure.yaml
@@ -1,5 +1,4 @@
 command: docker model configure
-aliases: docker model configure, docker model config
 short: Manage model runtime configurations
 long: Manage model runtime configurations
 usage: docker model configure [--context-size=<n>] [--speculative-draft-model=<model>] [--hf_overrides=<json>] [--gpu-memory-utilization=<float>] [--mode=<mode>] [--think] [--keep-alive=<duration>] MODEL [-- <runtime-flags...>]

--- a/cmd/cli/docs/reference/model.md
+++ b/cmd/cli/docs/reference/model.md
@@ -8,7 +8,7 @@ Docker Model Runner
 | Name                                            | Description                                                            |
 |:------------------------------------------------|:-----------------------------------------------------------------------|
 | [`bench`](model_bench.md)                       | Benchmark a model's performance at different concurrency levels        |
-| [`config`](model_config.md)                     | Set model runner configuration values                                  |
+| [`config`](model_config.md)                     | Manage persistent model runner configuration                           |
 | [`context`](model_context.md)                   | Manage Docker Model Runner contexts                                    |
 | [`df`](model_df.md)                             | Show Docker Model Runner disk usage                                    |
 | [`gateway`](model_gateway.md)                   | Run an OpenAI-compatible LLM gateway                                   |

--- a/cmd/cli/docs/reference/model.md
+++ b/cmd/cli/docs/reference/model.md
@@ -8,6 +8,7 @@ Docker Model Runner
 | Name                                            | Description                                                            |
 |:------------------------------------------------|:-----------------------------------------------------------------------|
 | [`bench`](model_bench.md)                       | Benchmark a model's performance at different concurrency levels        |
+| [`config`](model_config.md)                     | Set model runner configuration values                                  |
 | [`context`](model_context.md)                   | Manage Docker Model Runner contexts                                    |
 | [`df`](model_df.md)                             | Show Docker Model Runner disk usage                                    |
 | [`gateway`](model_gateway.md)                   | Run an OpenAI-compatible LLM gateway                                   |

--- a/cmd/cli/docs/reference/model_config.md
+++ b/cmd/cli/docs/reference/model_config.md
@@ -1,0 +1,8 @@
+# docker model config
+
+<!---MARKER_GEN_START-->
+Set model runner configuration values
+
+
+<!---MARKER_GEN_END-->
+

--- a/cmd/cli/docs/reference/model_config.md
+++ b/cmd/cli/docs/reference/model_config.md
@@ -1,7 +1,14 @@
 # docker model config
 
 <!---MARKER_GEN_START-->
-Set model runner configuration values
+Manage persistent model runner configuration
+
+### Subcommands
+
+| Name                                           | Description          |
+|:-----------------------------------------------|:---------------------|
+| [`sandbox.tool`](model_config_sandbox.tool.md) | Set the sandbox tool |
+
 
 
 <!---MARKER_GEN_END-->

--- a/cmd/cli/docs/reference/model_config_sandbox.tool.md
+++ b/cmd/cli/docs/reference/model_config_sandbox.tool.md
@@ -1,0 +1,8 @@
+# docker model config sandbox.tool
+
+<!---MARKER_GEN_START-->
+Set the sandbox tool
+
+
+<!---MARKER_GEN_END-->
+

--- a/cmd/dmr/main.go
+++ b/cmd/dmr/main.go
@@ -110,7 +110,16 @@ func runLaunch(args []string) error {
 		return fmt.Errorf("sandbox.tool is not configured. Run: dmr config sandbox.tool <tool>")
 	}
 
-	cmd := exec.Command(sandboxTool, args...)
+	if strings.ContainsAny(sandboxTool, "\x00\r\n") {
+		return fmt.Errorf("sandbox.tool contains invalid characters")
+	}
+
+	sandboxToolPath, err := exec.LookPath(sandboxTool)
+	if err != nil {
+		return fmt.Errorf("sandbox tool %q not found in PATH: %w", sandboxTool, err)
+	}
+
+	cmd := exec.Command(sandboxToolPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/dmr/main.go
+++ b/cmd/dmr/main.go
@@ -2,10 +2,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/docker/cli/cli/command"
@@ -27,6 +31,15 @@ func main() {
 }
 
 func run() error {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "config":
+			return runConfig(os.Args[2:])
+		case "launch":
+			return runLaunch(os.Args[2:])
+		}
+	}
+
 	cli, err := command.NewDockerCli()
 	if err != nil {
 		return fmt.Errorf("unable to initialize CLI: %w", err)
@@ -66,4 +79,122 @@ func newServeCmd() *cobra.Command {
 			return server.Run(ctx, server.Config{Version: Version})
 		},
 	}
+}
+
+func runConfig(args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: dmr config sandbox.tool <tool>")
+	}
+
+	key := args[0]
+	value := args[1]
+
+	if key != "sandbox.tool" {
+		return fmt.Errorf("unsupported config key %q", key)
+	}
+
+	return writeSandboxToolConfig(value)
+}
+
+func runLaunch(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: dmr launch <tool> [args...]")
+	}
+
+	sandboxTool, err := readSandboxToolConfig()
+	if err != nil {
+		return err
+	}
+
+	if sandboxTool == "" {
+		return fmt.Errorf("sandbox.tool is not configured. Run: dmr config sandbox.tool <tool>")
+	}
+
+	cmd := exec.Command(sandboxTool, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func dmrConfigPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine config directory: %w", err)
+	}
+
+	return filepath.Join(configDir, "dmr", "config.toml"), nil
+}
+
+func writeSandboxToolConfig(tool string) error {
+	path, err := dmrConfigPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("unable to create config directory: %w", err)
+	}
+
+	content := fmt.Sprintf("[sandbox]\ntool = %q\n", tool)
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("unable to write config: %w", err)
+	}
+
+	return nil
+}
+
+func readSandboxToolConfig() (string, error) {
+	path, err := dmrConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to read config: %w", err)
+	}
+	defer file.Close()
+
+	inSandboxSection := false
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inSandboxSection = line == "[sandbox]"
+			continue
+		}
+
+		if !inSandboxSection {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+
+		if strings.TrimSpace(key) != "tool" {
+			continue
+		}
+
+		return strings.Trim(strings.TrimSpace(value), `"`), nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("unable to parse config: %w", err)
+	}
+
+	return "", nil
 }

--- a/cmd/dmr/main.go
+++ b/cmd/dmr/main.go
@@ -139,8 +139,11 @@ func writeSandboxToolConfig(tool string) error {
 
 	content := fmt.Sprintf("[sandbox]\ntool = %q\n", tool)
 
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("unable to write config: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("unable to secure config permissions: %w", err)
 	}
 
 	return nil

--- a/cmd/dmr/main.go
+++ b/cmd/dmr/main.go
@@ -2,14 +2,10 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
-	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/docker/cli/cli/command"
@@ -31,15 +27,6 @@ func main() {
 }
 
 func run() error {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "config":
-			return runConfig(os.Args[2:])
-		case "launch":
-			return runLaunch(os.Args[2:])
-		}
-	}
-
 	cli, err := command.NewDockerCli()
 	if err != nil {
 		return fmt.Errorf("unable to initialize CLI: %w", err)
@@ -79,134 +66,4 @@ func newServeCmd() *cobra.Command {
 			return server.Run(ctx, server.Config{Version: Version})
 		},
 	}
-}
-
-func runConfig(args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("usage: dmr config sandbox.tool <tool>")
-	}
-
-	key := args[0]
-	value := args[1]
-
-	if key != "sandbox.tool" {
-		return fmt.Errorf("unsupported config key %q", key)
-	}
-
-	return writeSandboxToolConfig(value)
-}
-
-func runLaunch(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: dmr launch <tool> [args...]")
-	}
-
-	sandboxTool, err := readSandboxToolConfig()
-	if err != nil {
-		return err
-	}
-
-	if sandboxTool == "" {
-		return fmt.Errorf("sandbox.tool is not configured. Run: dmr config sandbox.tool <tool>")
-	}
-
-	if strings.ContainsAny(sandboxTool, "\x00\r\n") {
-		return fmt.Errorf("sandbox.tool contains invalid characters")
-	}
-
-	sandboxToolPath, err := exec.LookPath(sandboxTool)
-	if err != nil {
-		return fmt.Errorf("sandbox tool %q not found in PATH: %w", sandboxTool, err)
-	}
-
-	cmd := exec.Command(sandboxToolPath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
-func dmrConfigPath() (string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("unable to determine config directory: %w", err)
-	}
-
-	return filepath.Join(configDir, "dmr", "config.toml"), nil
-}
-
-func writeSandboxToolConfig(tool string) error {
-	path, err := dmrConfigPath()
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("unable to create config directory: %w", err)
-	}
-
-	content := fmt.Sprintf("[sandbox]\ntool = %q\n", tool)
-
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		return fmt.Errorf("unable to write config: %w", err)
-	}
-	if err := os.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("unable to secure config permissions: %w", err)
-	}
-
-	return nil
-}
-
-func readSandboxToolConfig() (string, error) {
-	path, err := dmrConfigPath()
-	if err != nil {
-		return "", err
-	}
-
-	file, err := os.Open(path)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("unable to read config: %w", err)
-	}
-	defer file.Close()
-
-	inSandboxSection := false
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			inSandboxSection = line == "[sandbox]"
-			continue
-		}
-
-		if !inSandboxSection {
-			continue
-		}
-
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			continue
-		}
-
-		if strings.TrimSpace(key) != "tool" {
-			continue
-		}
-
-		return strings.Trim(strings.TrimSpace(value), `"`), nil
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("unable to parse config: %w", err)
-	}
-
-	return "", nil
 }


### PR DESCRIPTION
Fixes #915

#### Describe the changes you have made in this PR -

This PR adds support for configuring and launching tools through a sandbox from the `dmr` wrapper.

Users can now configure the sandbox tool with:

```bash
dmr config sandbox.tool sbx
```

The above command writes TOML-style config

Manual Testing done using the following commands 

```
tmpdir="$(mktemp -d)"
XDG_CONFIG_HOME="$tmpdir/config" ./dmr config sandbox.tool sbx
cat "$tmpdir/config/dmr/config.toml"
```

Tested launch through a fake sandbox command and outputs have been verified successfully