### PR TITLE
docs: clarify configure show command help

### DIFF
--- a/cmd/cli/commands/configure_show.go
+++ b/cmd/cli/commands/configure_show.go
@@ -26,7 +26,7 @@ func newConfigureShowCmd() *cobra.Command {
 				return err
 			}
 
-			jsonResult, err := json.MarshalIndent(configs, "", " ")
+			jsonResult, err := json.MarshalIndent(configs, "", "  ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal configs to JSON: %w", err)
 			}

--- a/cmd/cli/commands/configure_show.go
+++ b/cmd/cli/commands/configure_show.go
@@ -5,31 +5,37 @@ import (
 	"fmt"
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
+
 	"github.com/spf13/cobra"
 )
 
 func newConfigureShowCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "show [MODEL]",
-		Short: "Show model configurations",
+		Short: "Show effective runtime configuration for models",
+		Long:  "Show the effective runtime configuration that Docker Model Runner has stored for one model or all models.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var modelFilter string
 			if len(args) > 0 {
 				modelFilter = args[0]
 			}
+
 			configs, err := desktopClient.ShowConfigs(modelFilter)
 			if err != nil {
 				return err
 			}
-			jsonResult, err := json.MarshalIndent(configs, "", "  ")
+
+			jsonResult, err := json.MarshalIndent(configs, "", " ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal configs to JSON: %w", err)
 			}
+
 			cmd.Println(string(jsonResult))
 			return nil
 		},
 		ValidArgsFunction: completion.ModelNames(getDesktopClient, 1),
 	}
+
 	return c
 }

--- a/cmd/cli/commands/configure_show.go
+++ b/cmd/cli/commands/configure_show.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/docker/model-runner/cmd/cli/commands/completion"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/docs/reference/docker_model_configure_show.yaml
+++ b/cmd/cli/docs/reference/docker_model_configure_show.yaml
@@ -1,6 +1,7 @@
 command: docker model configure show
-short: Show model configurations
-long: Show model configurations
+short: Show effective runtime configuration for models
+long: |
+    Show the effective runtime configuration that Docker Model Runner has stored for one model or all models.
 usage: docker model configure show [MODEL]
 pname: docker model configure
 plink: docker_model_configure.yaml


### PR DESCRIPTION
Update the configure show command description to explain that it displays the effective runtime configuration stored for one model or all models.