### PR TITLE
feat(registry): honor registry mirrors for model pulls and backend do…

### DIFF
--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -335,6 +335,11 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 		}
 	}
 
+	// Forward registry mirrors to the container if set on the host
+	if mirrors, ok := os.LookupEnv("MODEL_RUNNER_REGISTRY_MIRRORS"); ok && mirrors != "" {
+		env = append(env, "MODEL_RUNNER_REGISTRY_MIRRORS="+mirrors)
+	}
+
 	// Determine TLS port
 	tlsPort := tlsOpts.Port
 	if tlsOpts.Enabled && tlsPort == 0 {

--- a/pkg/distribution/oci/remote/remote.go
+++ b/pkg/distribution/oci/remote/remote.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/model-runner/pkg/distribution/oci"
 	"github.com/docker/model-runner/pkg/distribution/oci/authn"
 	"github.com/docker/model-runner/pkg/distribution/oci/reference"
+	"github.com/docker/model-runner/pkg/internal/registryutil"
 	godigest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -41,12 +42,13 @@ const (
 type Option func(*options)
 
 type options struct {
-	ctx       context.Context
-	transport http.RoundTripper
-	userAgent string
-	auth      authn.Authenticator
-	keychain  authn.Keychain
-	plainHTTP bool
+	ctx             context.Context
+	transport       http.RoundTripper
+	userAgent       string
+	auth            authn.Authenticator
+	keychain        authn.Keychain
+	plainHTTP       bool
+	registryMirrors []string
 }
 
 // WithContext sets the context for remote operations.
@@ -88,6 +90,13 @@ func WithAuthFromKeychain(kc authn.Keychain) Option {
 func WithPlainHTTP(plain bool) Option {
 	return func(o *options) {
 		o.plainHTTP = plain
+	}
+}
+
+// WithRegistryMirrors sets registry mirrors to try before registry-1.docker.io for model pulls.
+func WithRegistryMirrors(mirrors []string) Option {
+	return func(o *options) {
+		o.registryMirrors = mirrors
 	}
 }
 
@@ -444,9 +453,7 @@ func createResolver(o *options, ref reference.Reference) resolverComponents {
 		})
 	} else {
 		resolver = docker.NewResolver(docker.ResolverOptions{
-			Hosts: docker.ConfigureDefaultRegistries(
-				docker.WithAuthorizer(authorizer),
-				docker.WithClient(client)),
+			Hosts: registryutil.RegistryHosts(o.registryMirrors, authorizer, client),
 		})
 	}
 

--- a/pkg/distribution/registry/client.go
+++ b/pkg/distribution/registry/client.go
@@ -49,11 +49,12 @@ func GetDefaultRegistryOptions() []reference.Option {
 }
 
 type Client struct {
-	transport http.RoundTripper
-	userAgent string
-	keychain  authn.Keychain
-	auth      authn.Authenticator
-	plainHTTP bool
+	transport       http.RoundTripper
+	userAgent       string
+	keychain        authn.Keychain
+	auth            authn.Authenticator
+	plainHTTP       bool
+	registryMirrors []string
 }
 
 type ClientOption func(*Client)
@@ -90,6 +91,13 @@ func WithPlainHTTP(plain bool) ClientOption {
 	}
 }
 
+// WithRegistryMirrors sets registry mirrors to try before registry-1.docker.io.
+func WithRegistryMirrors(mirrors []string) ClientOption {
+	return func(c *Client) {
+		c.registryMirrors = mirrors
+	}
+}
+
 func NewClient(opts ...ClientOption) *Client {
 	client := &Client{
 		transport: remote.DefaultTransport,
@@ -106,11 +114,12 @@ func NewClient(opts ...ClientOption) *Client {
 // and applying optional modifications via ClientOption functions.
 func FromClient(base *Client, opts ...ClientOption) *Client {
 	client := &Client{
-		transport: base.transport,
-		userAgent: base.userAgent,
-		keychain:  base.keychain,
-		auth:      base.auth,
-		plainHTTP: base.plainHTTP,
+		transport:       base.transport,
+		userAgent:       base.userAgent,
+		keychain:        base.keychain,
+		auth:            base.auth,
+		plainHTTP:       base.plainHTTP,
+		registryMirrors: base.registryMirrors,
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -131,6 +140,7 @@ func (c *Client) Model(ctx context.Context, ref string) (types.ModelArtifact, er
 		remote.WithTransport(c.transport),
 		remote.WithUserAgent(c.userAgent),
 		remote.WithPlainHTTP(c.plainHTTP),
+		remote.WithRegistryMirrors(c.registryMirrors),
 	}
 
 	// Use direct auth if provided, otherwise fall back to keychain

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -190,3 +190,19 @@ func TLSKey() string {
 // TLSAutoCert is true (default) unless MODEL_RUNNER_TLS_AUTO_CERT is set to a falsy value.
 // Call as TLSAutoCert(true) to get the default-true behaviour.
 var TLSAutoCert = BoolWithDefault("MODEL_RUNNER_TLS_AUTO_CERT")
+
+// RegistryMirrors returns registry mirrors from MODEL_RUNNER_REGISTRY_MIRRORS (comma-separated URLs).
+// Mirrors are tried before registry-1.docker.io when pulling backend images.
+func RegistryMirrors() []string {
+	s := Var("MODEL_RUNNER_REGISTRY_MIRRORS")
+	if s == "" {
+		return nil
+	}
+	var mirrors []string
+	for _, m := range strings.Split(s, ",") {
+		if trimmed := strings.TrimSpace(m); trimmed != "" {
+			mirrors = append(mirrors, trimmed)
+		}
+	}
+	return mirrors
+}

--- a/pkg/inference/backends/diffusers/diffusers.go
+++ b/pkg/inference/backends/diffusers/diffusers.go
@@ -53,11 +53,13 @@ type diffusers struct {
 	customPythonPath string
 	// installDir is the directory where diffusers is installed.
 	installDir string
+	// registryMirrors is the list of registry mirrors to try before registry-1.docker.io.
+	registryMirrors []string
 }
 
 // New creates a new diffusers-based backend for image generation.
 // customPythonPath is an optional path to a custom python3 binary; if empty, the default installation is used.
-func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config, customPythonPath string) (inference.Backend, error) {
+func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config, customPythonPath string, registryMirrors []string) (inference.Backend, error) {
 	// If no config is provided, use the default configuration
 	if conf == nil {
 		conf = NewDefaultConfig()
@@ -77,6 +79,7 @@ func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Log
 		status:           inference.FormatNotInstalled(""),
 		customPythonPath: customPythonPath,
 		installDir:       installDir,
+		registryMirrors:  registryMirrors,
 	}, nil
 }
 
@@ -151,7 +154,7 @@ func (d *diffusers) downloadAndExtract(ctx context.Context) error {
 
 	// Pull the image
 	image := fmt.Sprintf("registry-1.docker.io/docker/model-runner:diffusers-%s", diffusersVersion)
-	if err := dockerhub.PullPlatform(ctx, image, filepath.Join(downloadDir, "image.tar"), runtime.GOOS, runtime.GOARCH); err != nil {
+	if err := dockerhub.PullPlatform(ctx, image, filepath.Join(downloadDir, "image.tar"), runtime.GOOS, runtime.GOARCH, d.registryMirrors); err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}
 

--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -128,7 +128,7 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 	defer os.RemoveAll(downloadDir)
 
 	l.status = inference.FormatInstalling(fmt.Sprintf("%s llama.cpp %s", inference.DetailDownloading, desiredTag))
-	if extractErr := extractFromImage(ctx, log, image, runtime.GOOS, runtime.GOARCH, downloadDir); extractErr != nil {
+	if extractErr := extractFromImage(ctx, log, image, runtime.GOOS, runtime.GOARCH, downloadDir, l.registryMirrors); extractErr != nil {
 		return fmt.Errorf("could not extract image: %w", extractErr)
 	}
 
@@ -174,14 +174,14 @@ func (l *llamaCpp) downloadLatestLlamaCpp(ctx context.Context, log logging.Logge
 }
 
 //nolint:unused // Used in platform-specific files (download_darwin.go, download_windows.go)
-func extractFromImage(ctx context.Context, log logging.Logger, image, requiredOs, requiredArch, destination string) error {
+func extractFromImage(ctx context.Context, log logging.Logger, image, requiredOs, requiredArch, destination string, mirrors []string) error {
 	log.Info("Extracting image", "image", image, "destination", destination)
 	tmpDir, err := os.MkdirTemp("", "docker-tar-extract")
 	if err != nil {
 		return err
 	}
 	imageTar := filepath.Join(tmpDir, "save.tar")
-	if err := dockerhub.PullPlatform(ctx, image, imageTar, requiredOs, requiredArch); err != nil {
+	if err := dockerhub.PullPlatform(ctx, image, imageTar, requiredOs, requiredArch, mirrors); err != nil {
 		return err
 	}
 	return dockerhub.Extract(imageTar, requiredArch, requiredOs, destination)

--- a/pkg/inference/backends/llamacpp/llamacpp.go
+++ b/pkg/inference/backends/llamacpp/llamacpp.go
@@ -52,6 +52,8 @@ type llamaCpp struct {
 	config config.BackendConfig
 	// gpuSupported indicates whether the underlying llama-server is built with GPU support.
 	gpuSupported bool
+	// registryMirrors is the list of registry mirrors to try before registry-1.docker.io.
+	registryMirrors []string
 }
 
 // New creates a new llama.cpp-based backend.
@@ -62,6 +64,7 @@ func New(
 	vendoredServerStoragePath string,
 	updatedServerStoragePath string,
 	conf config.BackendConfig,
+	registryMirrors []string,
 ) (inference.Backend, error) {
 	// If no config is provided, use the default configuration
 	if conf == nil {
@@ -75,6 +78,7 @@ func New(
 		vendoredServerStoragePath: vendoredServerStoragePath,
 		updatedServerStoragePath:  updatedServerStoragePath,
 		config:                    conf,
+		registryMirrors:           registryMirrors,
 	}, nil
 }
 

--- a/pkg/inference/backends/vllm/vllm.go
+++ b/pkg/inference/backends/vllm/vllm.go
@@ -43,13 +43,16 @@ type vLLM struct {
 	status string
 	// customBinaryPath is an optional custom path to the vllm binary.
 	customBinaryPath string
+	// registryMirrors is the list of registry mirrors to try before registry-1.docker.io.
+	registryMirrors []string
 }
 
 // Options holds the configuration for the unified vLLM backend constructor.
 type Options struct {
-	Config          *Config // Linux-only: extra vllm args (nil = defaults)
-	LinuxBinaryPath string  // Linux: custom vllm binary path
-	MetalPythonPath string  // macOS ARM64: custom python path
+	Config          *Config  // Linux-only: extra vllm args (nil = defaults)
+	LinuxBinaryPath string   // Linux: custom vllm binary path
+	MetalPythonPath string   // macOS ARM64: custom python path
+	RegistryMirrors []string // registry mirrors tried before registry-1.docker.io
 }
 
 // New creates the appropriate vLLM backend for the current platform.
@@ -58,9 +61,9 @@ type Options struct {
 // methods return errors.
 func New(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, opts Options) (inference.Backend, error) {
 	if platform.SupportsVLLMMetal() {
-		return newMetal(log, modelManager, serverLog, opts.MetalPythonPath)
+		return newMetal(log, modelManager, serverLog, opts.MetalPythonPath, opts.RegistryMirrors)
 	}
-	return newLinux(log, modelManager, serverLog, opts.Config, opts.LinuxBinaryPath)
+	return newLinux(log, modelManager, serverLog, opts.Config, opts.LinuxBinaryPath, opts.RegistryMirrors)
 }
 
 // NeedsDeferredInstall reports whether vllm on the current platform
@@ -71,7 +74,7 @@ func NeedsDeferredInstall() bool {
 
 // newLinux creates a new Linux vLLM-based backend.
 // customBinaryPath is an optional path to a custom vllm binary; if empty, the default path is used.
-func newLinux(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config, customBinaryPath string) (inference.Backend, error) {
+func newLinux(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, conf *Config, customBinaryPath string, registryMirrors []string) (inference.Backend, error) {
 	// If no config is provided, use the default configuration
 	if conf == nil {
 		conf = NewDefaultVLLMConfig()
@@ -84,6 +87,7 @@ func newLinux(log logging.Logger, modelManager *models.Manager, serverLog loggin
 		config:           conf,
 		status:           inference.FormatNotInstalled(""),
 		customBinaryPath: customBinaryPath,
+		registryMirrors:  registryMirrors,
 	}, nil
 }
 

--- a/pkg/inference/backends/vllm/vllm_metal.go
+++ b/pkg/inference/backends/vllm/vllm_metal.go
@@ -51,11 +51,13 @@ type vllmMetal struct {
 	installDir string
 	// status is the state in which the backend is in.
 	status string
+	// registryMirrors is the list of registry mirrors to try before registry-1.docker.io.
+	registryMirrors []string
 }
 
 // newMetal creates a new vllm-metal backend.
 // customPythonPath is an optional path to a custom python3 binary; if empty, the default installation is used.
-func newMetal(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, customPythonPath string) (inference.Backend, error) {
+func newMetal(log logging.Logger, modelManager *models.Manager, serverLog logging.Logger, customPythonPath string, registryMirrors []string) (inference.Backend, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user home directory: %w", err)
@@ -69,6 +71,7 @@ func newMetal(log logging.Logger, modelManager *models.Manager, serverLog loggin
 		customPythonPath: customPythonPath,
 		installDir:       installDir,
 		status:           inference.FormatNotInstalled(""),
+		registryMirrors:  registryMirrors,
 	}, nil
 }
 
@@ -143,7 +146,7 @@ func (v *vllmMetal) downloadAndExtract(ctx context.Context, _ *http.Client) erro
 
 	// Pull the image
 	image := fmt.Sprintf("registry-1.docker.io/docker/model-runner:vllm-metal-%s", vllmMetalVersion)
-	if err := dockerhub.PullPlatform(ctx, image, filepath.Join(downloadDir, "image.tar"), runtime.GOOS, runtime.GOARCH); err != nil {
+	if err := dockerhub.PullPlatform(ctx, image, filepath.Join(downloadDir, "image.tar"), runtime.GOOS, runtime.GOARCH, v.registryMirrors); err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}
 

--- a/pkg/inference/models/http_handler.go
+++ b/pkg/inference/models/http_handler.go
@@ -71,6 +71,8 @@ type ClientConfig struct {
 	UserAgent string
 	// PlainHTTP enables plain HTTP connections to registries (for testing).
 	PlainHTTP bool
+	// RegistryMirrors is a list of registry mirrors tried before registry-1.docker.io.
+	RegistryMirrors []string
 }
 
 // NewHTTPHandler creates a new model's handler.

--- a/pkg/inference/models/manager.go
+++ b/pkg/inference/models/manager.go
@@ -43,6 +43,7 @@ func NewManager(log logging.Logger, c ClientConfig) *Manager {
 		registry.WithTransport(c.Transport),
 		registry.WithUserAgent(c.UserAgent),
 		registry.WithPlainHTTP(c.PlainHTTP),
+		registry.WithRegistryMirrors(c.RegistryMirrors),
 	)
 
 	// Create the model distribution client.

--- a/pkg/internal/dockerhub/download.go
+++ b/pkg/internal/dockerhub/download.go
@@ -19,10 +19,11 @@ import (
 	"github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/containerd/platforms"
 	"github.com/docker/model-runner/pkg/internal/jsonutil"
+	"github.com/docker/model-runner/pkg/internal/registryutil"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func PullPlatform(ctx context.Context, image, destination, requiredOs, requiredArch string) error {
+func PullPlatform(ctx context.Context, image, destination, requiredOs, requiredArch string, mirrors []string) error {
 	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return fmt.Errorf("creating destination directory %s: %w", filepath.Dir(destination), err)
 	}
@@ -39,7 +40,7 @@ func PullPlatform(ctx context.Context, image, destination, requiredOs, requiredA
 	if err != nil {
 		return fmt.Errorf("creating new content store: %w", err)
 	}
-	desc, err := retry(ctx, 10, 1*time.Second, func() (*v1.Descriptor, error) { return fetch(ctx, store, image, requiredOs, requiredArch) })
+	desc, err := retry(ctx, 10, 1*time.Second, func() (*v1.Descriptor, error) { return fetch(ctx, store, image, requiredOs, requiredArch, mirrors) })
 	if err != nil {
 		return fmt.Errorf("fetching image: %w", err)
 	}
@@ -66,12 +67,10 @@ func retry(ctx context.Context, attempts int, sleep time.Duration, f func() (*v1
 	return nil, fmt.Errorf("after %d attempts, last error: %w", attempts, err)
 }
 
-func fetch(ctx context.Context, store content.Store, ref, requiredOs, requiredArch string) (*v1.Descriptor, error) {
+func fetch(ctx context.Context, store content.Store, ref, requiredOs, requiredArch string, mirrors []string) (*v1.Descriptor, error) {
+	authorizer := docker.NewDockerAuthorizer(docker.WithAuthCreds(dockerCredentials))
 	resolver := docker.NewResolver(docker.ResolverOptions{
-		Hosts: docker.ConfigureDefaultRegistries(
-			docker.WithAuthorizer(
-				docker.NewDockerAuthorizer(
-					docker.WithAuthCreds(dockerCredentials)))),
+		Hosts: registryutil.RegistryHosts(mirrors, authorizer, nil),
 	})
 	name, desc, err := resolver.Resolve(ctx, ref)
 	if err != nil {

--- a/pkg/internal/registryutil/mirrors.go
+++ b/pkg/internal/registryutil/mirrors.go
@@ -1,0 +1,63 @@
+package registryutil
+
+import (
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+)
+
+// RegistryHosts returns a RegistryHosts function that tries mirrors before the upstream registry.
+// Mirrors are only applied for Docker Hub (registry-1.docker.io / docker.io); all other
+// registries use the default configuration. When mirrors is empty the default configuration
+// is returned unchanged.
+//
+// client is used for both mirror and upstream connections; pass nil to use http.DefaultClient.
+func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.Client) docker.RegistryHosts {
+	var defaultOpts []docker.RegistryOpt
+	defaultOpts = append(defaultOpts, docker.WithAuthorizer(authorizer))
+	if client != nil {
+		defaultOpts = append(defaultOpts, docker.WithClient(client))
+	}
+	defaults := docker.ConfigureDefaultRegistries(defaultOpts...)
+	if len(mirrors) == 0 {
+		return defaults
+	}
+	return func(host string) ([]docker.RegistryHost, error) {
+		if host != "registry-1.docker.io" && host != "docker.io" {
+			return defaults(host)
+		}
+		mirrorClient := client
+		if mirrorClient == nil {
+			mirrorClient = http.DefaultClient
+		}
+		var hosts []docker.RegistryHost
+		for _, mirror := range mirrors {
+			u, err := url.Parse(mirror)
+			if err != nil {
+				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
+				continue
+			}
+			mirrorHost := u.Host
+			scheme := u.Scheme
+			if mirrorHost == "" {
+				mirrorHost = mirror
+				scheme = "https"
+			}
+			hosts = append(hosts, docker.RegistryHost{
+				Client:       mirrorClient,
+				Authorizer:   authorizer,
+				Host:         mirrorHost,
+				Scheme:       scheme,
+				Path:         "/v2",
+				Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
+			})
+		}
+		upstream, err := defaults("registry-1.docker.io")
+		if err != nil {
+			return nil, err
+		}
+		return append(hosts, upstream...), nil
+	}
+}

--- a/pkg/routing/backends.go
+++ b/pkg/routing/backends.go
@@ -35,6 +35,11 @@ type BackendsConfig struct {
 
 	IncludeDiffusers bool
 	DiffusersPath    string
+
+	// RegistryMirrors is a list of registry mirrors tried before registry-1.docker.io
+	// when pulling backend images. Populated from MODEL_RUNNER_REGISTRY_MIRRORS or
+	// injected by Docker Desktop from daemon.json registry-mirrors.
+	RegistryMirrors []string
 }
 
 // DefaultBackendDefs returns BackendDef entries for the configured backends.
@@ -50,7 +55,7 @@ func DefaultBackendDefs(cfg BackendsConfig) []BackendDef {
 
 	defs := []BackendDef{
 		{Name: llamacpp.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
-			return llamacpp.New(cfg.Log, mm, sl(llamacpp.Name), cfg.LlamaCppVendoredPath, cfg.LlamaCppUpdatedPath, cfg.LlamaCppConfig)
+			return llamacpp.New(cfg.Log, mm, sl(llamacpp.Name), cfg.LlamaCppVendoredPath, cfg.LlamaCppUpdatedPath, cfg.LlamaCppConfig, cfg.RegistryMirrors)
 		}},
 	}
 
@@ -68,6 +73,7 @@ func DefaultBackendDefs(cfg BackendsConfig) []BackendDef {
 				return vllm.New(cfg.Log, mm, sl(vllm.Name), vllm.Options{
 					LinuxBinaryPath: cfg.VLLMPath,
 					MetalPythonPath: cfg.VLLMMetalPath,
+					RegistryMirrors: cfg.RegistryMirrors,
 				})
 			},
 		})
@@ -78,7 +84,7 @@ func DefaultBackendDefs(cfg BackendsConfig) []BackendDef {
 			Name:     diffusers.Name,
 			Deferred: true,
 			Init: func(mm *models.Manager) (inference.Backend, error) {
-				return diffusers.New(cfg.Log, mm, sl(diffusers.Name), nil, cfg.DiffusersPath)
+				return diffusers.New(cfg.Log, mm, sl(diffusers.Name), nil, cfg.DiffusersPath, cfg.RegistryMirrors)
 			},
 		})
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -156,9 +156,10 @@ func Run(ctx context.Context, cfg Config) error {
 	svc, err := routing.NewService(routing.ServiceConfig{
 		Log: log,
 		ClientConfig: models.ClientConfig{
-			StoreRootPath: modelPath,
-			Logger:        log.With("component", "model-manager"),
-			Transport:     baseTransport,
+			StoreRootPath:   modelPath,
+			Logger:          log.With("component", "model-manager"),
+			Transport:       baseTransport,
+			RegistryMirrors: envconfig.RegistryMirrors(),
 		},
 		Backends: append(
 			routing.DefaultBackendDefs(routing.BackendsConfig{
@@ -183,6 +184,7 @@ func Run(ctx context.Context, cfg Config) error {
 				VLLMMetalPath:        vllmMetalServerPath,
 				IncludeDiffusers:     true,
 				DiffusersPath:        diffusersServerPath,
+				RegistryMirrors:      envconfig.RegistryMirrors(),
 			}),
 			routing.BackendDef{Name: sglang.Name, Init: func(mm *models.Manager) (inference.Backend, error) {
 				return sglang.New(log, mm, log.With("component", sglang.Name), nil, sglangServerPath)


### PR DESCRIPTION
Add `MODEL_RUNNER_REGISTRY_MIRRORS` support so model pulls and backend image downloads try configured mirrors before falling back to `registry-1.docker.io`.

To test:
```
MODEL_RUNNER_REGISTRY_MIRRORS=http://localhost:9999 MODEL_RUNNER_PORT=8080 make run LOCAL_LLAMA=1
```

```
MODEL_RUNNER_HOST=http://localhost:8080 docker model pull smollm2
```

Notice the logs:
```
time=2026-05-21T15:08:42.053+03:00 level=INFO msg="pulling model" model=smollm2
time=2026-05-21T15:08:42.053+03:00 level=INFO msg="starting model pull" component=model-manager reference=ai/smollm2:latest 
INFO[0041] trying next host
error="failed to do request: Head \"http://localhost:9999/v2/ai/smollm2/manifests/latest?ns=docker.io\": dial tcp 127.0.0.1:9999: connect: connection refused" host="localhost:9999"
time=2026-05-21T15:08:42.513+03:00 level=INFO msg="remote model digest" component=model-manager digest=sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9
time=2026-05-21T15:08:43.089+03:00 level=INFO msg="model not found in local store, pulling from remote" component=model-manager reference=ai/smollm2:latest
```