### PR TITLE
fix: use rm -f to handle missing .py files in llamacpp install

### DIFF
--- a/llamacpp/Makefile
+++ b/llamacpp/Makefile
@@ -42,7 +42,7 @@ ifeq ($(DETECTED_OS),macOS)
 		--config Release \
 		--prefix $(INSTALL_DIR)
 	@echo "Cleaning install directory..."
-	rm $(INSTALL_DIR)/bin/*.py
+	rm -f $(INSTALL_DIR)/bin/*.py
 	rm -rf $(INSTALL_DIR)/lib/cmake
 	rm -rf $(INSTALL_DIR)/lib/pkgconfig
 	rm -rf $(INSTALL_DIR)/include


### PR DESCRIPTION
## Summary

- The macOS e2e test has been failing across all PRs because `rm install/bin/*.py` exits non-zero when no `.py` files exist
- llama.cpp no longer ships Python scripts in `install/bin/`, so the glob expands to nothing and bare `rm` fails
- Changed `rm` to `rm -f` so the cleanup step silently succeeds when no files match

## Root cause

```
rm: install/bin/*.py: No such file or directory
make[2]: *** [build] Error 1
```

`rm -f` is the idiomatic fix — it ignores nonexistent files without changing behavior when files do exist.