### PR TITLE
ci: remove fragile bump-pinata and update-docs jobs from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ on:
         required: false
         type: string
       imagesOnly:
-        description: "Only build and push Docker images (skip CLI releases, pinata bump, docs update, and CE packaging)"
+        description: "Only build and push Docker images (skip CLI releases and CE packaging)"
         required: false
         type: boolean
         default: false
@@ -488,189 +488,6 @@ jobs:
           echo "✅ Desktop CLI release completed successfully"
 
   # ---------------------------------------------------------------------------
-  # Bump docker-model version in pinata and open a PR
-  # ---------------------------------------------------------------------------
-  bump-pinata:
-    if: ${{ !inputs.imagesOnly }}
-    needs: [prepare, release-cli-desktop]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout pinata
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          repository: docker/pinata
-          token: ${{ secrets.CLI_RELEASE_PAT }}
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Fetch latest llamacpp version from Docker Hub
-        id: llamacpp
-        run: |
-          TAGS_JSON=$(curl -s "https://hub.docker.com/v2/repositories/docker/docker-model-backend-llamacpp/tags?page_size=25&ordering=last_updated")
-          LLAMACPP_VERSION=$(echo "$TAGS_JSON" | jq -r '
-            (.results[] | select(.name == "latest-cpu") | .digest) as $d |
-            .results[] | select(.name != "latest-cpu" and (.name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-cpu$")) and .digest == $d) | .name | split("-")[0]
-          ')
-          if [ -z "$LLAMACPP_VERSION" ] || [ "$LLAMACPP_VERSION" = "null" ]; then
-            echo "::error::Failed to fetch latest llamacpp version from Docker Hub"
-            exit 1
-          fi
-          echo "version=$LLAMACPP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "📦 Latest llamacpp version: $LLAMACPP_VERSION"
-
-      - name: Bump docker-model and llamacpp versions in build.json
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          LLAMACPP_VERSION: ${{ steps.llamacpp.outputs.version }}
-        run: |
-          NEW_VERSION="v${VERSION}"
-          jq --arg model_v "$NEW_VERSION" --arg llama_v "$LLAMACPP_VERSION" '
-            .["docker-model"].version = $model_v |
-            .["llamacpp"].version = $llama_v
-          ' build.json > build.json.tmp
-          mv build.json.tmp build.json
-
-      - name: Bump model-runner Go dependency
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          go get github.com/docker/model-runner@v${VERSION}
-          go mod tidy
-          go mod vendor
-
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-        with:
-          token: ${{ secrets.CLI_RELEASE_PAT }}
-          base: main
-          commit-message: "chore: bump docker-model to v${{ needs.prepare.outputs.version }} and llamacpp to ${{ steps.llamacpp.outputs.version }}"
-          branch: bump-docker-model-v${{ needs.prepare.outputs.version }}
-          title: "Bump docker-model to v${{ needs.prepare.outputs.version }} and llamacpp to ${{ steps.llamacpp.outputs.version }}"
-          body: |
-            ### Ticket(s)
-
-            N/A — automated version bump
-
-            ### What this PR does
-
-            - Bumps docker-model version to v${{ needs.prepare.outputs.version }} in build.json.
-            - Bumps llamacpp version to ${{ steps.llamacpp.outputs.version }} in build.json (latest from [Docker Hub](https://hub.docker.com/r/docker/docker-model-backend-llamacpp/tags)).
-            - Updates `github.com/docker/model-runner` Go module to v${{ needs.prepare.outputs.version }} (go get + go mod tidy + go mod vendor).
-
-            ### Notes for the reviewer
-
-            Automated PR created by the model-runner release workflow.
-
-          draft: true
-
-  # ---------------------------------------------------------------------------
-  # Update CLI reference docs in docker/docs
-  # ---------------------------------------------------------------------------
-  update-docs:
-    if: ${{ !inputs.imagesOnly }}
-    needs: [prepare]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check if CLI docs changed
-        id: check-docs
-        env:
-          GH_TOKEN: ${{ secrets.CLI_RELEASE_PAT }}
-          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
-          PREVIOUS_TAG: ${{ needs.prepare.outputs.previous_tag }}
-        run: |
-          if [ -z "$PREVIOUS_TAG" ]; then
-            echo "No previous tag — assuming docs changed"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          CHANGED=$(gh api repos/docker/model-runner/compare/${PREVIOUS_TAG}...${RELEASE_TAG} \
-            --jq '[.files[].filename | select(startswith("cmd/cli/docs/reference/"))] | length')
-          if [ "$CHANGED" -gt 0 ]; then
-            echo "CLI docs changed ($CHANGED files)"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No CLI docs changes between $PREVIOUS_TAG and $RELEASE_TAG — skipping"
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout model-runner
-        if: steps.check-docs.outputs.changed == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Load GO version
-        if: steps.check-docs.outputs.changed == 'true'
-        id: versions
-        uses: ./.github/actions/load-go-version
-
-      - name: Checkout docs
-        if: steps.check-docs.outputs.changed == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          repository: docker/docs
-          token: ${{ secrets.CLI_RELEASE_PAT }}
-          fetch-depth: 0
-
-      - name: Set up Go
-        if: steps.check-docs.outputs.changed == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-        with:
-          go-version: ${{ steps.versions.outputs.go-version }}
-          cache: true
-
-      - name: Vendor model-runner CLI docs
-        if: steps.check-docs.outputs.changed == 'true'
-        env:
-          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
-        run: |
-          VENDOR_MODULE=github.com/docker/model-runner@${RELEASE_TAG} make vendor
-          # Remove the second require block added by `go get` — the docs repo
-          # only needs the direct dependency in the first require block.
-          awk '/^require \(/{n++} n==2{if(/^\)/) n=3; next} n!=2' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
-          cat -s go.mod > go.mod.tmp && mv go.mod.tmp go.mod
-
-      - name: Create pull request
-        if: steps.check-docs.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-        with:
-          token: ${{ secrets.DOCKER_DOCS }}
-          base: main
-          push-to-fork: ilopezluna/docs
-          commit-message: |
-            vendor: github.com/docker/model-runner ${{ needs.prepare.outputs.release_tag }}
-
-            See changes in https://github.com/docker/model-runner/compare/${{ needs.prepare.outputs.previous_tag }}...${{ needs.prepare.outputs.release_tag }}.
-          branch: update-model-runner-${{ needs.prepare.outputs.release_tag }}
-          title: "vendor: github.com/docker/model-runner ${{ needs.prepare.outputs.release_tag }}"
-          body: |
-            ## Description
-
-            Update Model Runner CLI docs.
-            See changes in https://github.com/docker/model-runner/compare/${{ needs.prepare.outputs.previous_tag }}...${{ needs.prepare.outputs.release_tag }}.
-
-            ```
-            VENDOR_MODULE=github.com/docker/model-runner@${{ needs.prepare.outputs.release_tag }} make vendor
-            ```
-
-            ## Reviews
-
-            <!-- Notes for reviewers here -->
-            <!-- List applicable reviews (optionally @tag reviewers) -->
-
-            - [ ] Technical review
-            - [ ] Editorial review
-            - [ ] Product review
-          draft: true
-
-  # ---------------------------------------------------------------------------
   # Release CLI for Docker CE — build .deb/.rpm packages and deploy
   #
   # Triggers packaging, waits for it, then triggers the deploy workflow.
@@ -785,7 +602,7 @@ jobs:
   # Create GitHub Release with AI-generated release notes
   # ---------------------------------------------------------------------------
   github-release:
-    needs: [prepare, release-notes, build, release-cli-desktop, bump-pinata, update-docs, verify-docker-ce]
+    needs: [prepare, release-notes, build, release-cli-desktop, verify-docker-ce]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Remove the bump-pinata and update-docs jobs from the release workflow. These jobs create PRs in external repos (docker/pinata and docker/docs) and are prone to failure due to private dependency authentication issues, which blocks the github-release job. See https://github.com/docker/model-runner/actions/runs/26226008696/job/77211265632