### PR TITLE
cli: hint when install-runner options are ignored

### DIFF
--- a/cmd/cli/commands/install-runner.go
+++ b/cmd/cli/commands/install-runner.go
@@ -245,6 +245,39 @@ type runnerOptions struct {
 	tlsKey          string
 }
 
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return false
+	}
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && flag.Changed
+}
+
+func existingRunnerOptionsHint(cmd *cobra.Command, opts runnerOptions) string {
+	backendChanged := commandFlagChanged(cmd, "backend")
+	gpuChanged := commandFlagChanged(cmd, "gpu")
+
+	if !backendChanged && !gpuChanged {
+		return ""
+	}
+
+	reinstallArgs := []string{"docker", "model", "reinstall-runner"}
+
+	if backendChanged && opts.backend != "" {
+		reinstallArgs = append(reinstallArgs, "--backend", fmt.Sprintf("%q", opts.backend))
+	}
+	if gpuChanged && opts.gpuMode != "" {
+		reinstallArgs = append(reinstallArgs, "--gpu", fmt.Sprintf("%q", opts.gpuMode))
+	}
+
+	return fmt.Sprintf(
+		"\nThe requested runner options were not applied because the Model Runner container is already running.\n"+
+			"To recreate the runner with the requested options, run:\n\n"+
+			"  %s\n",
+		strings.Join(reinstallArgs, " "),
+	)
+}
+
 // runInstallOrStart is shared logic for install-runner and start-runner commands
 func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error {
 	// On macOS ARM64, the vllm backend requires deferred installation
@@ -343,6 +376,9 @@ func runInstallOrStart(cmd *cobra.Command, opts runnerOptions, debug bool) error
 			} else {
 				cmd.Printf("Model Runner container %s is already running\n", ctrID[:12])
 			}
+
+			cmd.Print(existingRunnerOptionsHint(cmd, opts))
+
 			return nil
 		}
 	}

--- a/cmd/cli/commands/install-runner_test.go
+++ b/cmd/cli/commands/install-runner_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docker/model-runner/pkg/inference/backends/llamacpp"
@@ -152,5 +153,143 @@ func TestInstallRunnerValidArgsFunction(t *testing.T) {
 	// So ValidArgsFunction should be set to handle no arguments
 	if cmd.ValidArgsFunction == nil {
 		t.Error("Expected ValidArgsFunction to be set")
+	}
+}
+
+func TestExistingRunnerOptionsHintNoExplicitOptions(t *testing.T) {
+	cmd := newInstallRunner()
+
+	// Default install-runner options should not print a reinstall hint.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		backend: "",
+		gpuMode: "auto",
+	})
+
+	if got != "" {
+		t.Fatalf("expected no hint when backend/gpu flags are not explicitly changed, got %q", got)
+	}
+}
+
+func TestExistingRunnerOptionsHintWithBackendOnly(t *testing.T) {
+	cmd := newInstallRunner()
+
+	if err := cmd.Flags().Set("backend", vllm.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	// A backend-only request should preserve only the explicit backend flag.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		backend: vllm.Name,
+		gpuMode: "auto",
+	})
+
+	if !strings.Contains(got, `docker model reinstall-runner --backend "vllm"`) {
+		t.Fatalf("expected backend-only reinstall hint, got %q", got)
+	}
+	if strings.Contains(got, "--gpu") {
+		t.Fatalf("did not expect gpu flag in backend-only hint, got %q", got)
+	}
+}
+
+func TestExistingRunnerOptionsHintWithCUDA(t *testing.T) {
+	cmd := newInstallRunner()
+
+	if err := cmd.Flags().Set("gpu", "cuda"); err != nil {
+		t.Fatal(err)
+	}
+
+	// This fakes a user explicitly requesting CUDA without requiring local GPU hardware.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		gpuMode: "cuda",
+	})
+
+	if !strings.Contains(got, `docker model reinstall-runner --gpu "cuda"`) {
+		t.Fatalf("expected cuda reinstall hint, got %q", got)
+	}
+	if strings.Contains(got, "--backend") {
+		t.Fatalf("did not expect backend flag in cuda-only hint, got %q", got)
+	}
+}
+
+func TestExistingRunnerOptionsHintWithBackendAndCUDA(t *testing.T) {
+	cmd := newInstallRunner()
+
+	if err := cmd.Flags().Set("backend", vllm.Name); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("gpu", "cuda"); err != nil {
+		t.Fatal(err)
+	}
+
+	// This covers the WSL2/vLLM issue path: the existing runner needs reinstall-runner.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		backend: vllm.Name,
+		gpuMode: "cuda",
+	})
+
+	expectedFragments := []string{
+		"The requested runner options were not applied",
+		`docker model reinstall-runner --backend "vllm" --gpu "cuda"`,
+	}
+
+	for _, fragment := range expectedFragments {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("expected hint to contain %q, got %q", fragment, got)
+		}
+	}
+}
+
+func TestExistingRunnerOptionsHintWithNoGPU(t *testing.T) {
+	cmd := newInstallRunner()
+
+	if err := cmd.Flags().Set("gpu", "none"); err != nil {
+		t.Fatal(err)
+	}
+
+	// An explicit CPU/no-GPU request should be preserved in the reinstall command.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		gpuMode: "none",
+	})
+
+	if !strings.Contains(got, `docker model reinstall-runner --gpu "none"`) {
+		t.Fatalf("expected no-gpu reinstall hint, got %q", got)
+	}
+	if strings.Contains(got, "--backend") {
+		t.Fatalf("did not expect backend flag in no-gpu hint, got %q", got)
+	}
+}
+
+func TestExistingRunnerOptionsHintQuotesFlagValues(t *testing.T) {
+	cmd := newInstallRunner()
+
+	if err := cmd.Flags().Set("gpu", "cuda; echo bad"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Suggested command values should be quoted before being shown to the user.
+	got := existingRunnerOptionsHint(cmd, runnerOptions{
+		gpuMode: "cuda; echo bad",
+	})
+
+	if !strings.Contains(got, `docker model reinstall-runner --gpu "cuda; echo bad"`) {
+		t.Fatalf("expected quoted gpu reinstall hint, got %q", got)
+	}
+	if strings.Contains(got, "--gpu cuda;") {
+		t.Fatalf("expected gpu value to be quoted in reinstall hint, got %q", got)
+	}
+}
+
+func TestCommandFlagChangedDefensiveCases(t *testing.T) {
+	cmd := newInstallRunner()
+
+	// Missing commands and flags should be treated as unchanged.
+	if commandFlagChanged(nil, "gpu") {
+		t.Fatal("expected nil command to report unchanged flag")
+	}
+	if commandFlagChanged(cmd, "missing") {
+		t.Fatal("expected missing flag to report unchanged")
+	}
+	if commandFlagChanged(cmd, "gpu") {
+		t.Fatal("expected default gpu flag to report unchanged")
 	}
 }


### PR DESCRIPTION
## Summary
-  Add a reinstall hint when `install-runner` finds an existing running Model Runner container
-  Show the hint only when the user explicitly passed `--backend` or `--gpu`
-  Preserve the existing “already running” message and return behavior
-  Add focused tests for the new hint-generation logic

Fixes #907

## What changed
-  Added `commandFlagChanged` to check whether a Cobra flag was explicitly changed
-  Added `existingRunnerOptionsHint` to build the reinstall command hint
-  Updated the existing `ctrID != ""` branch to print the hint after the current already-running message
-  Added `cmd/cli/commands/install_runner_existing_options_hint_test.go`

## What this does not change
- Does not automatically reinstall or recreate an existing runner
- Does not change `reinstall-runner` behavior
- Does not change backend selection logic
- Does not change GPU probing or CUDA/vLLM runtime behavior
- Does not attempt to fully fix WSL2 CUDA/vLLM execution

## Tests added
- No hint when `--backend` and `--gpu` were not explicitly passed
- Backend-only hint
- GPU-only CUDA hint
- Backend + CUDA hint
- Explicit `--gpu none` hint
- Defensive flag-check cases

## Validation
- `go test ./cmd/cli/commands -run "TestInstallRunner|TestExistingRunnerOptionsHint|TestCommandFlagChanged" -v`
- go test ./cmd/cli/commands -v`
- `go test ./...`
- `make validate-all`

## Validation details
- `go.mod` tidy check passed
- `golangci-lint run ./...` passed with 0 issues
- `go test -race ./...` passed
- Shellcheck validation passed
- `.versions` is in sync with Dockerfile ARGs