### PR TITLE
feat: add Open WebUI volume mount and format containerApp entry

### DIFF
--- a/cmd/cli/commands/launch.go
+++ b/cmd/cli/commands/launch.go
@@ -48,7 +48,13 @@ var containerApps = map[string]containerApp{
 		envFn:           anythingllmEnv,
 		extraDockerArgs: []string{"-v", "anythingllm_storage:/app/server/storage"},
 	},
-	"openwebui": {defaultImage: "ghcr.io/open-webui/open-webui:latest", defaultHostPort: 3000, containerPort: 8080, envFn: openwebuiEnv},
+	"openwebui": {
+		defaultImage:    "ghcr.io/open-webui/open-webui:latest",
+		defaultHostPort: 3000,
+		containerPort:   8080,
+		envFn:           openwebuiEnv,
+		extraDockerArgs: []string{"-v", "openwebui_data:/app/backend/data"},
+	},
 }
 
 // hostApp describes a native CLI app launched on the host.


### PR DESCRIPTION
- Add persistent data volume for Open WebUI (`openwebui_data:/app/backend/data`) so user data survives container restarts
- Expand the single-line `openwebui` struct literal to multi-line format, matching the style of the `anythingllm` entry