### PR TITLE
fix: install libllama-server-impl.dylib to install/lib on macOS

### DIFF
--- a/llamacpp/native/CMakeLists.txt
+++ b/llamacpp/native/CMakeLists.txt
@@ -26,6 +26,14 @@ if (DDLLAMA_BUILD_SERVER)
     endif()
     add_subdirectory(vendor/llama.cpp)
 
+    # Install llama-server-impl shared library.
+    # Upstream gates this on LLAMA_TOOLS_INSTALL (which defaults OFF when used as a
+    # subdirectory), so we install it explicitly to ensure the dylib/so ends up in
+    # install/lib/ and the server binary can resolve its rpath dependency.
+    if (TARGET llama-server-impl)
+        install(TARGETS llama-server-impl LIBRARY DESTINATION lib)
+    endif()
+
     # Ensure shared library DLLs are installed on Windows.
     # Upstream install rules use LIBRARY which doesn't install RUNTIME (DLL) artifacts on DLL platforms.
     if (BUILD_SHARED_LIBS)

--- a/llamacpp/native/CMakeLists.txt
+++ b/llamacpp/native/CMakeLists.txt
@@ -31,7 +31,11 @@ if (DDLLAMA_BUILD_SERVER)
     # subdirectory), so we install it explicitly to ensure the dylib/so ends up in
     # install/lib/ and the server binary can resolve its rpath dependency.
     if (TARGET llama-server-impl)
-        install(TARGETS llama-server-impl LIBRARY DESTINATION lib)
+        install(TARGETS llama-server-impl
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin
+        )
     endif()
 
     # Ensure shared library DLLs are installed on Windows.


### PR DESCRIPTION
macOS E2E tests fail because `llama-server` links against `@rpath/libllama-server-impl.dylib`, which was never installed to `install/lib/`.

llama.cpp gates its install rule for `llama-server-impl` on `LLAMA_TOOLS_INSTALL` (defaults OFF when used as a cmake subdirectory), so the dylib builds to `build/bin/` but is never copied to `install/lib/`.

**Fix:** add an explicit `install(TARGETS llama-server-impl LIBRARY DESTINATION lib)` in `llamacpp/native/CMakeLists.txt`.

This avoids setting `-DLLAMA_TOOLS_INSTALL=ON` globally (which would install all unwanted upstream tool binaries like `llama-quantize`, `llama-bench`, `llama-cli`, etc.) and instead installs only the one missing library.

**Testing:** After `make build-llamacpp`, `install/lib/libllama-server-impl.dylib` will be present and the server binary's rpath will resolve correctly.