### PR TITLE
fix: resolve docker config path using cli/config (#943)

### DIFF
--- a/cmd/cli/pkg/standalone/containers.go
+++ b/cmd/cli/pkg/standalone/containers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/docker/cli/cli/config"
 )
 
 // controllerContainerName is the name to use for the controller container.
@@ -38,7 +39,7 @@ func copyDockerConfigToContainer(ctx context.Context, dockerClient *client.Clien
 		return nil
 	}
 
-	dockerConfigPath := os.ExpandEnv("$HOME/.docker/config.json")
+	dockerConfigPath := filepath.Join(config.Dir(), "config.json")
 	if s, err := os.Stat(dockerConfigPath); err != nil || s.Mode()&os.ModeType != 0 {
 		return nil
 	}


### PR DESCRIPTION
Fixes #943

**What this PR does:**
This fixes a silent failure in the Docker configuration sync that occurs on Windows and custom Linux environments. The previous code hardcoded `os.ExpandEnv("$HOME/.docker/config.json")`, which fails on Windows (where `$HOME` is not set by default) and ignores the standard `DOCKER_CONFIG` environment variable.

**Changes:**
- Imported the official `github.com/docker/cli/cli/config` package in `cmd/cli/pkg/standalone/containers.go`.
- Replaced the hardcoded path with `filepath.Join(config.Dir(), "config.json")`, leveraging Docker's native cross-platform path resolution logic.