### PR TITLE
Make llama.cpp Python cleanup optional

### DIFF
--- a/llamacpp/native/cann.Dockerfile
+++ b/llamacpp/native/cann.Dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=cache,target=/root/.ccache \
     cmake --build build --config Release && \
     cmake --install build --config Release --prefix install
 
-RUN rm install/bin/*.py
+RUN rm -f install/bin/*.py
 RUN rm -r install/lib/cmake
 RUN rm -r install/lib/pkgconfig
 RUN rm -r install/include

--- a/llamacpp/native/cuda.Dockerfile
+++ b/llamacpp/native/cuda.Dockerfile
@@ -40,7 +40,7 @@ RUN cmake $(cat cmake-flags)
 RUN cmake --build build --config Release -j$(nproc --ignore=2)
 RUN cmake --install build --config Release --prefix install
 
-RUN rm install/bin/*.py
+RUN rm -f install/bin/*.py
 RUN rm -r install/lib/cmake
 RUN rm -r install/lib/pkgconfig
 RUN rm -r install/include

--- a/llamacpp/native/generic.Dockerfile
+++ b/llamacpp/native/generic.Dockerfile
@@ -50,7 +50,7 @@ RUN cmake $(cat cmake-flags)
 RUN cmake --build build --config Release -j 4
 RUN cmake --install build --config Release --prefix install
 
-RUN rm install/bin/*.py
+RUN rm -f install/bin/*.py
 RUN rm -r install/lib/cmake
 RUN rm -r install/lib/pkgconfig
 RUN rm -r install/include

--- a/llamacpp/native/musa.Dockerfile
+++ b/llamacpp/native/musa.Dockerfile
@@ -36,7 +36,7 @@ RUN cmake $(cat cmake-flags)
 RUN cmake --build build --config Release
 RUN cmake --install build --config Release --prefix install
 
-RUN rm install/bin/*.py
+RUN rm -f install/bin/*.py
 RUN rm -r install/lib/cmake
 RUN rm -r install/lib/pkgconfig
 RUN rm -r install/include

--- a/llamacpp/native/rocm.Dockerfile
+++ b/llamacpp/native/rocm.Dockerfile
@@ -38,7 +38,7 @@ RUN cmake -B build \
 RUN cmake --build build --config Release
 RUN cmake --install build --config Release --prefix install
 
-RUN rm install/bin/*.py
+RUN rm -f install/bin/*.py
 RUN rm -r install/lib/cmake
 RUN rm -r install/lib/pkgconfig
 RUN rm -r install/include


### PR DESCRIPTION
## Summary
- make llama.cpp native Dockerfile Python helper cleanup tolerant when no `*.py` files are installed
- apply the same cleanup behavior across generic, CUDA, ROCm, CANN, and MUSA Dockerfiles

## Testing
- `rg -n 'RUN rm install/bin/\\*\\.py' llamacpp/native`\n- `rg -n 'RUN rm -f install/bin/\\*\\.py' llamacpp/native`\n- `git diff --check`\n\n## Notes\nThis keeps existing cleanup behavior when Python helper files are present, while avoiding a Docker build failure for builds where CMake install does not produce `install/bin/*.py`.\n