### PR TITLE
fix: add Pascal CUDA architectures

### DIFF
--- a/llamacpp/native/cuda.Dockerfile
+++ b/llamacpp/native/cuda.Dockerfile
@@ -32,6 +32,7 @@ RUN echo "-B build \
     -DGGML_NATIVE=OFF \
     -DGGML_OPENMP=OFF \
     -DGGML_CUDA=ON \
+    -DCMAKE_CUDA_ARCHITECTURES=61;62;70;75;80;86;89;120;121 \
     -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
     -DLLAMA_OPENSSL=OFF \
     -GNinja \


### PR DESCRIPTION
## Summary

Closes #929.

This sets `CMAKE_CUDA_ARCHITECTURES` explicitly for the native llama.cpp CUDA build so the image includes Pascal targets `sm_61` and `sm_62`. The list follows the issue's suggested architecture set and keeps the existing newer CUDA targets covered:

`61;62;70;75;80;86;89;120;121`

Without an explicit value, recent CUDA/CMake defaults can omit Pascal, which leaves GTX 10-series and similar cards without a compatible CUDA kernel and causes Docker Model Runner to fall back to CPU inference.

## Validation

- `git diff --check`
- Confirmed the Dockerfile contains the architecture flag exactly once
- Confirmed the semicolon-separated CMake list remains a single argument when passed through the existing `cmake-flags` command-substitution pattern

I did not run a full CUDA image build locally because that requires pulling the NVIDIA CUDA builder image and compiling llama.cpp; there does not appear to be a focused lightweight Dockerfile flag test in this repo.
