### PR TITLE
chore: migrate cagent-action to docker-agent-action (v2.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: docker/cagent-action@367a30ddb41e0156459d03750f508eac03f3c38a
+        uses: docker/docker-agent-action@3c0fa9d282c3f84d08dfd70ab0a28b151d11db70 # v2.0.0
         with:
           agent: .github/agents/release-notes-generator.yaml
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

`docker/cagent-action` has moved to a new repository: `docker/docker-agent-action`.
GitHub Actions `uses:` references must be updated explicitly, so this PR migrates all references and pins them to [v2.0.0](https://github.com/docker/docker-agent-action/releases/tag/v2.0.0).

- **New repository**: `docker/docker-agent-action`
- **Pinned commit**: `3c0fa9d282c3f84d08dfd70ab0a28b151d11db70`
- **Version**: `v2.0.0`

ℹ️ The old `docker/cagent-action` repo remains functional, so there is no deadline — merge whenever convenient. New features and fixes land in the new repo, which is where you'll want to be going forward.

> Auto-generated by the [migrate-consumers](https://github.com/docker/docker-agent-action/actions/runs/28023540082) workflow.