### PR TITLE
fix(cuda): add Pascal GPU architecture support to llama.cpp build

### DIFF
--- a/llamacpp/native/cuda.Dockerfile
+++ b/llamacpp/native/cuda.Dockerfile
@@ -24,6 +24,19 @@ RUN echo "gitdir: ../../.git/modules/llamacpp/native/vendor/llama.cpp" > vendor/
 
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
+
+# Assert CUDA 12.x — required for Pascal sm_61/sm_62 offline compilation.
+# The nvidia/cuda base image version is set by the CUDA_VERSION ARG above.
+RUN /usr/local/cuda/bin/nvcc --version | grep -q "release 12" || \
+    { echo "ERROR: CUDA 12.x is required for Pascal GPU support."; \
+      /usr/local/cuda/bin/nvcc --version; exit 1; }
+
+# Explicitly list target CUDA architectures to include Pascal (sm_61, sm_62).
+# CMake's CUDA_ARCHITECTURES defaults on CUDA 12.9+ omit pre-Turing architectures,
+# causing "no compatible GPU found" on GTX 10-series, P40, and similar Pascal GPUs.
+#
+# The list includes only architectures supported by the CUDA 12.x toolchain.
+# CUDA 13+ drops pre-sm_75 support — stay on CUDA 12.x for Pascal compatibility.
 RUN echo "-B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
@@ -32,6 +45,7 @@ RUN echo "-B build \
     -DGGML_NATIVE=OFF \
     -DGGML_OPENMP=OFF \
     -DGGML_CUDA=ON \
+    -DCMAKE_CUDA_ARCHITECTURES=61;62;70;75;80;86;89 \
     -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
     -DLLAMA_OPENSSL=OFF \
     -GNinja \


### PR DESCRIPTION
## Description

Add explicit `CMAKE_CUDA_ARCHITECTURES` to the llama.cpp CUDA build to include Pascal (sm_61, sm_62) GPU support.

Without this flag, CMake's CUDA architecture defaults on CUDA 12.9+ omit pre-Turing architectures, causing `no compatible GPU found` errors on GTX 10-series (1080, 1080 Ti, 1070, 1060), Tesla P40, and other Pascal GPUs.

CUDA 12.x fully supports offline compilation of these architectures — the limitation is only in CMake's default target list, not in nvcc capability.

## Changes

- **`llamacpp/native/cuda.Dockerfile`**: Added `-DCMAKE_CUDA_ARCHITECTURES=61;62;70;75;80;86;89` to the cmake flags, with a comment documenting why explicit architectures are needed and the CUDA version constraint for Pascal support.

## Background

- Closes #929
- Builds on the approach from #970 with added documentation explaining the non-obvious architecture constraints.
- CUDA 13+ drops offline compilation for pre-sm_75 targets, so the CUDA 12.x base image must be retained for Pascal compatibility.

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>