### PR TITLE
fix(registry): preserve mirror URL path prefix when resolving/pulling backend images

### DIFF
--- a/pkg/internal/dockerhub/download_test.go
+++ b/pkg/internal/dockerhub/download_test.go
@@ -79,6 +79,63 @@ func TestResolveDigest_UsesMirror(t *testing.T) {
 	}
 }
 
+// TestResolveDigest_UsesMirrorPathPrefix verifies that a mirror configured with
+// a path prefix (e.g. a JFrog Artifactory repository path) has its manifest
+// lookups routed under that prefix, not the host root. Before the path-preserving
+// fix in registryutil.RegistryHosts, the resolver queried <host>/v2/... and
+// missed the mirror entirely, falling back to registry-1.docker.io.
+func TestResolveDigest_UsesMirrorPathPrefix(t *testing.T) {
+	const (
+		wantDigest = "sha256:af91915100000000000000000000000000000000000000000000000000abcdef"
+		prefix     = "/artifactory/docker"
+		tag        = "latest-cuda"
+	)
+
+	var manifestUnderPrefix atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only serve the registry API under the configured path prefix; a request
+		// at the host root (e.g. /v2/...) is a miss, mimicking an Artifactory
+		// whose Docker endpoint lives under a repository path.
+		if !strings.HasPrefix(r.URL.Path, prefix+"/v2") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/manifests/"+tag) {
+			manifestUnderPrefix.Store(true)
+			w.Header().Set("Docker-Content-Digest", wantDigest)
+			w.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+			body := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+			return
+		}
+		// API version probe under the prefix.
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	ref := "registry-1.docker.io/docker/docker-model-backend-llamacpp:" + tag
+	got, err := ResolveDigest(ctx, ref, []string{srv.URL + prefix})
+	if err != nil {
+		t.Fatalf("ResolveDigest returned error: %v", err)
+	}
+	if got != wantDigest {
+		t.Fatalf("digest mismatch: got %q want %q", got, wantDigest)
+	}
+	if !manifestUnderPrefix.Load() {
+		t.Fatalf("expected manifest request under %q, mirror path prefix was not honored", prefix+"/v2")
+	}
+}
+
 // TestResolveDigest_CanceledContext verifies the resolver does not block when
 // the context is already canceled. This protects against silent stalls when
 // the network path to the upstream/mirror is blackholed (a frequent symptom

--- a/pkg/internal/registryutil/mirrors.go
+++ b/pkg/internal/registryutil/mirrors.go
@@ -55,8 +55,12 @@ func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.
 			// Preserve any path prefix on the mirror (e.g. a JFrog Artifactory
 			// repository path "/artifactory/api/docker/<repo>") and append the
 			// Registry v2 API root. Without this, a mirror configured with a path
-			// would be queried at the host root and fail.
-			path := strings.TrimRight(u.Path, "/") + "/v2"
+			// would be queried at the host root and fail. A "/v2" suffix already
+			// present on the configured mirror is kept as-is rather than doubled.
+			path := strings.TrimRight(u.Path, "/")
+			if !strings.HasSuffix(path, "/v2") {
+				path += "/v2"
+			}
 			hosts = append(hosts, docker.RegistryHost{
 				Client:       mirrorClient,
 				Authorizer:   authorizer,

--- a/pkg/internal/registryutil/mirrors.go
+++ b/pkg/internal/registryutil/mirrors.go
@@ -35,37 +35,15 @@ func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.
 		}
 		var hosts []docker.RegistryHost
 		for _, mirror := range mirrors {
-			// A mirror may be given without a scheme (e.g. "host:5000/path" or
-			// "127.0.0.1:5000"). url.Parse mishandles those — an IP:port errors
-			// on the colon, a host:port is parsed as scheme:opaque — so default
-			// to https before parsing when no scheme is present.
-			raw := mirror
-			if !strings.Contains(raw, "://") {
-				raw = "https://" + raw
-			}
-			u, err := url.Parse(raw)
-			if err != nil {
-				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
+			host, scheme, path, ok := parseMirror(mirror)
+			if !ok {
 				continue
-			}
-			if u.Host == "" {
-				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", "empty host")
-				continue
-			}
-			// Preserve any path prefix on the mirror (e.g. a JFrog Artifactory
-			// repository path "/artifactory/api/docker/<repo>") and append the
-			// Registry v2 API root. Without this, a mirror configured with a path
-			// would be queried at the host root and fail. A "/v2" suffix already
-			// present on the configured mirror is kept as-is rather than doubled.
-			path := strings.TrimRight(u.Path, "/")
-			if !strings.HasSuffix(path, "/v2") {
-				path += "/v2"
 			}
 			hosts = append(hosts, docker.RegistryHost{
 				Client:       mirrorClient,
 				Authorizer:   authorizer,
-				Host:         u.Host,
-				Scheme:       u.Scheme,
+				Host:         host,
+				Scheme:       scheme,
 				Path:         path,
 				Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
 			})
@@ -76,4 +54,40 @@ func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.
 		}
 		return append(hosts, upstream...), nil
 	}
+}
+
+// parseMirror normalizes a configured mirror string into the host, scheme and
+// Registry v2 API base path used to build a docker.RegistryHost. It returns
+// ok=false (after logging a warning) for a mirror that does not parse or has no
+// host, so the caller can skip it.
+//
+// Normalization rules:
+//   - A mirror without a scheme (e.g. "host:5000/path" or "127.0.0.1:5000")
+//     defaults to https. The scheme is prepended before parsing because
+//     url.Parse mishandles scheme-less inputs — an IP:port errors on the colon,
+//     a host:port is parsed as scheme:opaque.
+//   - Any path prefix is preserved (e.g. a JFrog Artifactory repository path
+//     "/artifactory/api/docker/<repo>"); without this a mirror with a path would
+//     be queried at the host root and fail.
+//   - "/v2" is appended unless the configured path already ends with it, so the
+//     suffix is never doubled.
+func parseMirror(mirror string) (host, scheme, path string, ok bool) {
+	raw := mirror
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
+		return "", "", "", false
+	}
+	if u.Host == "" {
+		slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", "empty host")
+		return "", "", "", false
+	}
+	path = strings.TrimRight(u.Path, "/")
+	if !strings.HasSuffix(path, "/v2") {
+		path += "/v2"
+	}
+	return u.Host, u.Scheme, path, true
 }

--- a/pkg/internal/registryutil/mirrors.go
+++ b/pkg/internal/registryutil/mirrors.go
@@ -35,20 +35,22 @@ func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.
 		}
 		var hosts []docker.RegistryHost
 		for _, mirror := range mirrors {
-			u, err := url.Parse(mirror)
+			// A mirror may be given without a scheme (e.g. "host:5000/path" or
+			// "127.0.0.1:5000"). url.Parse mishandles those — an IP:port errors
+			// on the colon, a host:port is parsed as scheme:opaque — so default
+			// to https before parsing when no scheme is present.
+			raw := mirror
+			if !strings.Contains(raw, "://") {
+				raw = "https://" + raw
+			}
+			u, err := url.Parse(raw)
 			if err != nil {
 				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
 				continue
 			}
-			// A mirror given without a scheme (e.g. "host:5000/path") parses with
-			// an empty Host and the whole value in Path. Re-parse it as https so
-			// the host and any path prefix are separated correctly.
 			if u.Host == "" {
-				u, err = url.Parse("https://" + mirror)
-				if err != nil {
-					slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
-					continue
-				}
+				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", "empty host")
+				continue
 			}
 			// Preserve any path prefix on the mirror (e.g. a JFrog Artifactory
 			// repository path "/artifactory/api/docker/<repo>") and append the

--- a/pkg/internal/registryutil/mirrors.go
+++ b/pkg/internal/registryutil/mirrors.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 )
@@ -39,18 +40,27 @@ func RegistryHosts(mirrors []string, authorizer docker.Authorizer, client *http.
 				slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
 				continue
 			}
-			mirrorHost := u.Host
-			scheme := u.Scheme
-			if mirrorHost == "" {
-				mirrorHost = mirror
-				scheme = "https"
+			// A mirror given without a scheme (e.g. "host:5000/path") parses with
+			// an empty Host and the whole value in Path. Re-parse it as https so
+			// the host and any path prefix are separated correctly.
+			if u.Host == "" {
+				u, err = url.Parse("https://" + mirror)
+				if err != nil {
+					slog.Warn("skipping invalid registry mirror", "mirror", mirror, "error", err)
+					continue
+				}
 			}
+			// Preserve any path prefix on the mirror (e.g. a JFrog Artifactory
+			// repository path "/artifactory/api/docker/<repo>") and append the
+			// Registry v2 API root. Without this, a mirror configured with a path
+			// would be queried at the host root and fail.
+			path := strings.TrimRight(u.Path, "/") + "/v2"
 			hosts = append(hosts, docker.RegistryHost{
 				Client:       mirrorClient,
 				Authorizer:   authorizer,
-				Host:         mirrorHost,
-				Scheme:       scheme,
-				Path:         "/v2",
+				Host:         u.Host,
+				Scheme:       u.Scheme,
+				Path:         path,
 				Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
 			})
 		}

--- a/pkg/internal/registryutil/mirrors_test.go
+++ b/pkg/internal/registryutil/mirrors_test.go
@@ -53,6 +53,20 @@ func TestRegistryHosts_PreservesMirrorPath(t *testing.T) {
 			wantPath:   "/v2",
 		},
 		{
+			name:       "existing v2 suffix not doubled",
+			mirror:     "https://mirror.example.com/artifactory/api/docker/repo/v2",
+			wantHost:   "mirror.example.com",
+			wantScheme: "https",
+			wantPath:   "/artifactory/api/docker/repo/v2",
+		},
+		{
+			name:       "existing v2 suffix with trailing slash",
+			mirror:     "https://mirror.example.com/v2/",
+			wantHost:   "mirror.example.com",
+			wantScheme: "https",
+			wantPath:   "/v2",
+		},
+		{
 			name:       "no scheme with path",
 			mirror:     "mirror.example.com/artifactory/docker",
 			wantHost:   "mirror.example.com",

--- a/pkg/internal/registryutil/mirrors_test.go
+++ b/pkg/internal/registryutil/mirrors_test.go
@@ -1,0 +1,124 @@
+package registryutil
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+)
+
+// hostsForDockerHub resolves the mirror hosts that apply to a Docker Hub
+// reference. It fails the test if RegistryHosts returns an error.
+func hostsForDockerHub(t *testing.T, mirrors []string) []docker.RegistryHost {
+	t.Helper()
+	authorizer := docker.NewDockerAuthorizer()
+	hosts, err := RegistryHosts(mirrors, authorizer, nil)("registry-1.docker.io")
+	if err != nil {
+		t.Fatalf("RegistryHosts returned error: %v", err)
+	}
+	return hosts
+}
+
+// TestRegistryHosts_PreservesMirrorPath verifies that a path prefix on the
+// mirror URL (e.g. a JFrog Artifactory repository path) is preserved and the
+// Registry v2 API root is appended to it, rather than the request being sent to
+// the host root. This is the path enterprise customers behind an Artifactory
+// mirror need.
+func TestRegistryHosts_PreservesMirrorPath(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mirror     string
+		wantHost   string
+		wantScheme string
+		wantPath   string
+	}{
+		{
+			name:       "path prefix preserved",
+			mirror:     "https://devopsartifactory.corp.lpl.com/artifactory/docker",
+			wantHost:   "devopsartifactory.corp.lpl.com",
+			wantScheme: "https",
+			wantPath:   "/artifactory/docker/v2",
+		},
+		{
+			name:       "trailing slash trimmed",
+			mirror:     "https://mirror.example.com/artifactory/docker/",
+			wantHost:   "mirror.example.com",
+			wantScheme: "https",
+			wantPath:   "/artifactory/docker/v2",
+		},
+		{
+			name:       "no path uses v2 root",
+			mirror:     "https://mirror.example.com",
+			wantHost:   "mirror.example.com",
+			wantScheme: "https",
+			wantPath:   "/v2",
+		},
+		{
+			name:       "no scheme with path",
+			mirror:     "mirror.example.com/artifactory/docker",
+			wantHost:   "mirror.example.com",
+			wantScheme: "https",
+			wantPath:   "/artifactory/docker/v2",
+		},
+		{
+			name:       "no scheme bare host",
+			mirror:     "mirror.example.com:5000",
+			wantHost:   "mirror.example.com:5000",
+			wantScheme: "https",
+			wantPath:   "/v2",
+		},
+		{
+			name:       "http scheme preserved",
+			mirror:     "http://mirror.internal/proxy/docker",
+			wantHost:   "mirror.internal",
+			wantScheme: "http",
+			wantPath:   "/proxy/docker/v2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hosts := hostsForDockerHub(t, []string{tc.mirror})
+			if len(hosts) == 0 {
+				t.Fatalf("expected at least the mirror host, got none")
+			}
+			// The mirror is always tried first, before the upstream fallback.
+			mirror := hosts[0]
+			if mirror.Host != tc.wantHost {
+				t.Errorf("Host: got %q want %q", mirror.Host, tc.wantHost)
+			}
+			if mirror.Scheme != tc.wantScheme {
+				t.Errorf("Scheme: got %q want %q", mirror.Scheme, tc.wantScheme)
+			}
+			if mirror.Path != tc.wantPath {
+				t.Errorf("Path: got %q want %q", mirror.Path, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestRegistryHosts_AppendsUpstreamFallback verifies the upstream registry is
+// still appended after the mirror, so a mirror miss falls through to
+// registry-1.docker.io.
+func TestRegistryHosts_AppendsUpstreamFallback(t *testing.T) {
+	hosts := hostsForDockerHub(t, []string{"https://mirror.example.com/artifactory/docker"})
+	if len(hosts) < 2 {
+		t.Fatalf("expected mirror + upstream, got %d host(s)", len(hosts))
+	}
+	last := hosts[len(hosts)-1]
+	if last.Host != "registry-1.docker.io" {
+		t.Errorf("expected upstream fallback registry-1.docker.io, got %q", last.Host)
+	}
+}
+
+// TestRegistryHosts_NonDockerHubBypassesMirror verifies mirrors are only applied
+// to Docker Hub references; other registries use the default configuration.
+func TestRegistryHosts_NonDockerHubBypassesMirror(t *testing.T) {
+	authorizer := docker.NewDockerAuthorizer()
+	hosts, err := RegistryHosts([]string{"https://mirror.example.com/artifactory/docker"}, authorizer, nil)("ghcr.io")
+	if err != nil {
+		t.Fatalf("RegistryHosts returned error: %v", err)
+	}
+	for _, h := range hosts {
+		if h.Host == "mirror.example.com" {
+			t.Fatalf("mirror should not be applied to non-Docker-Hub host ghcr.io")
+		}
+	}
+}

--- a/pkg/internal/registryutil/mirrors_test.go
+++ b/pkg/internal/registryutil/mirrors_test.go
@@ -67,6 +67,20 @@ func TestRegistryHosts_PreservesMirrorPath(t *testing.T) {
 			wantPath:   "/v2",
 		},
 		{
+			name:       "no scheme IP with port",
+			mirror:     "127.0.0.1:5000",
+			wantHost:   "127.0.0.1:5000",
+			wantScheme: "https",
+			wantPath:   "/v2",
+		},
+		{
+			name:       "no scheme IP with port and path",
+			mirror:     "127.0.0.1:5000/artifactory/docker",
+			wantHost:   "127.0.0.1:5000",
+			wantScheme: "https",
+			wantPath:   "/artifactory/docker/v2",
+		},
+		{
 			name:       "http scheme preserved",
 			mirror:     "http://mirror.internal/proxy/docker",
 			wantHost:   "mirror.internal",


### PR DESCRIPTION
## Context

Follow-up to #974, which routed the llama.cpp backend tag→digest resolution through the mirror-aware containerd resolver. While diagnosing [CSESC-1468](https://docker.atlassian.net/browse/CSESC-1468) on the latest logs, the backend pull still failed with a `403 Forbidden` HEAD to `registry-1.docker.io`, even though the mirror was configured and active.

Root cause: `registryutil.RegistryHosts` **dropped the path component** of the configured mirror URL and hardcoded the Registry v2 API root to `/v2` on the bare host. A mirror served under a path prefix — notably a JFrog Artifactory repository path like `/artifactory/api/docker/<repo>` — was therefore queried at the host root (`<host>/v2/...`), missed, and the resolver fell through to the upstream `registry-1.docker.io`, which 403s behind the corporate proxy. The upstream 403 masked the real (silent) mirror miss.

This is independent of #974 and affects **both** code paths that build hosts via `RegistryHosts`: tag resolution (`ResolveDigest`) and the image pull (`PullPlatform`).

## Changes

- **Preserve the mirror path** — `RegistryHosts` now builds `Path = strings.TrimRight(u.Path, "/") + "/v2"` instead of forcing `/v2` on the bare host. A mirror `https://host/artifactory/api/docker/<repo>` now resolves manifests at `https://host/artifactory/api/docker/<repo>/v2/<name>/manifests/<ref>`.
- **Robust scheme-less parsing** — a mirror given without a scheme (e.g. `host:5000/path`) parses with an empty `Host` and the whole value in `Path`; re-parse it as `https://…` so host and path are separated correctly (the previous code put the entire string into `Host`).
- Mirrors with no path keep the prior `/v2` behavior.

## Tests

- `pkg/internal/registryutil/mirrors_test.go` (new) — table-driven coverage of the resulting `Host`/`Scheme`/`Path` across mirror forms (path prefix, trailing slash, no path, scheme-less with/without path, `http` scheme), plus the upstream fallback ordering and the non-Docker-Hub bypass.
- `pkg/internal/dockerhub/download_test.go` — `TestResolveDigest_UsesMirrorPathPrefix`: an `httptest` registry that serves **only** under `/artifactory/docker/v2` (404 at the host root), so it fails if the path-preserving behavior regresses.

## Verification

- `go build ./...`, `go vet ./pkg/internal/registryutil/... ./pkg/internal/dockerhub/...`
- `go test ./pkg/internal/registryutil/... ./pkg/internal/dockerhub/...` (goleak clean)

## Note

This fix is necessary but not sufficient on its own for the CSESC-1468 customer: they still need to identify the exact URL at which their Artifactory exposes a compatible Docker Registry v2 API (their `/artifactory/docker/v2/` returned 404). Once that base URL is configured as the mirror, this change ensures Model Runner honors its path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CSESC-1468]: https://docker.atlassian.net/browse/CSESC-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ