### PR TITLE
Rewrite dmr as a standalone, engine-independent binary

### DIFF
--- a/.github/workflows/release-dmr.yml
+++ b/.github/workflows/release-dmr.yml
@@ -1,0 +1,179 @@
+name: Release dmr
+
+# Builds the standalone dmr binary for macOS (arm64), Linux (amd64/arm64),
+# and Windows (amd64), publishes a GitHub Release with the archives, then
+# opens the corresponding Homebrew formula and WinGet manifest updates so
+# `brew install docker/tap/dmr` and `winget install Docker.dmr` pick up the
+# new version.
+#
+# Triggered by pushing a tag of the form dmr-vX.Y.Z (kept distinct from the
+# model-runner container image release tags used by release.yml).
+
+on:
+  push:
+    tags:
+      - "dmr-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release, e.g. dmr-v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  build:
+    name: Build all targets
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      # Full history (incl. tags) so that `make build-dmr-cross`'s `git
+      # describe --match 'dmr-v*'` resolves DMR_VERSION to the exact tag
+      # being released here — the same version derivation used by
+      # `make build-dmr` for local/dev builds, kept as a single source of
+      # truth instead of re-encoding build flags in this workflow.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Cross-compile dmr
+        run: make build-dmr-cross
+
+      - name: Package archives
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          for dir in dist/dmr/*/; do
+            target=$(basename "$dir")
+            if [ -f "${dir}dmr.exe" ]; then
+              (cd "$dir" && zip "$OLDPWD/dist/release/dmr-${target}.zip" dmr.exe)
+            else
+              tar czf "dist/release/dmr-${target}.tar.gz" -C "$dir" dmr
+            fi
+          done
+
+      - id: version
+        run: echo "version=${TAG#dmr-v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dmr-archives
+          path: dist/release/*
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dmr-archives
+          path: dist
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: "dmr ${{ needs.build.outputs.version }}"
+          files: dist/*
+          generate_release_notes: true
+
+  publish-homebrew:
+    name: Publish Homebrew formula
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute release checksums
+        id: sha
+        run: |
+          set -euo pipefail
+          for target in darwin-arm64 linux-amd64 linux-arm64; do
+            curl -sL -o "${target}.tar.gz" \
+              "https://github.com/${{ github.repository }}/releases/download/${TAG}/dmr-${target}.tar.gz"
+            sum=$(sha256sum "${target}.tar.gz" | cut -d' ' -f1)
+            echo "${target//-/_}=${sum}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Generate formula
+        run: |
+          set -euo pipefail
+          mkdir -p formula
+          cat > formula/dmr.rb <<RUBY
+          class Dmr < Formula
+            desc "Standalone Docker Model Runner — run local models with no Docker Desktop required"
+            homepage "https://github.com/${{ github.repository }}"
+            version "${{ needs.release.outputs.version }}"
+            license "Apache-2.0"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/${{ github.repository }}/releases/download/${TAG}/dmr-darwin-arm64.tar.gz"
+                sha256 "${{ steps.sha.outputs.darwin_arm64 }}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "https://github.com/${{ github.repository }}/releases/download/${TAG}/dmr-linux-amd64.tar.gz"
+                sha256 "${{ steps.sha.outputs.linux_amd64 }}"
+              end
+              on_arm do
+                url "https://github.com/${{ github.repository }}/releases/download/${TAG}/dmr-linux-arm64.tar.gz"
+                sha256 "${{ steps.sha.outputs.linux_arm64 }}"
+              end
+            end
+
+            def install
+              bin.install "dmr"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/dmr version")
+            end
+          end
+          RUBY
+
+      - name: Open pull request against docker/homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="dmr-${{ needs.release.outputs.version }}"
+          gh repo clone docker/homebrew-tap tap -- --depth=1
+          cp formula/dmr.rb tap/Formula/dmr.rb
+          cd tap
+          git checkout -b "$branch"
+          git -c user.name="docker-tools-robot" -c user.email="docker-tools-robot@users.noreply.github.com" \
+            commit -am "dmr ${{ needs.release.outputs.version }}"
+          git push origin "$branch"
+          gh pr create --repo docker/homebrew-tap \
+            --title "dmr ${{ needs.release.outputs.version }}" \
+            --body "Automated formula update for dmr ${{ needs.release.outputs.version }}."
+
+  publish-winget:
+    name: Publish WinGet manifest
+    needs: release
+    runs-on: windows-latest
+    steps:
+      - name: Install wingetcreate
+        run: winget install wingetcreate --accept-source-agreements --accept-package-agreements
+
+      - name: Submit manifest to microsoft/winget-pkgs
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_GH_KEY }}
+        run: |
+          $Version = "${{ needs.release.outputs.version }}"
+          $Url = "https://github.com/${{ github.repository }}/releases/download/$env:TAG/dmr-windows-amd64.zip"
+          wingetcreate update Docker.dmr -s -v $Version -u $Url

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 model-runner
 model-runner.sock
 docker-model
-dmr
+/dmr
+dist/dmr/
 # Directory where we store the updated llama.cpp
 updated-inference/
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ DOCKER_BUILD_COMMON_ARGS = \
 	-t $(DOCKER_IMAGE)
 
 # Phony targets grouped by category
-.PHONY: build build-cli build-dmr build-llamacpp install-cli run clean test integration-tests e2e
+.PHONY: build build-cli build-dmr build-dmr-cross build-llamacpp install-cli run clean test integration-tests e2e
 .PHONY: validate validate-versions validate-all lint help
 .PHONY: docker-build docker-build-multiplatform docker-run docker-run-impl
 .PHONY: docker-build-vllm docker-run-vllm docker-build-vllm-rocm docker-run-vllm-rocm docker-build-sglang docker-run-sglang
@@ -60,8 +60,31 @@ build-server:
 build-cli:
 	$(MAKE) -C cmd/cli
 
+DMR_VERSION := $(shell git describe --tags --always --dirty --match 'dmr-v*' | sed 's/^dmr-//')
+DMR_LDFLAGS := -s -w \
+	-X main.Version=$(DMR_VERSION) \
+	-X github.com/docker/model-runner/cmd/cli/desktop.Version=$(DMR_VERSION)
+
+# build-dmr builds a native dmr binary. dmr has no cgo dependencies, so
+# CGO_ENABLED=0 keeps the binary statically linked and trivial to
+# cross-compile (see build-dmr-cross).
 build-dmr:
-	CGO_ENABLED=1 go build -ldflags="-s -w -X main.Version=$(shell git describe --tags --always --dirty --match 'v*')" -o dmr ./cmd/dmr
+	CGO_ENABLED=0 go build -ldflags="$(DMR_LDFLAGS)" -o dmr ./cmd/dmr
+
+# build-dmr-cross builds standalone dmr binaries for every platform we
+# publish packages for (see packaging/), into dist/dmr/<os>-<arch>/dmr.
+DMR_CROSS_TARGETS := darwin-arm64 linux-amd64 linux-arm64 windows-amd64
+
+build-dmr-cross:
+	@for target in $(DMR_CROSS_TARGETS); do \
+		os=$${target%-*}; arch=$${target#*-}; \
+		ext=""; [ "$$os" = "windows" ] && ext=".exe"; \
+		echo "Building dmr for $$os/$$arch..."; \
+		mkdir -p dist/dmr/$$target; \
+		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -trimpath \
+			-ldflags="$(DMR_LDFLAGS)" \
+			-o dist/dmr/$$target/dmr$$ext ./cmd/dmr; \
+	done
 
 build-llamacpp:
 	git submodule update --init llamacpp/native
@@ -410,6 +433,7 @@ help:
 	@echo "  build				- Build server, CLI plugin, and dmr wrapper (default)"
 	@echo "  build-server			- Build the model-runner server"
 	@echo "  build-cli			- Build the CLI (docker-model plugin)"
+	@echo "  build-dmr-cross		- Cross-compile dmr for all published platforms into dist/dmr/"
 	@echo "  install-cli			- Build and install the CLI as a Docker plugin"
 	@echo "  docs				- Generate CLI documentation"
 	@echo "  run				- Run the application locally"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker Model Runner (DMR) makes it easy to manage, run, and deploy AI models usi
 
 ## Overview
 
-This package supports the Docker Model Runner in Docker Desktop and Docker Engine.
+This package supports the Docker Model Runner in Docker Desktop, Docker Engine, and as the standalone `dmr` binary (no Docker installation required — see [Standalone (dmr)](#standalone-dmr) below).
 
 ### Installation
 
@@ -27,6 +27,37 @@ sudo usermod -aG docker $USER # give user permission to access docker daemon, re
 ```
 
 Docker Model Runner is included in Docker Engine when installed from Docker's official repositories.
+
+### Standalone (dmr)
+
+If you don't want to install Docker Desktop or Docker Engine at all, `dmr`
+is a single self-contained binary that bundles both the inference daemon and
+the full model management CLI (`run`, `ls`, `pull`, `rm`, `ps`, ...). It has
+no dependency on Docker Desktop or a running Docker Engine.
+
+```bash
+# macOS (arm64)
+brew install docker/tap/dmr
+
+# Windows (amd64)
+winget install Docker.dmr
+```
+
+Linux users can download a prebuilt archive from the
+[latest `dmr-v*` release](https://github.com/docker/model-runner/releases)
+or build it from source (see [`cmd/dmr`](./cmd/dmr)):
+
+```bash
+make build-dmr
+./dmr serve &      # start the daemon
+./dmr pull ai/gemma3
+./dmr run ai/gemma3 "Hello"
+```
+
+`dmr serve` listens on TCP port `12434` by default (see `dmr serve --help`
+for `--port`/`--socket`/`--models-path`), and the bundled CLI talks to it
+there automatically. Point any dmr command at a different daemon with
+`MODEL_RUNNER_HOST` (or `--host`), exactly as with `docker model`.
 
 ### Verifying Your Installation
 

--- a/cmd/dmr/README.md
+++ b/cmd/dmr/README.md
@@ -1,0 +1,48 @@
+# dmr
+
+`dmr` is the standalone Docker Model Runner: a single binary that bundles
+both the inference daemon and the full model management CLI, with **no
+dependency on Docker Desktop or a running Docker Engine**.
+
+```
+dmr serve              # start the daemon (foreground)
+dmr pull ai/gemma3     # pull a model
+dmr run ai/gemma3 "Hi" # run it
+dmr ls                 # list local models
+dmr ps                 # list running models
+dmr rm ai/gemma3       # remove a local model
+```
+
+## How it fits together
+
+- `dmr serve` runs [`pkg/server`](../../pkg/server) directly, in-process —
+  the same daemon used by the `docker-model-runner` container and by Docker
+  Desktop's bundled runner. It listens on TCP port `12434` by default (or a
+  Unix socket via `--socket`); see `dmr serve --help`.
+- Every other `dmr` subcommand is the same command tree as the `docker
+  model` CLI plugin ([`cmd/cli/commands`](../cli/commands)), so it has full
+  feature parity (`run`, `pull`, `push`, `tag`, `inspect`, `logs`, `bench`,
+  `configure`, ...). See [`cmd/cli/README.md`](../cli/README.md) for full
+  command documentation.
+- `dmr` always talks to its daemon over `MODEL_RUNNER_HOST` (default
+  `http://localhost:12434`), which forces the "manual host" code path in
+  [`cmd/cli/desktop/context.go`](../cli/desktop/context.go). This is what
+  makes `dmr` engine-independent: unlike `docker model`, it never probes a
+  Docker Engine connection or checks for Docker Desktop.
+- Docker-Engine-only commands that manage a `docker-model-runner`
+  *container* (`install-runner`, `start-runner`, `stop-runner`,
+  `restart-runner`, `reinstall-runner`, `uninstall-runner`) are hidden from
+  `dmr`, since `dmr serve` replaces them — there's no container to manage.
+
+## Building
+
+```
+make build-dmr         # native build, output ./dmr
+make build-dmr-cross   # cross-compile every published target into dist/dmr/<os>-<arch>/
+```
+
+`dmr` has no cgo dependencies, so it cross-compiles cleanly for macOS
+(arm64), Linux (amd64/arm64), and Windows (amd64) from any host. See
+[`../../packaging/README.md`](../../packaging/README.md) for how these
+builds are released via Homebrew (`brew install docker/tap/dmr`) and WinGet
+(`winget install Docker.dmr`).

--- a/cmd/dmr/main.go
+++ b/cmd/dmr/main.go
@@ -1,69 +1,24 @@
-// Command dmr is the unified Docker Model Runner daemon and client.
+// Command dmr is the standalone Docker Model Runner: a single binary that
+// bundles both the inference daemon ("dmr serve") and the full model
+// management CLI (run, ls, pull, rm, ps, ...) used to talk to it.
+//
+// dmr has no dependency on Docker Desktop or a running Docker Engine: the
+// daemon is a plain HTTP process, and the CLI always talks to it directly
+// over MODEL_RUNNER_HOST (see root.go). This makes dmr suitable for use on
+// any macOS or Linux host, with or without Docker installed.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/docker/cli/cli/command"
-	"github.com/docker/model-runner/cmd/cli/commands"
-	"github.com/docker/model-runner/pkg/server"
-	"github.com/spf13/cobra"
 )
 
+// Version is set at build time via -ldflags "-X main.Version=...".
 var Version = "dev"
-
-const defaultHost = "http://localhost:12434"
-const defaultPort = "12434"
 
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
-	}
-}
-
-func run() error {
-	cli, err := command.NewDockerCli()
-	if err != nil {
-		return fmt.Errorf("unable to initialize CLI: %w", err)
-	}
-
-	root := commands.NewRootCmd(cli)
-	root.Use = "dmr"
-	root.Short = "Docker Model Runner"
-
-	if os.Getenv("MODEL_RUNNER_HOST") == "" {
-		if err := os.Setenv("MODEL_RUNNER_HOST", defaultHost); err != nil {
-			return fmt.Errorf("unable to set MODEL_RUNNER_HOST: %w", err)
-		}
-	}
-
-	root.AddCommand(newServeCmd())
-
-	return root.Execute()
-}
-
-func newServeCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "serve",
-		Short: "Start the Docker Model Runner daemon",
-		// skip Docker CLI init; serve runs the daemon directly
-		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if os.Getenv("MODEL_RUNNER_PORT") == "" {
-				if err := os.Setenv("MODEL_RUNNER_PORT", defaultPort); err != nil {
-					return fmt.Errorf("unable to set MODEL_RUNNER_PORT: %w", err)
-				}
-			}
-
-			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-			defer cancel()
-
-			return server.Run(ctx, server.Config{Version: Version})
-		},
 	}
 }

--- a/cmd/dmr/root.go
+++ b/cmd/dmr/root.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/model-runner/cmd/cli/commands"
+	"github.com/spf13/cobra"
+)
+
+// defaultHost is the address dmr's client commands talk to by default: the
+// daemon started locally via "dmr serve".
+const defaultHost = "http://localhost:12434"
+
+// run assembles the dmr root command and executes it. It always forces
+// MODEL_RUNNER_HOST to a local address before building the command tree so
+// that command execution takes the "manual host" path
+// (ModelRunnerEngineKindMobyManual) in cmd/cli/desktop/context.go and never
+// probes for a Docker Desktop installation or a Docker Engine connection.
+func run() error {
+	if os.Getenv("MODEL_RUNNER_HOST") == "" {
+		if err := os.Setenv("MODEL_RUNNER_HOST", defaultHost); err != nil {
+			return fmt.Errorf("unable to set MODEL_RUNNER_HOST: %w", err)
+		}
+	}
+
+	// commands.NewRootCmd builds the full model management command tree
+	// (run, ls, pull, rm, ps, inspect, logs, ...) shared with the "docker
+	// model" CLI plugin. It requires a *command.DockerCli for historical
+	// reasons, but NewDockerCli only sets up local state (I/O streams,
+	// ~/.docker/config.json) — it never dials a Docker Engine, so this
+	// remains fully standalone.
+	cli, err := command.NewDockerCli()
+	if err != nil {
+		return fmt.Errorf("unable to initialize CLI: %w", err)
+	}
+
+	root := commands.NewRootCmd(cli)
+	root.Use = "dmr"
+	root.Short = "Docker Model Runner"
+	root.Long = `dmr is the standalone Docker Model Runner.
+
+It runs both the inference daemon ("dmr serve") and the client CLI used to
+manage and run models, with no dependency on Docker Desktop or a running
+Docker Engine.`
+	root.Version = Version
+
+	root.AddCommand(newServeCmd())
+	removeEngineOnlyCommands(root)
+
+	return root.Execute()
+}
+
+// engineOnlyCommands manage a Docker-Engine-hosted model-runner container
+// (pull the image, create/start/stop it, etc.). They don't apply to
+// standalone dmr, which runs the daemon in-process via "dmr serve" instead,
+// so they're removed from the command tree to avoid confusion.
+var engineOnlyCommands = []string{
+	"install-runner",
+	"uninstall-runner",
+	"start-runner",
+	"stop-runner",
+	"restart-runner",
+	"reinstall-runner",
+}
+
+func removeEngineOnlyCommands(root *cobra.Command) {
+	names := make(map[string]bool, len(engineOnlyCommands))
+	for _, name := range engineOnlyCommands {
+		names[name] = true
+	}
+
+	var toRemove []*cobra.Command
+	for _, cmd := range root.Commands() {
+		if names[cmd.Name()] {
+			toRemove = append(toRemove, cmd)
+		}
+	}
+	root.RemoveCommand(toRemove...)
+}

--- a/cmd/dmr/root_test.go
+++ b/cmd/dmr/root_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRemoveEngineOnlyCommands(t *testing.T) {
+	root := &cobra.Command{Use: "dmr"}
+	for _, name := range append([]string{"run", "ls", "serve"}, engineOnlyCommands...) {
+		root.AddCommand(&cobra.Command{Use: name})
+	}
+
+	removeEngineOnlyCommands(root)
+
+	remaining := make(map[string]bool)
+	for _, cmd := range root.Commands() {
+		remaining[cmd.Name()] = true
+	}
+
+	for _, name := range engineOnlyCommands {
+		if remaining[name] {
+			t.Errorf("expected engine-only command %q to be removed", name)
+		}
+	}
+
+	for _, name := range []string{"run", "ls", "serve"} {
+		if !remaining[name] {
+			t.Errorf("expected command %q to remain", name)
+		}
+	}
+}
+
+// TestServePersistentPreRunEOverridesParent locks in the cobra behavior that
+// newServeCmd() relies on: a child command's own PersistentPreRunE replaces
+// (rather than chains after) its parent's, so attaching "serve" — with its
+// no-op PersistentPreRunE — to the root command built by commands.NewRootCmd
+// is sufficient on its own to skip that root's Docker CLI plugin
+// initialization. See https://pkg.go.dev/github.com/spf13/cobra#Command,
+// "Persistent*Run functions will be inherited by children if they do not
+// declare their own."
+func TestServePersistentPreRunEOverridesParent(t *testing.T) {
+	var parentRan, childRan bool
+
+	root := &cobra.Command{
+		Use: "dmr",
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			parentRan = true
+			return nil
+		},
+	}
+
+	serve := newServeCmd()
+	// Swap out the real RunE (which starts the daemon) for a no-op so this
+	// stays a pure command-tree test.
+	serve.RunE = func(*cobra.Command, []string) error {
+		childRan = true
+		return nil
+	}
+	root.AddCommand(serve)
+
+	root.SetArgs([]string{"serve"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root.Execute() error = %v", err)
+	}
+
+	if parentRan {
+		t.Error("expected root's PersistentPreRunE NOT to run for \"serve\", but it did")
+	}
+	if !childRan {
+		t.Error("expected serve's RunE to run, but it didn't")
+	}
+}

--- a/cmd/dmr/serve.go
+++ b/cmd/dmr/serve.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/docker/model-runner/pkg/server"
+	"github.com/spf13/cobra"
+)
+
+// defaultPort is the TCP port the daemon listens on when neither --port,
+// --socket, MODEL_RUNNER_PORT, nor MODEL_RUNNER_SOCK is set. It matches
+// defaultHost above so that the bundled CLI can find a freshly started
+// daemon with zero configuration.
+const defaultPort = "12434"
+
+// serveOptions holds the flags exposed by "dmr serve". Each maps onto an
+// environment variable consumed by pkg/envconfig; flags take precedence
+// over any pre-existing environment variable.
+type serveOptions struct {
+	port       string
+	socket     string
+	modelsPath string
+}
+
+func newServeCmd() *cobra.Command {
+	var opts serveOptions
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Docker Model Runner daemon",
+		Long: `Start the Docker Model Runner daemon.
+
+The daemon manages the lifecycle of inference backends (llama.cpp, vLLM,
+SGLang, MLX, diffusers) and exposes an OpenAI-compatible HTTP API for
+listing, pulling, and running models. It requires no Docker Desktop or
+Docker Engine installation.
+
+By default it listens on TCP port 12434. Use --socket to listen on a Unix
+domain socket instead.`,
+		// "dmr serve" runs the daemon in-process; it must not go through the
+		// client-side Docker CLI plugin initialization used by every other
+		// dmr subcommand.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServe(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.port, "port", "", "TCP port to listen on (overrides MODEL_RUNNER_PORT; default 12434)")
+	cmd.Flags().StringVar(&opts.socket, "socket", "", "Unix domain socket to listen on instead of TCP (overrides MODEL_RUNNER_SOCK)")
+	cmd.Flags().StringVar(&opts.modelsPath, "models-path", "", "directory used to store pulled models (overrides MODELS_PATH)")
+	cmd.MarkFlagsMutuallyExclusive("port", "socket")
+
+	return cmd
+}
+
+func runServe(ctx context.Context, opts serveOptions) error {
+	if err := applyServeEnv(opts); err != nil {
+		return err
+	}
+
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	return server.Run(ctx, server.Config{Version: Version})
+}
+
+// applyServeEnv translates serve flags into the environment variables read
+// by pkg/envconfig, applying the standalone default TCP port when neither a
+// flag nor an environment variable already specifies a listener.
+//
+// pkg/server.Run prefers MODEL_RUNNER_PORT over MODEL_RUNNER_SOCK whenever
+// both are set, so an explicit --socket/--port flag must clear the other
+// variable rather than merely setting its own — otherwise a
+// MODEL_RUNNER_PORT inherited from the environment would silently override
+// an explicit --socket flag (--port and --socket are themselves mutually
+// exclusive as CLI flags; see MarkFlagsMutuallyExclusive in newServeCmd).
+func applyServeEnv(opts serveOptions) error {
+	switch {
+	case opts.socket != "":
+		if err := os.Unsetenv("MODEL_RUNNER_PORT"); err != nil {
+			return fmt.Errorf("unable to unset MODEL_RUNNER_PORT: %w", err)
+		}
+		if err := os.Setenv("MODEL_RUNNER_SOCK", opts.socket); err != nil {
+			return fmt.Errorf("unable to set MODEL_RUNNER_SOCK: %w", err)
+		}
+	case opts.port != "":
+		if err := os.Unsetenv("MODEL_RUNNER_SOCK"); err != nil {
+			return fmt.Errorf("unable to unset MODEL_RUNNER_SOCK: %w", err)
+		}
+		if err := os.Setenv("MODEL_RUNNER_PORT", opts.port); err != nil {
+			return fmt.Errorf("unable to set MODEL_RUNNER_PORT: %w", err)
+		}
+	case os.Getenv("MODEL_RUNNER_PORT") == "" && os.Getenv("MODEL_RUNNER_SOCK") == "":
+		if err := os.Setenv("MODEL_RUNNER_PORT", defaultPort); err != nil {
+			return fmt.Errorf("unable to set MODEL_RUNNER_PORT: %w", err)
+		}
+	}
+
+	if opts.modelsPath != "" {
+		if err := os.Setenv("MODELS_PATH", opts.modelsPath); err != nil {
+			return fmt.Errorf("unable to set MODELS_PATH: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/dmr/serve_test.go
+++ b/cmd/dmr/serve_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestApplyServeEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       serveOptions
+		presetEnv  map[string]string
+		wantPort   string
+		wantSocket string
+	}{
+		{
+			name:     "defaults to standalone TCP port when nothing is set",
+			opts:     serveOptions{},
+			wantPort: defaultPort,
+		},
+		{
+			name:     "explicit port flag wins",
+			opts:     serveOptions{port: "9999"},
+			wantPort: "9999",
+		},
+		{
+			name:       "explicit socket flag wins",
+			opts:       serveOptions{socket: "/tmp/dmr.sock"},
+			wantSocket: "/tmp/dmr.sock",
+		},
+		{
+			name:       "explicit socket flag clears an inherited MODEL_RUNNER_PORT",
+			opts:       serveOptions{socket: "/tmp/dmr.sock"},
+			presetEnv:  map[string]string{"MODEL_RUNNER_PORT": "12434"},
+			wantSocket: "/tmp/dmr.sock",
+		},
+		{
+			name:      "explicit port flag clears an inherited MODEL_RUNNER_SOCK",
+			opts:      serveOptions{port: "9999"},
+			presetEnv: map[string]string{"MODEL_RUNNER_SOCK": "/tmp/other.sock"},
+			wantPort:  "9999",
+		},
+		{
+			name:       "pre-existing MODEL_RUNNER_SOCK is left alone without flags",
+			opts:       serveOptions{},
+			presetEnv:  map[string]string{"MODEL_RUNNER_SOCK": "/tmp/other.sock"},
+			wantSocket: "/tmp/other.sock",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv both isolates these process-global variables between
+			// subtests and restores their prior value afterwards; an empty
+			// string is equivalent to "unset" for every reader involved here
+			// (os.Getenv, envconfig.Var).
+			for _, key := range []string{"MODEL_RUNNER_PORT", "MODEL_RUNNER_SOCK", "MODELS_PATH"} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tt.presetEnv {
+				t.Setenv(k, v)
+			}
+
+			if err := applyServeEnv(tt.opts); err != nil {
+				t.Fatalf("applyServeEnv() error = %v", err)
+			}
+
+			if got := os.Getenv("MODEL_RUNNER_PORT"); got != tt.wantPort {
+				t.Errorf("MODEL_RUNNER_PORT = %q, want %q", got, tt.wantPort)
+			}
+			if got := os.Getenv("MODEL_RUNNER_SOCK"); got != tt.wantSocket {
+				t.Errorf("MODEL_RUNNER_SOCK = %q, want %q", got, tt.wantSocket)
+			}
+		})
+	}
+}

--- a/cmd/dmr/testmain_test.go
+++ b/cmd/dmr/testmain_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs goleak after the test suite to detect goroutine leaks.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,45 @@
+# Packaging dmr
+
+The standalone `dmr` binary (see [`cmd/dmr`](../cmd/dmr)) is distributed via:
+
+- **Homebrew** — `brew install docker/tap/dmr` (macOS, arm64)
+- **WinGet** — `winget install Docker.dmr` (Windows, amd64)
+- **Direct download** — cross-compiled archives attached to each
+  [GitHub release](https://github.com/docker/model-runner/releases) tagged
+  `dmr-vX.Y.Z` (macOS arm64, Linux amd64/arm64, Windows amd64)
+
+There are no static package manifests checked into this repository: the
+[`release-dmr.yml`](../.github/workflows/release-dmr.yml) workflow builds the
+binaries, creates the GitHub release, generates the Homebrew formula and
+opens a PR against `docker/homebrew-tap`, and submits the WinGet manifest to
+`microsoft/winget-pkgs` via `wingetcreate`, all from the version being
+released. This mirrors the packaging approach used by
+[`docker/sandboxes`](https://github.com/docker/sandboxes)'s
+`publish-brew.yml`/`publish-winget.yml`.
+
+## Cutting a release
+
+```
+git tag dmr-v0.1.0
+git push origin dmr-v0.1.0
+```
+
+This triggers `release-dmr.yml`, which requires the following repository
+secrets:
+
+- `HOMEBREW_TAP_TOKEN` — token with push/PR access to `docker/homebrew-tap`
+- `WINGET_GH_KEY` — token used by `wingetcreate` to submit to
+  `microsoft/winget-pkgs`
+
+## Local cross-compilation
+
+```
+make build-dmr-cross
+```
+
+builds every published target into `dist/dmr/<os>-<arch>/dmr`. dmr has no
+cgo dependencies, so all targets cross-compile cleanly from any host.
+
+Linux `.deb`/`.rpm` packages continue to be produced by the existing
+`docker-model-plugin` packaging pipeline (see `.github/workflows/release.yml`)
+and are unaffected by this workflow.

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -99,12 +100,19 @@ func TCPPort() string {
 }
 
 // LlamaServerPath returns the path to the llama.cpp server binary.
-// Configured via LLAMA_SERVER_PATH; defaults to the Docker Desktop bundle location.
+// Configured via LLAMA_SERVER_PATH. On macOS this defaults to the Docker
+// Desktop bundle location as a last-resort lookup (Desktop vendors its own
+// copy there); on every other platform there is no meaningful default path
+// to check, and the daemon falls back to downloading the pinned llama.cpp
+// release on demand.
 func LlamaServerPath() string {
 	if s := Var("LLAMA_SERVER_PATH"); s != "" {
 		return s
 	}
-	return "/Applications/Docker.app/Contents/Resources/model-runner/bin"
+	if runtime.GOOS == "darwin" {
+		return "/Applications/Docker.app/Contents/Resources/model-runner/bin"
+	}
+	return ""
 }
 
 // LlamaArgs returns custom arguments to pass to the llama.cpp server.

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -1,0 +1,30 @@
+package envconfig_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/docker/model-runner/pkg/envconfig"
+)
+
+func TestLlamaServerPath(t *testing.T) {
+	t.Run("explicit override wins", func(t *testing.T) {
+		t.Setenv("LLAMA_SERVER_PATH", "/custom/path")
+		if got := envconfig.LlamaServerPath(); got != "/custom/path" {
+			t.Fatalf("LlamaServerPath() = %q, want %q", got, "/custom/path")
+		}
+	})
+
+	t.Run("default depends on platform", func(t *testing.T) {
+		t.Setenv("LLAMA_SERVER_PATH", "")
+		got := envconfig.LlamaServerPath()
+		if runtime.GOOS == "darwin" {
+			want := "/Applications/Docker.app/Contents/Resources/model-runner/bin"
+			if got != want {
+				t.Fatalf("LlamaServerPath() = %q, want %q", got, want)
+			}
+		} else if got != "" {
+			t.Fatalf("LlamaServerPath() = %q, want empty string on %s", got, runtime.GOOS)
+		}
+	})
+}

--- a/pkg/envconfig/testmain_test.go
+++ b/pkg/envconfig/testmain_test.go
@@ -1,0 +1,12 @@
+package envconfig_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs goleak after the test suite to detect goroutine leaks.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary

This rewrites `cmd/dmr` (previously a ~70-line hack combining the CLI command
tree with a bolted-on `serve` subcommand) into a small, documented,
genuinely standalone package, and adds the build/release plumbing needed to
distribute it outside this repo — laying the groundwork for adoption by
tools like sbx that
don't want a Docker Desktop or Docker Engine dependency.

### What changed

- **`cmd/dmr/root.go`** builds the full model management command tree
  (`run`, `ls`, `pull`, `rm`, `ps`, `inspect`, `logs`, ...) and always forces
  `MODEL_RUNNER_HOST` to the local daemon first. This guarantees every `dmr`
  invocation takes the "manual host" path in `cmd/cli/desktop/context.go`
  and never probes for Docker Desktop or a Docker Engine connection. A
  regression test (`TestServePersistentPreRunEOverridesParent`) locks in the
  cobra semantics this relies on: a child command's own `PersistentPreRunE`
  replaces, rather than chains after, its parent's.
- **`cmd/dmr/serve.go`** runs `pkg/server` in-process (the same daemon used
  by the `docker-model-runner` container and Docker Desktop's bundled
  runner), with `--port`/`--socket`/`--models-path` flags in addition to the
  existing env vars. `--port`/`--socket` are mutually exclusive
  (`MarkFlagsMutuallyExclusive`), and an explicit flag clears the *other*
  transport's environment variable first, since `pkg/server` prefers
  `MODEL_RUNNER_PORT` over `MODEL_RUNNER_SOCK` whenever both happen to be
  set — otherwise an inherited env var could silently override an explicit
  flag. Covered by `TestApplyServeEnv`.
- Docker-Engine-only commands that manage a `docker-model-runner`
  *container* (`install-runner`, `start-runner`, `stop-runner`,
  `restart-runner`, `reinstall-runner`, `uninstall-runner`) are now hidden
  from the `dmr` command tree — `dmr serve` replaces the container
  entirely, so these no longer apply and only added confusion.
- `pkg/envconfig.LlamaServerPath()` no longer defaults to the Docker Desktop
  bundle path on non-macOS platforms (that path can never exist there); it's
  now only checked as a last-resort lookup on macOS itself, where Desktop
  vendors its own copy.
- Confirmed `dmr` has zero cgo dependencies, so `make build-dmr` now builds
  with `CGO_ENABLED=0`, versioned from the `dmr-vX.Y.Z` tag scheme
  (`git describe --match 'dmr-v*'`, stripped of its prefix) rather than the
  container image's `v*` tags. A new `make build-dmr-cross` target
  cross-compiles it for every platform we intend to package: macOS
  (arm64), Linux (amd64/arm64), Windows (amd64) — all verified locally.
- Adds `.github/workflows/release-dmr.yml`: on a `dmr-vX.Y.Z` tag, the build
  job runs `make build-dmr-cross` directly (rather than re-encoding
  GOOS/GOARCH/ldflags in YAML, so there's a single source of truth for
  dmr's build flags), publishes a GitHub release, opens the Homebrew
  formula PR against `docker/homebrew-tap`, and submits the WinGet manifest
  to `microsoft/winget-pkgs` via `wingetcreate` — so `dmr` becomes
  installable via `brew install docker/tap/dmr` / `winget install Docker.dmr`
  on its own release cadence, independent of Docker Desktop's or Docker
  Engine's pipelines. Modeled on `docker/sandboxes`'s `publish-brew.yml` /
  `publish-winget.yml`.
- Documents all of the above in `README.md`, `cmd/dmr/README.md`, and the
  new `packaging/README.md`.

### Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `make lint` (`golangci-lint run ./...`) — 0 issues
- `go test -race ./...` — all packages pass, including new tests for
  `cmd/dmr` (`TestRemoveEngineOnlyCommands`,
  `TestServePersistentPreRunEOverridesParent`, `TestApplyServeEnv`) and
  `pkg/envconfig` (`LlamaServerPath` platform behavior)
- `go mod tidy` — no changes
- Manually ran `dmr serve --port 19434` with no Docker installed/running,
  confirmed `/models` responds and the daemon downloads llama.cpp from the
  registry on demand
- Cross-compiled and ran `dmr version`/`dmr --help` for all four target
  platforms (darwin/arm64, linux/amd64, linux/arm64, windows/amd64 build
  only, not run), and exercised the release workflow's packaging step
  locally against real `make build-dmr-cross` output
- Rebased on current `main` (no conflicts) and squashed to a single commit

### Not in scope here

Linux `.deb`/`.rpm` packaging is unaffected — it continues through the
existing `docker-model-plugin` pipeline referenced in `release.yml`.