### PR TITLE
ci(release-dmr): pin actions to commit SHAs, drop 3p release action

### DIFF
--- a/.github/workflows/release-dmr.yml
+++ b/.github/workflows/release-dmr.yml
@@ -38,11 +38,11 @@ jobs:
       # being released here — the same version derivation used by
       # `make build-dmr` for local/dev builds, kept as a single source of
       # truth instead of re-encoding build flags in this workflow.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
 
@@ -65,7 +65,7 @@ jobs:
       - id: version
         run: echo "version=${TAG#dmr-v}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dmr-archives
           path: dist/release/*
@@ -78,17 +78,21 @@ jobs:
     outputs:
       version: ${{ needs.build.outputs.version }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: dmr-archives
           path: dist
 
-      - uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.TAG }}
-          name: "dmr ${{ needs.build.outputs.version }}"
-          files: dist/*
-          generate_release_notes: true
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "dmr ${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            dist/*
 
   publish-homebrew:
     name: Publish Homebrew formula


### PR DESCRIPTION
## What

Pins the four GitHub Actions used by `release-dmr.yml` to the commit
SHAs already vetted/used elsewhere in this repo (`release.yml`,
`ci.yml`, `e2e-test.yml`, `integration-test.yml`), and replaces
`softprops/action-gh-release@v2` with a `gh release create` step
matching the pattern `release.yml` already uses for the model-runner
container image releases.

## Why

Pushing the `dmr-v0.1.0` tag to trigger the first standalone `dmr`
release failed immediately:

```
The actions actions/checkout@v4, actions/setup-go@v5, and
actions/upload-artifact@v4 are not allowed in docker/model-runner
because all actions must be pinned to a full-length commit SHA.
```

`release-dmr.yml` was added referencing floating major-version tags
and a third-party release action, neither of which comply with the
org's action-pinning policy that every other workflow in this repo
already follows. No new action pins are introduced here — each SHA
already appears in an existing, presumably-reviewed workflow.

## Testing

- `actionlint .github/workflows/release-dmr.yml` passes.
- Re-triggered the `dmr-v0.1.0` release via workflow_dispatch after
  this merges to confirm the workflow runs end-to-end (see linked run).