### PR TITLE
chore: bump llama.cpp verrsion for macOS and Windows

### DIFF
--- a/pkg/inference/backends/llamacpp/download.go
+++ b/pkg/inference/backends/llamacpp/download.go
@@ -33,7 +33,7 @@ const (
 	// with the Linux bundle (Dockerfile LLAMA_SERVER_VERSION) whenever llama.cpp
 	// is upgraded, so all platforms ship a consistent, tested build. Users can
 	// override it via LLAMA_SERVER_VERSION or `--llama-server-version`.
-	pinnedServerVersion = "v0.0.34"
+	pinnedServerVersion = "b9879"
 )
 
 var (


### PR DESCRIPTION
```
./dmr serve
```

```
$ ./dmr status
Docker Model Runner is running

BACKEND    STATUS         DETAILS
llama.cpp  Running        llama.cpp b9879-metal (sha256:b70706f473b4043ca3e0c32704a7fda3412b83bceef0564684187b8011230de8) 72874f5
diffusers  Not Installed
mlx        Not Installed  package not installed
sglang     Not Installed  only supported on Linux
vllm       Not Installed
```