### PR TITLE
Build dmr.exe on Windows in build-dmr target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,17 @@ DMR_LDFLAGS := -s -w \
 	-X main.Version=$(DMR_VERSION) \
 	-X github.com/docker/model-runner/cmd/cli/desktop.Version=$(DMR_VERSION)
 
+# Add .exe on windows, nothing elsewhere
+DMR_EXE := dmr
+ifeq ($(OS),Windows_NT)
+DMR_EXE := dmr.exe
+endif
+
 # build-dmr builds a native dmr binary. dmr has no cgo dependencies, so
 # CGO_ENABLED=0 keeps the binary statically linked and trivial to
 # cross-compile (see build-dmr-cross).
 build-dmr:
-	CGO_ENABLED=0 go build -ldflags="$(DMR_LDFLAGS)" -o dmr ./cmd/dmr
+	CGO_ENABLED=0 go build -ldflags="$(DMR_LDFLAGS)" -o $(DMR_EXE) ./cmd/dmr
 
 # build-dmr-cross builds standalone dmr binaries for every platform we
 # publish packages for (see packaging/), into dist/dmr/<os>-<arch>/dmr.
@@ -108,7 +114,7 @@ run: build
 # Clean build artifacts
 clean:
 	rm -f $(APP_NAME)
-	rm -f dmr
+	rm -f $(DMR_EXE)
 	rm -f model-runner.sock
 
 # Run tests

--- a/cmd/dmr/README.md
+++ b/cmd/dmr/README.md
@@ -37,7 +37,7 @@ dmr rm ai/gemma3       # remove a local model
 ## Building
 
 ```
-make build-dmr         # native build, output ./dmr
+make build-dmr         # native build, output ./dmr (or dmr.exe on Windows)
 make build-dmr-cross   # cross-compile every published target into dist/dmr/<os>-<arch>/
 ```
 


### PR DESCRIPTION
## Summary
- The build-dmr Makefile target always built a binary named "dmr",
  which is unusable on Windows because the OS requires a .exe suffix
  to execute it directly
- Detect Windows via the built-in `$(OS)` variable and use a
  `DMR_EXE` variable for the output filename, so the target produces
  `dmr.exe` on Windows and `dmr` everywhere else. This avoids
  shelling out to `go env GOEXE` on every invocation, which adds
  overhead and can fail if `go` is not on the PATH
- Reuse `DMR_EXE` in the `clean` target instead of hardcoding both
  `dmr` and `dmr.exe` so cleanup stays in sync with the build output
- Update the README to match

## Test plan
- `make validate-all` (go mod tidy, lint, tests w/ race detection, shellcheck) passes
- `make build-dmr` and `make clean` verified locally on macOS