### PR TITLE
ci(release): guard run-ID polling against transient gh failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,20 +528,35 @@ jobs:
           BEFORE_ID=$(gh run list \
             --repo docker/inference-engine-llama.cpp \
             --workflow release-cli-dd.yml \
-            --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+            --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo "")
+          case "$BEFORE_ID" in
+            ''|*[!0-9]*)
+              echo "::error::Could not read the pre-dispatch run ID for release-cli-dd.yml"
+              exit 1
+              ;;
+          esac
 
           gh workflow run release-cli-dd.yml \
             --repo docker/inference-engine-llama.cpp \
             -f model-cli-ref="$RELEASE_TAG" \
             -f tag="v$VERSION"
 
+          # Poll for the run WE just triggered: the first run whose ID exceeds
+          # BEFORE_ID. Tolerate transient `gh` failures mid-poll (empty or
+          # non-numeric CANDIDATE) by skipping the iteration — a flaky query
+          # must not abort the release on `integer expression expected`.
           RUN_ID=""
+          LAST_SEEN=""
           for _ in $(seq 1 30); do
             sleep 3
             CANDIDATE=$(gh run list \
               --repo docker/inference-engine-llama.cpp \
               --workflow release-cli-dd.yml \
-              --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+              --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo "")
+            case "$CANDIDATE" in
+              ''|*[!0-9]*) continue ;;
+            esac
+            LAST_SEEN="$CANDIDATE"
             if [ "$CANDIDATE" -gt "$BEFORE_ID" ]; then
               RUN_ID="$CANDIDATE"
               break
@@ -549,7 +564,7 @@ jobs:
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "::error::Failed to determine Desktop CLI release run ID"
+            echo "::error::Failed to determine Desktop CLI release run ID after ~90s (before=$BEFORE_ID, last seen=${LAST_SEEN:-none})"
             exit 1
           fi
 
@@ -596,19 +611,34 @@ jobs:
           BEFORE_ID=$(gh run list \
             --repo docker/packaging \
             --workflow release-model.yml \
-            --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+            --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo "")
+          case "$BEFORE_ID" in
+            ''|*[!0-9]*)
+              echo "::error::Could not read the pre-dispatch run ID for release-model.yml"
+              exit 1
+              ;;
+          esac
 
           gh workflow run release-model.yml \
             --repo docker/packaging \
             -f ref="$RELEASE_TAG"
 
+          # Poll for the run WE just triggered: the first run whose ID exceeds
+          # BEFORE_ID. Tolerate transient `gh` failures mid-poll (empty or
+          # non-numeric CANDIDATE) by skipping the iteration — a flaky query
+          # must not abort the release on `integer expression expected`.
           RUN_ID=""
+          LAST_SEEN=""
           for _ in $(seq 1 30); do
             sleep 3
             CANDIDATE=$(gh run list \
               --repo docker/packaging \
               --workflow release-model.yml \
-              --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+              --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo "")
+            case "$CANDIDATE" in
+              ''|*[!0-9]*) continue ;;
+            esac
+            LAST_SEEN="$CANDIDATE"
             if [ "$CANDIDATE" -gt "$BEFORE_ID" ]; then
               RUN_ID="$CANDIDATE"
               break
@@ -616,7 +646,7 @@ jobs:
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "::error::Failed to determine packaging workflow run ID"
+            echo "::error::Failed to determine packaging workflow run ID after ~90s (before=$BEFORE_ID, last seen=${LAST_SEEN:-none})"
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up to #1005, addressing the [Sourcery review](https://github.com/docker/model-runner/pull/1005) `bug_risk` comment.

## Problem

The monotonic run-ID polling loops added in #1005 compare `$CANDIDATE` numerically without validating it:

```bash
CANDIDATE=$(gh run list ... --jq '.[0].databaseId // 0')
if [ "$CANDIDATE" -gt "$BEFORE_ID" ]; then
```

The `// 0` only covers an empty result array. If `gh run list` itself fails transiently (network/auth) or returns an unexpected payload, `CANDIDATE` can be empty or non-numeric and `[ "$CANDIDATE" -gt "$BEFORE_ID" ]` errors with `integer expression expected` — the exact kind of transient flake this logic was meant to absorb.

## Changes

- **Tolerate transient `gh` failures mid-poll** (`2>/dev/null || echo ""`) and **skip** any iteration where `CANDIDATE` is empty/non-numeric, instead of erroring on the comparison.
- **Validate `BEFORE_ID` up front** and fail with a clear message *before* dispatch if it can't be read.
- **Richer failure message** — include before/last-seen IDs and the wait duration to ease race/misconfig diagnosis.

Applied to both trigger jobs: desktop (`release-cli-dd.yml`) and packaging (`release-model.yml`).

## Not included (noted for later)
Sourcery also suggested extracting the duplicated trigger-and-wait logic into a shared composite action/script. That's a larger refactor and left out of this focused fix.

Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)