### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/cmd/cli/commands/skills/docker-model-runner/references/docker-model-guide.md
+++ b/cmd/cli/commands/skills/docker-model-runner/references/docker-model-guide.md
@@ -177,7 +177,7 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
-> **Tip:** The same OpenAI Python client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not running Model Runner locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=model-runner&utm_content=openai) at `https://api.daoxe.com/v1`.
+> **Tip:** The same OpenAI Python client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not running Model Runner locally — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
 
 ### JavaScript/TypeScript
 

--- a/cmd/cli/commands/skills/docker-model-runner/references/docker-model-guide.md
+++ b/cmd/cli/commands/skills/docker-model-runner/references/docker-model-guide.md
@@ -177,6 +177,8 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
+> **Tip:** The same OpenAI Python client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not running Model Runner locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=model-runner&utm_content=openai) at `https://api.daoxe.com/v1`.
+
 ### JavaScript/TypeScript
 
 ```javascript


### PR DESCRIPTION
## Summary

Clarify that the OpenAI Python client `base_url` pattern works with OpenAI-compatible multi-model gateways when not using the default provider endpoint, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render
- [ ] Existing examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>