### PR TITLE
Allow llama.cpp reasoning preservation flags

### DIFF
--- a/pkg/inference/runtime_flags_allowlist.go
+++ b/pkg/inference/runtime_flags_allowlist.go
@@ -170,11 +170,13 @@ var LlamaCppAllowedFlags = map[string]bool{
 	"--chat-template":        true,
 	"--chat-template-kwargs": true,
 	"--jinja":                true, "--no-jinja": true,
-	"--pooling":              true,
-	"--reasoning-format":     true,
-	"--reasoning-budget":     true,
-	"--prefill-assistant":    true,
-	"--no-prefill-assistant": true,
+	"--pooling":               true,
+	"--reasoning-format":      true,
+	"--reasoning-budget":      true,
+	"--reasoning-preserve":    true,
+	"--no-reasoning-preserve": true,
+	"--prefill-assistant":     true,
+	"--no-prefill-assistant":  true,
 
 	// Web interface and API (safe flags only - no file paths)
 	"--api-prefix": true,

--- a/pkg/inference/runtime_flags_allowlist_test.go
+++ b/pkg/inference/runtime_flags_allowlist_test.go
@@ -161,6 +161,10 @@ func TestLlamaCppAllowedFlags_Categories(t *testing.T) {
 			"--embeddings", "--embedding", "--reranking", "--rerank",
 			"--metrics", "--no-metrics", "--jinja", "--no-jinja",
 		},
+		"reasoning": {
+			"--reasoning-format", "--reasoning-budget",
+			"--reasoning-preserve", "--no-reasoning-preserve",
+		},
 		"speculative": {
 			"--spec-draft-n-max", "--draft-n-max", "--draft-max", "--spec-draft-n-min", "--draft-n-min", "--draft-min",
 			"--spec-draft-p-min", "--draft-p-min",

--- a/pkg/inference/runtime_flags_test.go
+++ b/pkg/inference/runtime_flags_test.go
@@ -92,6 +92,13 @@ func TestValidateRuntimeFlags(t *testing.T) {
 			description: "Sampling flags should be allowed",
 		},
 		{
+			name:        "llama.cpp: reasoning preservation flags allowed",
+			backend:     "llama.cpp",
+			flags:       []string{"--reasoning-preserve", "--no-reasoning-preserve"},
+			expectError: false,
+			description: "Reasoning preservation flags should be allowed",
+		},
+		{
 			name:    "llama.cpp: real-world flags from issue 515",
 			backend: "llama.cpp",
 			flags: []string{


### PR DESCRIPTION
This PR adds `--reasoning-preserve` and `--no-reasoning-preserve` to the `llama.cpp` runtime flag allowlist.

These flags are supported by `llama.cpp` and are boolean-only options. They do not access files or external resources, so they fit the existing security model used for runtime flag validation. `--reasoning-preserve` is important for reasoning models because it keeps the reasoning trace in the conversation history, allowing prompt/KV cache reuse when combined with prompt caching. 

Without this change, Docker Model Runner rejects the flags before `llama.cpp` is started.