### PR TITLE
docs: document unified memory env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ MODEL_RUNNER_HOST=http://localhost:13434 ./model-cli list
 
 - [Model Runner Documentation](https://docs.docker.com/desktop/features/model-runner/)
 - [Model CLI README](./cmd/cli/README.md)
+- [Unified memory for integrated GPUs](./docs/unified-memory.md)
 - [Model Specification](https://github.com/docker/model-spec/blob/main/spec.md)
 - [Community Slack Channel](https://dockercommunity.slack.com/archives/C09H9P5E57B)
 

--- a/docs/unified-memory.md
+++ b/docs/unified-memory.md
@@ -1,0 +1,31 @@
+# Unified memory configuration for integrated GPUs
+
+Docker Model Runner uses llama.cpp under the hood. On systems with integrated GPUs (for example AMD APUs), available shared memory may be reported incorrectly unless unified memory is enabled.
+
+## Docker Compose
+
+Set environment variables on the model runner service:
+
+```yaml
+services:
+  model-runner:
+    image: docker/model-runner:latest
+    environment:
+      GGML_CUDA_ENABLE_UNIFIED_MEMORY: "1"
+```
+
+## docker model run
+
+```shell
+docker model run -e GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 ai/gemma3 "Hello"
+```
+
+## Standalone dmr
+
+```shell
+export GGML_CUDA_ENABLE_UNIFIED_MEMORY=1
+dmr serve &
+dmr run ai/gemma3 "Hello"
+```
+
+See [ggml-org/llama.cpp#18159](https://github.com/ggml-org/llama.cpp/issues/18159) for background.

--- a/docs/unified-memory.md
+++ b/docs/unified-memory.md
@@ -17,7 +17,7 @@ services:
 ## docker model run
 
 ```shell
-docker model run -e GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 ai/gemma3 "Hello"
+GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 docker model run ai/gemma3 "Hello"
 ```
 
 ## Standalone dmr


### PR DESCRIPTION
## Summary
- Document GGML_CUDA_ENABLE_UNIFIED_MEMORY for Docker Compose, docker model run, and dmr

Fixes #994

## Test plan
- [x] Verified docs/unified-memory.md and README link