### PR TITLE
Fix token realm SSRF guard to allow registries on the same host

### DIFF
--- a/pkg/distribution/oci/remote/guard_internal_test.go
+++ b/pkg/distribution/oci/remote/guard_internal_test.go
@@ -17,7 +17,7 @@ func TestNewGuardedAuthClientBlocksLoopback(t *testing.T) {
 	}))
 	defer internalService.Close()
 
-	client := newGuardedAuthClient(nil)
+	client := newGuardedAuthClient(nil, "")
 	resp, err := client.Get(internalService.URL) //nolint:noctx
 	if err == nil {
 		resp.Body.Close()
@@ -50,7 +50,7 @@ func TestGuardedAuthClientHonorsProxyOnPrivateAddress(t *testing.T) {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	base.Proxy = http.ProxyURL(proxyURL)
 
-	client := newGuardedAuthClient(base)
+	client := newGuardedAuthClient(base, "")
 
 	// A public realm must be reachable through the loopback proxy. 203.0.113.0/24
 	// is TEST-NET-3: never routable, so a hit proves the request went via the proxy.

--- a/pkg/distribution/oci/remote/remote.go
+++ b/pkg/distribution/oci/remote/remote.go
@@ -425,7 +425,7 @@ type resolverComponents struct {
 func createResolver(o *options, ref reference.Reference) resolverComponents {
 	authorizer := docker.NewDockerAuthorizer(
 		docker.WithAuthCreds(credentialsFunc(o, ref)),
-		docker.WithAuthClient(newGuardedAuthClient(o.transport)))
+		docker.WithAuthClient(newGuardedAuthClient(o.transport, ref.Context().Registry.RegistryStr())))
 
 	// Wrap transport with Range header support for resumable downloads
 	// and User-Agent header for registry compatibility (required by HuggingFace)
@@ -530,7 +530,7 @@ func createResolverWithPushScope(o *options, ref reference.Reference) (resolverC
 			}
 			return cfg.Username, cfg.Password, nil
 		}),
-		docker.WithAuthClient(newGuardedAuthClient(o.transport)))
+		docker.WithAuthClient(newGuardedAuthClient(o.transport, ref.Context().Registry.RegistryStr())))
 
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Hosts: docker.ConfigureDefaultRegistries(

--- a/pkg/distribution/oci/remote/ssrf_pull_test.go
+++ b/pkg/distribution/oci/remote/ssrf_pull_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/docker/model-runner/pkg/distribution/oci/reference"
@@ -14,22 +13,18 @@ import (
 
 // TestPullSSRF_RealmNotFollowedToInternalService exercises the pull path end to
 // end: a malicious registry answers every request with a 401 Bearer challenge
-// whose realm points at a loopback "internal service". The token fetch that
-// containerd's authorizer performs against that realm must be blocked, so the
-// internal service is never contacted. This is the code path (remote.Image ->
-// createResolver) that the original CVE-2026-33990 fix left unguarded.
+// whose realm points at a *different* internal host (the cloud metadata service
+// at 169.254.169.254). The token fetch that containerd's authorizer performs
+// against that realm must be blocked, so the internal service is never
+// contacted. This is the cross-host pivot the SSRF fix targets.
+//
+// A realm on the registry's OWN host is permitted (same trust domain), so
+// internal/corporate registries keep working — see
+// transport_test.go's TestExchangeAllowsInternalRealmOnSameHost.
 func TestPullSSRF_RealmNotFollowedToInternalService(t *testing.T) {
-	var internalHits atomic.Int32
-	internalService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		internalHits.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{"token":"leaked-via-ssrf"}`)
-	}))
-	defer internalService.Close()
-
 	maliciousRegistry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("WWW-Authenticate",
-			fmt.Sprintf(`Bearer realm="%s/token",service="evil-registry"`, internalService.URL))
+			fmt.Sprintf(`Bearer realm="http://169.254.169.254/latest/meta-data",service="evil-registry"`))
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer maliciousRegistry.Close()
@@ -42,9 +37,9 @@ func TestPullSSRF_RealmNotFollowedToInternalService(t *testing.T) {
 
 	_, err = remote.Image(ref, remote.WithContext(t.Context()), remote.WithPlainHTTP(true))
 	if err == nil {
-		t.Fatal("remote.Image should have failed: the token realm resolves to a loopback address and must be rejected")
+		t.Fatal("remote.Image should have failed: the token realm resolves to a different internal host (cloud metadata) and must be rejected")
 	}
-	if hits := internalHits.Load(); hits != 0 {
-		t.Errorf("SSRF not blocked on the pull path: the internal service at %s was contacted %d time(s) via the token realm", internalService.URL, hits)
+	if !strings.Contains(err.Error(), "realm") {
+		t.Errorf("expected a realm-related rejection error, got: %q", err.Error())
 	}
 }

--- a/pkg/distribution/oci/remote/transport.go
+++ b/pkg/distribution/oci/remote/transport.go
@@ -96,7 +96,42 @@ func isDisallowedIP(ip net.IP) bool {
 // resolve the name itself: checking the resolved IPs is the validation, and a
 // name that cannot be resolved locally is rejected (fail closed) rather than
 // forwarded unchecked.
-func validateTokenEndpointURL(u *url.URL) error {
+// sameHost reports whether the realm host and the registry host refer to the
+// same host, comparing case-insensitively and ignoring any port. The realm
+// host from url.URL.Hostname() already has any port and IPv6 brackets stripped,
+// so only the configured registry host needs normalising here.
+func sameHost(realmHost, registryHost string) bool {
+	stripPort := func(h string) string {
+		if h == "" {
+			return h
+		}
+		if host, _, err := net.SplitHostPort(h); err == nil {
+			return host
+		}
+		return h
+	}
+	return strings.EqualFold(stripPort(realmHost), stripPort(registryHost))
+}
+
+// validateTokenEndpointURL validates the host of a token-endpoint URL against
+// the internal-hostname blocklist and the private/loopback/link-local ranges.
+// The local DNS resolution this performs is deliberate even when a proxy will
+// resolve the name itself: checking the resolved IPs is the validation, and a
+// name that cannot be resolved locally is rejected (fail closed) rather than
+// forwarded unchecked.
+//
+// When the realm host equals the registry host being pulled from, the check is
+// skipped: a token endpoint on the registry's own host is, by definition,
+// within the same trust domain the user explicitly chose to pull from. This is
+// what keeps internal/corporate registries (whose token endpoint lives on an
+// RFC1918 network) working, while still blocking a registry from pivoting the
+// client to a *different* internal host such as the cloud metadata service.
+func validateTokenEndpointURL(u *url.URL, registryHost string) error {
+	if sameHost(u.Hostname(), registryHost) {
+		// Same trust domain as the registry being pulled: permit private/
+		// loopback/link-local addresses so internal registries work.
+		return nil
+	}
 	port := u.Port()
 	if port == "" {
 		if u.Scheme == "https" {
@@ -161,7 +196,7 @@ func resolveAndValidateHost(hostname, port string) (dialAddr string, err error) 
 // proxied deployment: with a proxy configured, the dialer sees the proxy's
 // address — commonly a private or loopback IP — rather than the realm's, and
 // would reject the proxy itself.
-func newGuardedAuthClient(base http.RoundTripper) *http.Client {
+func newGuardedAuthClient(base http.RoundTripper, registryHost string) *http.Client {
 	var proxied *http.Transport
 	if t, ok := base.(*http.Transport); ok {
 		proxied = t.Clone()
@@ -178,6 +213,11 @@ func newGuardedAuthClient(base http.RoundTripper) *http.Client {
 		if err != nil {
 			return nil, fmt.Errorf("invalid token endpoint address %q: %w", addr, err)
 		}
+		if sameHost(host, registryHost) {
+			// Realm is the registry's own host: dial directly without the
+			// internal-address blocklist (see validateTokenEndpointURL).
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		}
 		dialAddr, err := resolveAndValidateHost(host, port)
 		if err != nil {
 			return nil, err
@@ -185,7 +225,7 @@ func newGuardedAuthClient(base http.RoundTripper) *http.Client {
 		return (&net.Dialer{}).DialContext(ctx, network, dialAddr)
 	}
 
-	return &http.Client{Transport: &guardedAuthTransport{proxied: proxied, direct: direct}}
+	return &http.Client{Transport: &guardedAuthTransport{proxied: proxied, direct: direct, registryHost: registryHost}}
 }
 
 // guardedAuthTransport validates every token-endpoint request against the SSRF
@@ -199,8 +239,9 @@ func newGuardedAuthClient(base http.RoundTripper) *http.Client {
 //     so pinning the dial address is neither possible nor meaningful. The
 //     realm host is validated here at the request level instead.
 type guardedAuthTransport struct {
-	proxied *http.Transport // proxy settings intact, stock dialer
-	direct  *http.Transport // no proxy, validating dialer pinned to the resolved IP
+	proxied     *http.Transport // proxy settings intact, stock dialer
+	direct      *http.Transport // no proxy, validating dialer pinned to the resolved IP
+	registryHost string         // host of the registry being pulled; same-host realms skip the blocklist
 }
 
 func (g *guardedAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -210,7 +251,7 @@ func (g *guardedAuthTransport) RoundTrip(req *http.Request) (*http.Response, err
 			return nil, fmt.Errorf("determining proxy for token endpoint: %w", err)
 		}
 		if proxyURL != nil {
-			if err := validateTokenEndpointURL(req.URL); err != nil {
+			if err := validateTokenEndpointURL(req.URL, g.registryHost); err != nil {
 				return nil, fmt.Errorf("realm URL rejected: %w", err)
 			}
 			return g.proxied.RoundTrip(req)
@@ -288,8 +329,9 @@ func parseWWWAuthenticate(header string) WWWAuthenticate {
 // the registry's WWW-Authenticate challenge and is therefore untrusted; the
 // guarded client rejects realms on internal hostnames or private/loopback
 // addresses and honors any configured proxy.
-func Exchange(ctx context.Context, _ reference.Registry, auth authn.Authenticator, transport http.RoundTripper, scopes []string, pr *PingResponse) (*Token, error) {
-	client := newGuardedAuthClient(transport)
+func Exchange(ctx context.Context, reg reference.Registry, auth authn.Authenticator, transport http.RoundTripper, scopes []string, pr *PingResponse) (*Token, error) {
+	registryHost := reg.RegistryStr()
+	client := newGuardedAuthClient(transport, registryHost)
 
 	// Build token request URL
 	tokenURL, err := url.Parse(pr.WWWAuthenticate.Realm)
@@ -300,7 +342,7 @@ func Exchange(ctx context.Context, _ reference.Registry, auth authn.Authenticato
 	// Validate the realm before any request is made so a blocked realm fails
 	// fast with a clear error. The guarded client re-validates at connection
 	// time (or per request when proxied), closing the TOCTOU window.
-	if err := validateTokenEndpointURL(tokenURL); err != nil {
+	if err := validateTokenEndpointURL(tokenURL, registryHost); err != nil {
 		return nil, fmt.Errorf("realm URL rejected: %w", err)
 	}
 

--- a/pkg/distribution/oci/remote/transport_test.go
+++ b/pkg/distribution/oci/remote/transport_test.go
@@ -63,6 +63,41 @@ func TestExchangeSSRF_RequestSentToRealmURL(t *testing.T) {
 	}
 }
 
+// TestExchangeAllowsInternalRealmOnSameHost verifies that an internal/corporate
+// registry whose token endpoint lives on the same host (e.g. an RFC1918 address
+// or loopback) is NOT blocked by the SSRF guard. The realm is within the same
+// trust domain as the registry being pulled, so private/loopback/link-local
+// addresses must be permitted there.
+func TestExchangeAllowsInternalRealmOnSameHost(t *testing.T) {
+	var hitCount atomic.Int32
+
+	// "Internal service" on 127.0.0.1 — without the same-host exception this
+	// would be rejected by the loopback blocklist.
+	internalService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"token":"internal-token"}`)
+	}))
+	defer internalService.Close()
+
+	// Registry host matches the realm host (both resolve to 127.0.0.1).
+	ref, err := reference.ParseReference("127.0.0.1:5000/myimage")
+	if err != nil {
+		t.Fatalf("failed to parse reference: %v", err)
+	}
+
+	pr := pingResponseForRealm(internalService.URL + "/token")
+
+	_, err = remote.Exchange(t.Context(), ref.Context().Registry, nil, nil, []string{"repository:x:pull"}, pr)
+	if err != nil && strings.Contains(err.Error(), "realm URL rejected") {
+		t.Fatalf("internal same-host realm was wrongly rejected: %v", err)
+	}
+	if hitCount.Load() == 0 {
+		t.Errorf("expected the token request to reach the internal service at %s (same-host realms must be allowed)", internalService.URL)
+	}
+}
+
 // TestExchangeSSRF_SensitiveBodyNotReflectedInError verifies that Exchange()
 // does NOT include a token-endpoint response body in the error it returns to
 // the caller.


### PR DESCRIPTION
Close #1050 

## Description
PR #1038 added an SSRF guard that blocks token-exchange realms
(`WWW-Authenticate: Bearer realm=...`) resolving to private/loopback/link-local
addresses. That blocklist is too broad: it also rejects **internal/corporate
registries** whose token endpoint lives on an RFC1918 network (or on
`localhost`), because their realm resolves to a private IP. Such registries are
a common enterprise deployment (internal Harbor/Artifactory/HuggingFace
mirrors), and after #1038 pulls from them fail with `realm URL rejected`.

This PR narrows the guard so a realm on the **same host as the registry being
pulled** is permitted, while still blocking a registry from pivoting the client
to a *different* internal host (e.g. the cloud metadata service
`169.254.169.254`).

### Why this is safe
The SSRF threat is a cross-trust-domain pivot: a registry at host A returns a
`realm` pointing at host B (metadata / internal admin) that the *client* can
reach but the registry cannot. When the realm host equals the registry host, the
token request stays within the same trust domain the user explicitly chose to
pull from, so there is no pivot. Metadata and other internal hosts remain
blocked because they differ from the registry host.

### Changes
- `validateTokenEndpointURL(u, registryHost)`: returns nil (skip the blocklist)
  when the realm host equals `registryHost`.
- `sameHost(realmHost, registryHost)`: case-insensitive, port-agnostic host
  comparison (`url.URL.Hostname()` already strips ports/brackets).
- `newGuardedAuthClient(base, registryHost)`: threads the registry host into the
  guarded transport; the direct dialer also skips the blocklist for same-host
  realms (DNS-rebinding protection is preserved for cross-host cases).
- `Exchange` and the resolver (`createResolver` / `createResolverWithPushScope`)
  pass `ref.Context().Registry.RegistryStr()` as the registry host.

### Tests
- `TestExchangeAllowsInternalRealmOnSameHost`: same-host loopback realm allowed.
- `TestPullSSRF_RealmNotFollowedToInternalService`: reworked to assert the
  cross-host pivot to `169.254.169.254` is still blocked on the pull path.
- Existing loopback/link-local and proxy tests unchanged (pass `""` registry
  host → full validation).

## How to test
1. Point model-runner at an internal registry whose token endpoint is on a
   private IP / `localhost`; pulling now succeeds (previously `realm URL
   rejected`).
2. A registry returning `realm=http://169.254.169.254/...` is still rejected.

## Related
- Follow-up to #1038.

Created with: CodeBuddy
