### PR TITLE
deps: bump multer to 2.3.0 in demos/extractor

### DIFF
--- a/demos/extractor/package-lock.json
+++ b/demos/extractor/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "multer": "2.2.0",
+        "multer": "2.3.0",
         "pdf-data-extractor": "^1.0.1"
       },
       "devDependencies": {
@@ -1015,9 +1015,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/demos/extractor/package.json
+++ b/demos/extractor/package.json
@@ -16,9 +16,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
     "cors": "^2.8.5",
-    "multer": "2.2.0",
+    "express": "^4.18.2",
+    "multer": "2.3.0",
     "pdf-data-extractor": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates `multer` to 2.3.0 in `demos/extractor`.

Evidence:
- `demos/extractor/package.json` referenced `multer@2.2.0`
- osv-scanner reported GHSA-535w-7cp7-47q4, GHSA-qfvm-cv95-jqjf, GHSA-qvfw-j98x-7q72, GHSA-wc9g-mqfw-jrwm before the update
- updated version: `multer@2.3.0`

Validation:
- osv-scanner no longer reports those advisories after the update
- `node --check server.js` passes and `require('multer')` loads
- `node server.js` fails on unmodified `main` the same way (pdf-data-extractor exports error), so the boot failure is pre-existing

Note: osv-scanner still reports separate advisories for dev dependencies of this demo (`brace-expansion`, `fast-uri`) and for `body-parser@1.20.5`. This patch only clears the multer advisories.

Scope: dependency update only.
